### PR TITLE
docs: add Oh My Pi integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
+| **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,7 @@
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
+| **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |

--- a/docs/oh-my-pi.md
+++ b/docs/oh-my-pi.md
@@ -1,0 +1,131 @@
+[English](./oh-my-pi.md) | [简体中文](./oh-my-pi.zh-CN.md) · [← Back](../README.md)
+
+# Using DeepSeek with Oh My Pi
+
+[Oh My Pi](https://github.com/can1357/oh-my-pi) is a terminal AI coding agent. As of v14.5 it ships DeepSeek V4 model entries, but the built-in compat is incomplete — a custom `models.yml` is still required for reliable use.
+
+## Prerequisites
+
+Install Oh My Pi: <https://github.com/can1357/oh-my-pi#installation>
+
+Get an API key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys):
+
+```sh
+export DEEPSEEK_API_KEY=<your API key>
+```
+
+## Configuration
+
+Create `~/.omp/agent/models.yml`:
+
+```yaml
+providers:
+  deepseek:
+    baseUrl: https://api.deepseek.com
+    api: openai-completions
+    apiKey: DEEPSEEK_API_KEY
+    authHeader: true
+    models:
+      - id: deepseek-v4-pro
+        name: DeepSeek V4 Pro
+        reasoning: true
+        thinking:
+          minLevel: high
+          maxLevel: xhigh
+          mode: effort
+        input: [text]
+        contextWindow: 1000000
+        maxTokens: 384000
+        compat:
+          supportsDeveloperRole: false
+          supportsReasoningEffort: true
+          maxTokensField: max_tokens
+          reasoningEffortMap:
+            high: high
+            xhigh: max
+          supportsToolChoice: false
+          requiresReasoningContentForToolCalls: true
+          requiresAssistantContentForToolCalls: true
+          extraBody:
+            thinking:
+              type: enabled
+      - id: deepseek-v4-flash
+        name: DeepSeek V4 Flash
+        reasoning: true
+        thinking:
+          minLevel: high
+          maxLevel: xhigh
+          mode: effort
+        input: [text]
+        contextWindow: 1000000
+        maxTokens: 384000
+        compat:
+          supportsDeveloperRole: false
+          supportsReasoningEffort: true
+          maxTokensField: max_tokens
+          reasoningEffortMap:
+            high: high
+            xhigh: max
+          supportsToolChoice: false
+          requiresReasoningContentForToolCalls: true
+          requiresAssistantContentForToolCalls: true
+          extraBody:
+            thinking:
+              type: enabled
+```
+
+## Configuration notes
+
+### Basics
+
+| Field | Notes |
+| ----- | ----- |
+| `baseUrl: https://api.deepseek.com` | DeepSeek OpenAI-compatible endpoint. Do not append `/v1`. |
+| `authHeader: true` | Sends `Authorization: Bearer $DEEPSEEK_API_KEY`. Does not go through OAuth `/login`. |
+| `supportsDeveloperRole: false` | Sends system prompt as `system` role. DeepSeek rejects the `developer` role. |
+| `maxTokensField: max_tokens` | DeepSeek uses `max_tokens`, not OpenAI's `max_completion_tokens`. |
+
+### Thinking mode
+
+| Field | Notes |
+| ----- | ----- |
+| `thinking.mode: effort` | Uses effort-based thinking. OMP sends a `reasoning_effort` parameter. |
+| `thinking.minLevel: high` / `maxLevel: xhigh` | Locks the selector to DeepSeek's two supported levels. |
+| `reasoningEffortMap: { high: high, xhigh: max }` | Maps OMP's `xhigh` to DeepSeek's `max`. Without this, `xhigh` is unrecognized. |
+| `extraBody.thinking.type: enabled` | Explicitly enables DeepSeek V4 thinking mode. |
+| `supportsReasoningEffort: true` | Allows OMP to send `reasoning_effort`. |
+
+### Three critical compat fields
+
+These three fields are essential. Without them, DeepSeek V4 will return 400 errors when using tools in thinking mode.
+
+| Field | Notes |
+| ----- | ----- |
+| `supportsToolChoice: false` | DeepSeek V4 thinking mode rejects the `tool_choice` parameter. |
+| `requiresReasoningContentForToolCalls: true` | DeepSeek requires `reasoning_content` to be preserved across tool-call turns in conversation history. Skipping this causes 400. |
+| `requiresAssistantContentForToolCalls: true` | Ensures tool-call messages have non-null `content`. Use together with the field above. |
+
+## Usage
+
+```sh
+cd /path/to/your-project
+omp --model deepseek/deepseek-v4-pro
+```
+
+For faster responses:
+
+```sh
+omp --model deepseek/deepseek-v4-flash
+```
+
+Switch models inside Oh My Pi with `/model` or `Ctrl+L`.
+
+## Known issues
+
+**Do not rely on the built-in model entries.** Recent builds list `deepseek-v4-pro` and `deepseek-v4-flash` via `omp --list-models deepseek`, but they lack the three critical compat fields above. Long thinking-mode conversations with tool calls will 400. Always use the `models.yml` configuration shown above.
+
+Oh My Pi does not currently have a DeepSeek OAuth `/login` entry. API keys must be provided via the `DEEPSEEK_API_KEY` environment variable or the `apiKey` field in `models.yml`.
+
+When using DeepSeek V4 through unofficial providers (DeepInfra, KiloCode, NVIDIA NIM, Zenmux, etc.) via OpenAI-compatible endpoints, `reasoning_content` replay behavior varies and compatibility is unresolved. Prefer the official `api.deepseek.com` endpoint.
+
+In `models.yml`, `compat` replaces the built-in block wholesale — it does not merge. Always specify the full set of compat fields.

