### PR TITLE
add integration guides for Crush and Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
+| **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
+| **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 
 ## Resources

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,6 +24,8 @@
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |
+| **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
+| **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 
 ## 相关资源

--- a/docs/crush.md
+++ b/docs/crush.md
@@ -1,0 +1,87 @@
+[English](./crush.md) | [简体中文](./crush.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Crush
+
+Crush is a glamorous open-source AI coding agent that runs in your terminal, built by Charm. It supports multi-model switching, LSP integration, MCP servers, and agentic coding workflows.
+
+#### 1. Install Crush
+
+- Install [Node.js](https://nodejs.org/en/download/).
+- Run the following command in your terminal to install Crush:
+
+```bash
+npm install -g @charmland/crush
+```
+
+- After installation, run the following command. If the version number is displayed, the installation is successful:
+
+```bash
+crush --version
+```
+
+> **Note:** macOS users can also install via Homebrew: `brew install charmbracelet/tap/crush`.
+
+#### 2. Configure DeepSeek Provider
+
+Crush supports custom providers via OpenAI-compatible APIs. Add DeepSeek to your configuration file:
+
+- **Linux / macOS**: `~/.config/crush/crush.json`
+- **Windows**: `%USERPROFILE%\.config\crush\crush.json`
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "providers": {
+    "deepseek": {
+      "type": "openai-compat",
+      "base_url": "https://api.deepseek.com/v1",
+      "api_key": "$DEEPSEEK_API_KEY",
+      "models": [
+        {
+          "id": "deepseek-v4-pro",
+          "name": "DeepSeek-V4-Pro",
+          "context_window": 1048576,
+          "default_max_tokens": 32768,
+          "can_reason": true
+        },
+        {
+          "id": "deepseek-v4-flash",
+          "name": "DeepSeek-V4-Flash",
+          "context_window": 1048576,
+          "default_max_tokens": 32768,
+          "can_reason": true
+        }
+      ]
+    }
+  }
+}
+```
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+Set the environment variable:
+
+Linux / Mac users:
+
+```bash
+export DEEPSEEK_API_KEY="<your DeepSeek API Key>"
+```
+
+Windows users:
+
+```powershell
+$env:DEEPSEEK_API_KEY="<your DeepSeek API Key>"
+```
+
+#### 3. Run and Select Model
+
+- Enter the project directory and execute the `crush` command:
+
+```bash
+cd /path/to/my-project
+crush
+```
+
+- Press `Ctrl+L` (or type `/model`) to open the model switcher.
+- Select the **DeepSeek** provider and choose `DeepSeek-V4-Pro` or `DeepSeek-V4-Flash`.
+- Start coding with your new terminal bestie 💘

--- a/docs/crush.zh-CN.md
+++ b/docs/crush.zh-CN.md
@@ -1,0 +1,87 @@
+[English](./crush.md) | [简体中文](./crush.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Crush
+
+Crush 是由 Charm 开发的华丽开源 AI 编程 Agent，运行在终端中。支持多模型切换、LSP 集成、MCP 服务器和代理式编码工作流。
+
+#### 1. 安装 Crush
+
+- 安装 [Node.js](https://nodejs.org/zh-cn/download/)。
+- 在命令行界面，执行以下命令安装 Crush：
+
+```bash
+npm install -g @charmland/crush
+```
+
+- 安装结束后，执行以下命令，若显示版本号则安装成功：
+
+```bash
+crush --version
+```
+
+> **注意：** macOS 用户也可以通过 Homebrew 安装：`brew install charmbracelet/tap/crush`。
+
+#### 2. 配置 DeepSeek 供应商
+
+Crush 支持通过 OpenAI 兼容 API 添加自定义供应商。在配置文件中添加 DeepSeek：
+
+- **Linux / macOS**：`~/.config/crush/crush.json`
+- **Windows**：`%USERPROFILE%\.config\crush\crush.json`
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "providers": {
+    "deepseek": {
+      "type": "openai-compat",
+      "base_url": "https://api.deepseek.com/v1",
+      "api_key": "$DEEPSEEK_API_KEY",
+      "models": [
+        {
+          "id": "deepseek-v4-pro",
+          "name": "DeepSeek-V4-Pro",
+          "context_window": 1048576,
+          "default_max_tokens": 32768,
+          "can_reason": true
+        },
+        {
+          "id": "deepseek-v4-flash",
+          "name": "DeepSeek-V4-Flash",
+          "context_window": 1048576,
+          "default_max_tokens": 32768,
+          "can_reason": true
+        }
+      ]
+    }
+  }
+}
+```
+
+其中 API Key 在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取。
+
+设置环境变量：
+
+Linux / Mac 用户：
+
+```bash
+export DEEPSEEK_API_KEY="<你的 DeepSeek API Key>"
+```
+
+Windows 用户：
+
+```powershell
+$env:DEEPSEEK_API_KEY="<你的 DeepSeek API Key>"
+```
+
+#### 3. 运行并选择模型
+
+- 进入项目目录并执行 `crush` 命令：
+
+```bash
+cd /path/to/my-project
+crush
+```
+
+- 按 `Ctrl+L`（或输入 `/model`）打开模型切换器。
+- 选择 **DeepSeek** 供应商，然后选择 `DeepSeek-V4-Pro` 或 `DeepSeek-V4-Flash`。
+- 开始与你的终端编程新搭档一起编码 💘

--- a/docs/pi_mono.md
+++ b/docs/pi_mono.md
@@ -1,0 +1,101 @@
+[English](./pi_mono.md) | [简体中文](./pi_mono.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Pi
+
+Pi (pi-mono) is a minimal, aggressively extensible terminal coding harness. It adapts to your workflows through TypeScript extensions, skills, prompt templates, and themes — with tree-structured sessions and 15+ built-in providers.
+
+#### 1. Install Pi
+
+- Install [Node.js](https://nodejs.org/en/download/).
+- Run the following command in your terminal to install Pi:
+
+```bash
+npm install -g @mariozechner/pi-coding-agent
+```
+
+- After installation, run the following command. If the version number is displayed, the installation is successful:
+
+```bash
+pi --version
+```
+
+> **Note:** Linux / macOS users can also install via the official script:
+> ```bash
+> curl -fsSL https://pi.dev/install.sh | sh
+> ```
+
+#### 2. Configure DeepSeek Provider
+
+Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compatible provider:
+
+- **Linux / macOS**: `~/.pi/agent/models.json`
+- **Windows**: `%USERPROFILE%\.pi\agent\models.json`
+
+```json
+{
+  "providers": {
+    "deepseek": {
+      "baseUrl": "https://api.deepseek.com/v1",
+      "api": "openai-completions",
+      "apiKey": "$DEEPSEEK_API_KEY",
+      "models": [
+        {
+          "id": "deepseek-v4-pro",
+          "name": "DeepSeek-V4-Pro",
+          "contextWindow": 1048576,
+          "maxTokens": 32768,
+          "input": ["text"],
+          "reasoning": true,
+          "compat": {
+            "thinkingFormat": "deepseek"
+          }
+        },
+        {
+          "id": "deepseek-v4-flash",
+          "name": "DeepSeek-V4-Flash",
+          "contextWindow": 1048576,
+          "maxTokens": 32768,
+          "input": ["text"],
+          "reasoning": true,
+          "compat": {
+            "thinkingFormat": "deepseek"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+Set the environment variable:
+
+Linux / Mac users:
+
+```bash
+export DEEPSEEK_API_KEY="<your DeepSeek API Key>"
+```
+
+Windows users:
+
+```powershell
+$env:DEEPSEEK_API_KEY="<your DeepSeek API Key>"
+```
+
+> **Tip:** The `apiKey` field also supports shell command resolution for secure key management. Replace `"$DEEPSEEK_API_KEY"` with a command like `"!pass show api/deepseek"` if you use a password manager.
+
+#### 3. Run and Select Model
+
+- Enter the project directory and execute the `pi` command:
+
+```bash
+cd /path/to/my-project
+pi
+```
+
+- Type `/model` to open the model switcher.
+- Select **deepseek** and choose `DeepSeek-V4-Pro` or `DeepSeek-V4-Flash`.
+- Start coding with your minimal terminal harness.
+
+For more configuration options, see the [Pi models documentation](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent/docs/models.md).

--- a/docs/pi_mono.zh-CN.md
+++ b/docs/pi_mono.zh-CN.md
@@ -1,0 +1,101 @@
+[English](./pi_mono.md) | [简体中文](./pi_mono.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Pi
+
+Pi（pi-mono）是一个极简且高度可扩展的终端编码框架。它通过 TypeScript 扩展、技能、提示模板和主题来适配你的工作流，支持树状会话结构和 15+ 内置供应商。
+
+#### 1. 安装 Pi
+
+- 安装 [Node.js](https://nodejs.org/zh-cn/download/)。
+- 在命令行界面，执行以下命令安装 Pi：
+
+```bash
+npm install -g @mariozechner/pi-coding-agent
+```
+
+- 安装结束后，执行以下命令，若显示版本号则安装成功：
+
+```bash
+pi --version
+```
+
+> **注意：** Linux / macOS 用户也可以通过官方脚本安装：
+> ```bash
+> curl -fsSL https://pi.dev/install.sh | sh
+> ```
+
+#### 2. 配置 DeepSeek 供应商
+
+Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI 兼容供应商：
+
+- **Linux / macOS**：`~/.pi/agent/models.json`
+- **Windows**：`%USERPROFILE%\.pi\agent\models.json`
+
+```json
+{
+  "providers": {
+    "deepseek": {
+      "baseUrl": "https://api.deepseek.com/v1",
+      "api": "openai-completions",
+      "apiKey": "$DEEPSEEK_API_KEY",
+      "models": [
+        {
+          "id": "deepseek-v4-pro",
+          "name": "DeepSeek-V4-Pro",
+          "contextWindow": 1048576,
+          "maxTokens": 32768,
+          "input": ["text"],
+          "reasoning": true,
+          "compat": {
+            "thinkingFormat": "deepseek"
+          }
+        },
+        {
+          "id": "deepseek-v4-flash",
+          "name": "DeepSeek-V4-Flash",
+          "contextWindow": 1048576,
+          "maxTokens": 32768,
+          "input": ["text"],
+          "reasoning": true,
+          "compat": {
+            "thinkingFormat": "deepseek"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+其中 API Key 在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取。
+
+设置环境变量：
+
+Linux / Mac 用户：
+
+```bash
+export DEEPSEEK_API_KEY="<你的 DeepSeek API Key>"
+```
+
+Windows 用户：
+
+```powershell
+$env:DEEPSEEK_API_KEY="<你的 DeepSeek API Key>"
+```
+
+> **提示：** `apiKey` 字段也支持通过 shell 命令动态获取，便于安全密钥管理。如果你使用密码管理器，可以将 `"$DEEPSEEK_API_KEY"` 替换为类似 `"!pass show api/deepseek"` 的命令。
+
+#### 3. 运行并选择模型
+
+- 进入项目目录并执行 `pi` 命令：
+
+```bash
+cd /path/to/my-project
+pi
+```
+
+- 输入 `/model` 打开模型切换器。
+- 选择 **deepseek**，然后选择 `DeepSeek-V4-Pro` 或 `DeepSeek-V4-Flash`。
+- 开始使用你的极简终端编码框架。
+
+更多配置选项请参阅 [Pi 模型文档](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent/docs/models.md)。


### PR DESCRIPTION
This PR adds integration guides for Crush and Pi-Mono to help users connect DeepSeek models to these terminal-based AI coding agents.
Added `docs/crush.md` and `docs/crush.zh-CN.md`.
Updated `README.md` and `README.zh-CN.md` to include Crush and Pi in the tools table.