### PR TITLE
docs: add Thinking Mode and HTTP 400 error troubleshooting for Hermes

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -31,3 +31,62 @@ Reload your shell and start Hermes configuration:
 - Enter the Base URL as `https://api.deepseek.com`
 - Select the `deepseek-v4-pro` model
 - Continue with the remaining options
+
+#### 3. Thinking Mode and Common Errors
+
+##### About Thinking Mode
+
+DeepSeek models have Thinking Mode enabled by default. During tool-calling turns, the model generates `reasoning_content` (chain-of-thought), and per the [DeepSeek Thinking Mode documentation](https://api-docs.deepseek.com/guides/thinking_mode), this `reasoning_content` must be passed back in subsequent requests.
+
+Hermes sets `display.show_reasoning` to `false` by default, which strips `reasoning_content` from the conversation history. This can cause an HTTP 400 error.
+
+##### Handling the 400 Error
+
+If you encounter the following error at runtime:
+
+```
+HTTP 400: The `reasoning_content` in the thinking mode must be passed back to the API.
+```
+
+This means `reasoning_content` is not being correctly passed back. Here are two solutions:
+
+**Option A: Disable Thinking Mode (Recommended)**
+
+Edit `~/.hermes/config.yaml` and add the following under the `model` section:
+
+```yaml
+model:
+  default: deepseek-v4-pro
+  provider: custom
+  base_url: https://api.deepseek.com
+  api_mode: chat_completions
+  api_key: <your-deepseek-api-key>
+  extra_body:
+    thinking:
+      type: disabled
+```
+
+With this option, DeepSeek no longer generates `reasoning_content`, avoiding the passback conflict entirely while also saving context tokens.
+
+**Option B: Keep Thinking Mode**
+
+If you want to keep the reasoning process, enable `show_reasoning` to ensure `reasoning_content` is preserved in the conversation history:
+
+```yaml
+model:
+  default: deepseek-v4-pro
+  provider: custom
+  base_url: https://api.deepseek.com
+  api_mode: chat_completions
+  api_key: <your-deepseek-api-key>
+  extra_body:
+    thinking:
+      type: enabled
+
+display:
+  show_reasoning: true
+```
+
+With this option, Hermes preserves and forwards `reasoning_content`, but the terminal will display the reasoning process and context consumption will increase.
+
+Restart Hermes after modifying the configuration for changes to take effect.

--- a/docs/hermes.zh-CN.md
+++ b/docs/hermes.zh-CN.md
@@ -31,3 +31,62 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 - Base URL 填写 `https://api.deepseek.com`
 - 选择 `deepseek-v4-pro` 模型
 - 继续完成其余配置选项
+
+#### 3. 思考模式与常见错误
+
+##### 关于思考模式
+
+DeepSeek 模型默认开启思考模式（Thinking Mode）。在工具调用场景下，模型会生成 `reasoning_content`（思维链内容），且根据 [DeepSeek 思考模式文档](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode)，工具调用后的 `reasoning_content` 必须随对话历史回传给 API。
+
+Hermes 的 `display.show_reasoning` 默认值为 `false`，会从对话历史中移除 `reasoning_content`，可能导致 HTTP 400 错误。
+
+##### 400 错误处理
+
+如果运行时出现以下错误：
+
+```
+HTTP 400: The `reasoning_content` in the thinking mode must be passed back to the API.
+```
+
+这说明 `reasoning_content` 未正确回传。以下为两种处理方案：
+
+**方案一：关闭思考模式（推荐）**
+
+编辑 `~/.hermes/config.yaml`，在 `model` 配置中添加：
+
+```yaml
+model:
+  default: deepseek-v4-pro
+  provider: custom
+  base_url: https://api.deepseek.com
+  api_mode: chat_completions
+  api_key: <your-deepseek-api-key>
+  extra_body:
+    thinking:
+      type: disabled
+```
+
+此方案下，DeepSeek 不再生成 `reasoning_content`，不会触发回传冲突，同时节省上下文消耗。
+
+**方案二：保留思考模式**
+
+若需要保留推理过程，需启用 `show_reasoning` 确保 `reasoning_content` 在对话历史中正确回传：
+
+```yaml
+model:
+  default: deepseek-v4-pro
+  provider: custom
+  base_url: https://api.deepseek.com
+  api_mode: chat_completions
+  api_key: <your-deepseek-api-key>
+  extra_body:
+    thinking:
+      type: enabled
+
+display:
+  show_reasoning: true
+```
+
+此方案下，Hermes 会保留并回传 `reasoning_content`，但终端会展示推理过程，上下文消耗也会增加。
+
+修改配置文件后重启 Hermes 生效。


### PR DESCRIPTION
## Summary

Adds a new section to the Hermes integration guide covering DeepSeek's Thinking Mode behavior and its known HTTP 400 error when used with Hermes Agent.

## Problem

DeepSeek models have Thinking Mode enabled by default. When Hermes performs tool calls, the model generates `reasoning_content` (chain-of-thought) that must be passed back in subsequent requests per DeepSeek's API requirement. However, Hermes sets `display.show_reasoning` to `false` by default, which strips `reasoning_content` from the conversation history, causing:

```
HTTP 400: The `reasoning_content` in the thinking mode must be passed back to the API.
```

This is a real issue users encounter, and the existing docs don't mention it.

## Changes

- Add section on Thinking Mode behavior with Hermes
- Document the HTTP 400 error cause
- Provide two solutions:
  1. **Disable Thinking Mode** (recommended) — via `extra_body.thinking.type: disabled`
  2. **Keep Thinking Mode** — enable `show_reasoning: true` to preserve `reasoning_content`
- Updated both `hermes.md` (English) and `hermes.zh-CN.md` (Chinese)

## Verification

- Both files only add new content; no existing content was modified
- Both English and Chinese versions are consistent