--- a/docs/oh-my-pi.zh-CN.md
+++ b/docs/oh-my-pi.zh-CN.md
@@ -1,0 +1,131 @@
+[English](./oh-my-pi.md) | [简体中文](./oh-my-pi.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 在 Oh My Pi 中使用 DeepSeek
+
+[Oh My Pi](https://github.com/can1357/oh-my-pi) 是终端 AI 编程 Agent。自 v14.5 起内置了 DeepSeek V4 模型条目，但内置条目缺少关键配置，直接使用可能报错，仍需自定义 `models.yml`。
+
+## 前置条件
+
+安装 Oh My Pi：<https://github.com/can1357/oh-my-pi#installation>
+
+从 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key：
+
+```sh
+export DEEPSEEK_API_KEY=<你的 API Key>
+```
+
+## 配置
+
+创建 `~/.omp/agent/models.yml`：
+
+```yaml
+providers:
+  deepseek:
+    baseUrl: https://api.deepseek.com
+    api: openai-completions
+    apiKey: DEEPSEEK_API_KEY
+    authHeader: true
+    models:
+      - id: deepseek-v4-pro
+        name: DeepSeek V4 Pro
+        reasoning: true
+        thinking:
+          minLevel: high
+          maxLevel: xhigh
+          mode: effort
+        input: [text]
+        contextWindow: 1000000
+        maxTokens: 384000
+        compat:
+          supportsDeveloperRole: false
+          supportsReasoningEffort: true
+          maxTokensField: max_tokens
+          reasoningEffortMap:
+            high: high
+            xhigh: max
+          supportsToolChoice: false
+          requiresReasoningContentForToolCalls: true
+          requiresAssistantContentForToolCalls: true
+          extraBody:
+            thinking:
+              type: enabled
+      - id: deepseek-v4-flash
+        name: DeepSeek V4 Flash
+        reasoning: true
+        thinking:
+          minLevel: high
+          maxLevel: xhigh
+          mode: effort
+        input: [text]
+        contextWindow: 1000000
+        maxTokens: 384000
+        compat:
+          supportsDeveloperRole: false
+          supportsReasoningEffort: true
+          maxTokensField: max_tokens
+          reasoningEffortMap:
+            high: high
+            xhigh: max
+          supportsToolChoice: false
+          requiresReasoningContentForToolCalls: true
+          requiresAssistantContentForToolCalls: true
+          extraBody:
+            thinking:
+              type: enabled
+```
+
+## 配置要点
+
+### 基础
+
+| 字段 | 说明 |
+| ---- | ---- |
+| `baseUrl: https://api.deepseek.com` | DeepSeek OpenAI 兼容接口。不要加 `/v1`。 |
+| `authHeader: true` | 发送 `Authorization: Bearer $DEEPSEEK_API_KEY`。不经过 OAuth `/login`。 |
+| `supportsDeveloperRole: false` | 以 `system` 角色发系统提示词。DeepSeek API 不接受 `developer` 角色。 |
+| `maxTokensField: max_tokens` | DeepSeek 的输出限制字段是 `max_tokens`，不是 OpenAI 的 `max_completion_tokens`。 |
+
+### Thinking（思考模式）
+
+| 字段 | 说明 |
+| ---- | ---- |
+| `thinking.mode: effort` | 使用 effort-based thinking，OMP 会发 `reasoning_effort` 参数。 |
+| `thinking.minLevel: high` / `maxLevel: xhigh` | 限制为 DeepSeek 支持的两档。 |
+| `reasoningEffortMap: { high: high, xhigh: max }` | OMP 的 `xhigh` 映射为 DeepSeek 的 `max`。不配这个会导致 `xhigh` 不被识别。 |
+| `extraBody.thinking.type: enabled` | 显式启用 DeepSeek V4 思考模式。 |
+| `supportsReasoningEffort: true` | 允许 OMP 发送 `reasoning_effort`。 |
+
+### 三项关键 compat（必配）
+
+这三个字段是避免报错的关键。不配会导致 DeepSeek V4 在 thinking mode 下带 tool call 时返回 400。
+
+| 字段 | 说明 |
+| ---- | ---- |
+| `supportsToolChoice: false` | DeepSeek V4 thinking mode 不接受 `tool_choice` 参数。 |
+| `requiresReasoningContentForToolCalls: true` | DeepSeek 要求 tool call 对话的历史消息中必须保留 `reasoning_content`。不配会导致 400。 |
+| `requiresAssistantContentForToolCalls: true` | 确保 tool call 消息的 `content` 字段不为空。配合上一个字段使用。 |
+
+## 使用
+
+```sh
+cd /path/to/your-project
+omp --model deepseek/deepseek-v4-pro
+```
+
+需要更快响应时：
+
+```sh
+omp --model deepseek/deepseek-v4-flash
+```
+
+在 Oh My Pi 内输入 `/model` 或按 `Ctrl+L` 切换模型。
+
+## 已知问题
+
+**不推荐依赖内置模型条目。** 较新版本 `omp --list-models deepseek` 能列出 `deepseek-v4-pro` 和 `deepseek-v4-flash`，但内置条目缺少上述三项关键 compat。直接用内置条目在 thinking mode 下带 tool call 的长对话大概率 400。始终使用上方的 `models.yml` 配置。
+
+Oh My Pi 目前没有 DeepSeek 的 OAuth `/login` 入口。只能通过 `DEEPSEEK_API_KEY` 环境变量或 `models.yml` 中的 `apiKey` 字段配置 API Key。
+
+DeepSeek V4 在非官方 provider（DeepInfra、KiloCode、NVIDIA NIM、Zenmux 等）上通过 OpenAI-compatible 接口使用时，reasoning_content 回传规则可能不同，兼容性未收敛。建议优先用官方 `api.deepseek.com`。
+
+`models.yml` 的 `compat` 是整块替换，不跟内置条目合并。所以 compat 必须写全，不能只补缺的字段。


### PR DESCRIPTION
## Summary
- add English and Chinese Oh My Pi integration guides for DeepSeek-V4 models
- document the OMP models.yml provider configuration for DeepSeek OpenAI-compatible API
- add Oh My Pi to both README guide indexes

## Verification
- checked markdown relative links for README and new guide files
- ran git diff --check
- verified local OMP model discovery with omp --list-models deepseek

Closes #22