### PR TITLE
Add GitHub Copilot CLI guide for DeepSeek V4 BYOK integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
+| **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,7 @@
 | --------------- | --------------------------------------------------------------------- | ----------------------------------- |
 | **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
+| **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |

--- a/docs/copilot_cli.md
+++ b/docs/copilot_cli.md
@@ -1,0 +1,90 @@
+[English](./copilot_cli.md) | [简体中文](./copilot_cli.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with GitHub Copilot CLI
+
+Configure GitHub Copilot CLI to use DeepSeek V4 models via BYOK (Bring Your Own Key) with the Anthropic-compatible endpoint.
+
+> **Important:** Use `anthropic` as the provider type. The `openai` type triggers a `400` error: `The reasoning_content in the thinking mode must be passed back to the API.` — DeepSeek requires `reasoning_content` to be echoed back on subsequent requests, which Copilot CLI's OpenAI integration does not support. The Anthropic Messages API endpoint avoids this issue entirely.
+
+#### 1. Install GitHub Copilot CLI
+
+```shell
+npm install -g @github/copilot
+```
+
+Requires Node.js 22 or later. See the [official getting-started guide](https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-getting-started) for details.
+
+#### 2. Get a DeepSeek API Key
+
+- Go to [DeepSeek Platform](https://platform.deepseek.com/api_keys) and create an API key.
+- Copy the key (it starts with `sk-`).
+
+#### 3. Configure Environment Variables
+
+Linux / Mac:
+
+```shell
+export COPILOT_PROVIDER_TYPE=anthropic
+export COPILOT_PROVIDER_BASE_URL=https://api.deepseek.com/anthropic
+export COPILOT_PROVIDER_API_KEY=sk-your-deepseek-api-key
+export COPILOT_MODEL=deepseek-v4-pro
+```
+
+Windows (PowerShell):
+
+```powershell
+$env:COPILOT_PROVIDER_TYPE="anthropic"
+$env:COPILOT_PROVIDER_BASE_URL="https://api.deepseek.com/anthropic"
+$env:COPILOT_PROVIDER_API_KEY="sk-your-deepseek-api-key"
+$env:COPILOT_MODEL="deepseek-v4-pro"
+```
+
+Available models: `deepseek-v4-pro`, `deepseek-v4-flash`. Switch by changing `COPILOT_MODEL`.
+
+#### 4. Start Copilot CLI
+
+```shell
+copilot
+```
+
+Full agent mode, tool calling, and MCP support — all powered by DeepSeek.
+
+#### Optional: Token Limits
+
+Since `deepseek-v4-pro` is not in Copilot CLI's built-in model catalog, configure the token limits explicitly:
+
+Linux / Mac:
+
+```shell
+export COPILOT_PROVIDER_MAX_PROMPT_TOKENS=840000
+export COPILOT_PROVIDER_MAX_OUTPUT_TOKENS=128000
+```
+
+Windows (PowerShell):
+
+```powershell
+$env:COPILOT_PROVIDER_MAX_PROMPT_TOKENS="840000"
+$env:COPILOT_PROVIDER_MAX_OUTPUT_TOKENS="128000"
+```
+
+Run `copilot help providers` for all available environment variables.
+
+#### Optional: Offline Mode
+
+Linux / Mac:
+
+```shell
+export COPILOT_OFFLINE=true
+```
+
+Windows (PowerShell):
+
+```powershell
+$env:COPILOT_OFFLINE="true"
+```
+
+Note: your prompts still go to `api.deepseek.com` — offline mode only blocks GitHub's API calls.
+
+#### Resources
+
+- [GitHub Copilot CLI BYOK docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models)

--- a/docs/copilot_cli.zh-CN.md
+++ b/docs/copilot_cli.zh-CN.md
@@ -1,0 +1,90 @@
+[English](./copilot_cli.md) | [简体中文](./copilot_cli.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 GitHub Copilot CLI
+
+通过 BYOK（自带密钥）模式配置 GitHub Copilot CLI 使用 DeepSeek V4 模型，基于 Anthropic 兼容端点接入。
+
+> **重要提示：** 请使用 `anthropic` 作为 provider type。使用 `openai` 类型会触发 `400` 错误：`The reasoning_content in the thinking mode must be passed back to the API.` — DeepSeek 要求将模型输出的 `reasoning_content` 在下一次请求中原样回传，Copilot CLI 的 OpenAI 集成不支持此机制。改用 Anthropic Messages API 端点可以完全避免此问题。
+
+#### 1. 安装 GitHub Copilot CLI
+
+```shell
+npm install -g @github/copilot
+```
+
+需要 Node.js 22 或更高版本。详细说明参考[官方入门指南](https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-getting-started)。
+
+#### 2. 获取 DeepSeek API Key
+
+- 前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 创建 API Key。
+- 复制 Key（以 `sk-` 开头）。
+
+#### 3. 配置环境变量
+
+Linux / Mac：
+
+```shell
+export COPILOT_PROVIDER_TYPE=anthropic
+export COPILOT_PROVIDER_BASE_URL=https://api.deepseek.com/anthropic
+export COPILOT_PROVIDER_API_KEY=sk-your-deepseek-api-key
+export COPILOT_MODEL=deepseek-v4-pro
+```
+
+Windows（PowerShell）：
+
+```powershell
+$env:COPILOT_PROVIDER_TYPE="anthropic"
+$env:COPILOT_PROVIDER_BASE_URL="https://api.deepseek.com/anthropic"
+$env:COPILOT_PROVIDER_API_KEY="sk-your-deepseek-api-key"
+$env:COPILOT_MODEL="deepseek-v4-pro"
+```
+
+可选模型：`deepseek-v4-pro`、`deepseek-v4-flash`，修改 `COPILOT_MODEL` 即可切换。
+
+#### 4. 启动 Copilot CLI
+
+```shell
+copilot
+```
+
+完整支持 Agent 模式、工具调用和 MCP — 全部由 DeepSeek 驱动。
+
+#### 可选：配置 Token 限制
+
+由于 `deepseek-v4-pro` 不在 Copilot CLI 的内置模型目录中，建议显式配置 token 限制：
+
+Linux / Mac：
+
+```shell
+export COPILOT_PROVIDER_MAX_PROMPT_TOKENS=840000
+export COPILOT_PROVIDER_MAX_OUTPUT_TOKENS=128000
+```
+
+Windows（PowerShell）：
+
+```powershell
+$env:COPILOT_PROVIDER_MAX_PROMPT_TOKENS="840000"
+$env:COPILOT_PROVIDER_MAX_OUTPUT_TOKENS="128000"
+```
+
+运行 `copilot help providers` 可查看所有可用环境变量。
+
+#### 可选：离线模式
+
+Linux / Mac：
+
+```shell
+export COPILOT_OFFLINE=true
+```
+
+Windows（PowerShell）：
+
+```powershell
+$env:COPILOT_OFFLINE="true"
+```
+
+注意：提示词仍会发送到 `api.deepseek.com` — 离线模式仅阻止 GitHub 的 API 调用。
+
+#### 相关资源
+
+- [GitHub Copilot CLI BYOK 文档](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models)


### PR DESCRIPTION
## Summary

  - Added English and Chinese guides for integrating DeepSeek V4 into GitHub
  Copilot CLI via BYOK mode
  - Uses `anthropic` provider type to avoid the 400 error (`reasoning_content`
  must be passed back to the API) on the OpenAI path
  - Covers both Linux/Mac and Windows PowerShell configuration, plus optional
  token limits and offline mode

  ## Test plan

  - [x] Verify README table links point to the correct guide files
  - [x] Verify language switcher links between English and Chinese guides