### PR TITLE
docs: add GenericAgent guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
-| **GenericAgent** | A minimal, self-evolving autonomous agent framework with a core of only ~3K lines of code. | [Guide](./docs/generic_agent.md) |
+| **GenericAgent** | Self-evolving agent: grows skill tree from 3.3K-line seed, achieving full system control with 6x less token consumption. | [Guide](./docs/generic_agent.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
+| **GenericAgent** | A minimal, self-evolving autonomous agent framework with a core of only ~3K lines of code. | [Guide](./docs/generic_agent.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
-| **GenericAgent** | 极简、自进化的自治 Agent 框架，核心代码约 3K 行。 | [指南](./docs/generic_agent.zh-CN.md) |
+| **GenericAgent** | 自进化 Agent：从 3.3K 行种子代码长出技能树，以 6 倍更低的 token 消耗实现完整系统控制。 | [指南](./docs/generic_agent.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,7 @@
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
+| **GenericAgent** | 极简、自进化的自治 Agent 框架，核心代码约 3K 行。 | [指南](./docs/generic_agent.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |

--- a/docs/generic_agent.md
+++ b/docs/generic_agent.md
@@ -1,0 +1,103 @@
+[English](./deepseek-generic-agent.md) | [简体中文](../zh/deepseek-generic-agent.md) · [← Back Home](../index.md)
+
+# Integrate DeepSeek into GenericAgent
+
+This guide shows how to connect DeepSeek to GenericAgent in three steps: install GenericAgent, configure your DeepSeek API key, and start using it.
+
+## 1. Install GenericAgent
+
+Prepare Python 3.11 or 3.12 first, then get the GenericAgent source code.
+
+Run:
+
+```bash
+git clone https://github.com/lsdefine/GenericAgent.git
+cd GenericAgent
+pip install streamlit pywebview
+```
+
+If your environment uses `pip3`, run:
+
+```bash
+pip3 install streamlit pywebview
+```
+
+## 2. Configure the DeepSeek API Key
+
+GenericAgent reads model settings from `mykey.py`.
+
+> ### Quick `mykey.py` Setup
+>
+> **Step 1: Copy the template**
+> In the GenericAgent project folder, copy `mykey_template.py` and rename the copy to `mykey.py`.
+>
+> **Step 2: Edit `mykey.py`**
+> Open `mykey.py` in any text editor. Lines starting with `#` are comments, so they will be ignored at runtime.
+>
+> There are two ways to add your config:
+> - Option A: fill an existing config block and remove the leading `#`
+> - Option B: keep the original comments and add a new active config block
+>
+> In short: lines with `#` do not take effect, lines without `#` do.
+>
+> **Step 3: Save the file**
+> Save `mykey.py` after editing.
+>
+> **Step 4: Restart GA**
+> After changing `mykey.py`, restart GenericAgent so the new config is loaded.
+
+For this DeepSeek setup, put the following config into `mykey.py`:
+
+```python
+oai_config = {
+    'apikey': 'sk-', #DEEPSEEK_API_KEY
+    'apibase': 'https://api.deepseek.com',
+    'model': 'deepseek-v4-pro',
+}
+```
+
+Notes:
+
+- Put your actual DeepSeek key into `apikey`
+- Keep `apibase` as `https://api.deepseek.com`
+- Use `deepseek-v4-pro` as the model
+- If you have multiple active configs in `mykey.py`, GA uses the first active one by default
+
+## 3. Start and Use GenericAgent
+
+### First Launch
+
+From the GenericAgent project directory, run:
+
+```bash
+python launch.pyw
+```
+
+On Windows, you can also start it by double-clicking `launch.pyw`.
+
+If a Streamlit chat page opens in the browser, or a pywebview window appears, the launch succeeded.
+
+### Let GA Install the Remaining Dependencies
+
+After the first launch, you do not need to install every remaining package manually. Send this message in the chat:
+
+```text
+请查看你的代码，安装所有用得上的 python 依赖
+```
+
+GA will inspect its own code and install the remaining Python dependencies.
+
+### Start Using It
+
+After that:
+
+1. Open the GenericAgent UI
+2. Confirm it is reading the DeepSeek config from `mykey.py`
+3. Send a simple test message such as `Hello, introduce yourself`
+4. If you get a normal reply, DeepSeek is connected successfully
+
+## Further Reading
+
+If you want the full GenericAgent tutorial covering installation, configuration, capabilities, and advanced usage, see:
+
+- [hello-generic-agent detailed tutorial](https://github.com/datawhalechina/hello-generic-agent)

--- a/docs/generic_agent.zh-CN.md
+++ b/docs/generic_agent.zh-CN.md
@@ -1,0 +1,103 @@
+[English](../en/deepseek-generic-agent.md) | [简体中文](./deepseek-generic-agent.md) · [← 返回首页](../index.md)
+
+# 把 DeepSeek 接入 GenericAgent
+
+本文介绍如何把 DeepSeek 接入 GenericAgent。整体只需要三步：安装 GenericAgent、配置 DeepSeek API Key、启动后开始使用。
+
+## 1. 安装 GenericAgent
+
+先准备好 Python 3.11 或 3.12，然后获取 GenericAgent 项目代码。
+
+在终端执行：
+
+```bash
+git clone https://github.com/lsdefine/GenericAgent.git
+cd GenericAgent
+pip install streamlit pywebview
+```
+
+如果你的环境使用 `pip3`，则改为：
+
+```bash
+pip3 install streamlit pywebview
+```
+
+## 2. 配置 DeepSeek API Key
+
+GenericAgent 通过 `mykey.py` 读取模型配置。
+
+> ### 🔰 mykey 配置最简流程
+>
+> **第 1 步：复制模板文件**
+> 进入 GenericAgent 项目目录，找到 `mykey_template.py`，复制一份，然后把副本重命名为 `mykey.py`。
+>
+> **第 2 步：编辑 `mykey.py`**
+> 用任意文本编辑器打开 `mykey.py`。你会看到很多 `#` 开头的行，这些都是注释，程序运行时会自动忽略。
+>
+> 填写配置有两种方式：
+> - 方式 A：找到对应配置区域，填好信息后，删掉该行前面的 `#`
+> - 方式 B：不改原注释，直接在文件里另起一行写生效配置
+>
+> 简单来说：有 `#` 的行不会生效，没有 `#` 的行才会生效。
+>
+> **第 3 步：保存文件**
+> 改完后保存 `mykey.py`。
+>
+> **第 4 步：重启 GA**
+> 每次修改 `mykey.py` 后，都建议关掉 GenericAgent 再重新启动，让新配置生效。
+
+下面是这次接入 DeepSeek 需要填写的最简配置，直接复制到 `mykey.py` 即可：
+
+```python
+oai_config = {
+    'apikey': 'sk-', #DEEPSEEK_API_KEY
+    'apibase': 'https://api.deepseek.com',
+    'model': 'deepseek-v4-pro',
+}
+```
+
+说明：
+
+- `apikey` 填你的 DeepSeek Key
+- `apibase` 固定为 `https://api.deepseek.com`
+- `model` 使用 `deepseek-v4-pro`
+- 如果你在 `mykey.py` 里同时写了多组配置，GA 默认首先读取第一个生效配置
+
+## 3. 启动并使用 GenericAgent
+
+### 首次启动
+
+在 GenericAgent 项目目录下执行：
+
+```bash
+python launch.pyw
+```
+
+如果你是 Windows，也可以直接双击 `launch.pyw` 启动。
+
+看到浏览器弹出 Streamlit 聊天界面，或者出现 pywebview 窗口，就说明启动成功了。
+
+### 让 GA 自动安装剩余依赖
+
+最小依赖装完后，其余依赖不用手动一个个补。启动成功后，在对话框里输入这句话：
+
+```text
+请查看你的代码，安装所有用得上的 python 依赖
+```
+
+GA 会自己读代码、找出需要的包，并把剩余依赖安装好。
+
+### 开始使用
+
+依赖补完后：
+
+1. 打开 GenericAgent 界面
+2. 确认当前模型读取到了你在 `mykey.py` 中配置的 DeepSeek
+3. 输入一条测试消息，例如“你好，请介绍一下你自己”
+4. 看到正常回复，就说明 DeepSeek 已经成功接入 GenericAgent
+
+## 详细教程参考
+
+如果你想系统了解 GenericAgent 的完整安装、配置、能力和进阶使用，可以参考：
+
+- [hello-generic-agent 详细教程](https://github.com/datawhalechina/hello-generic-agent)


### PR DESCRIPTION
  # Overview

  - Added bilingual integration guides for GenericAgent in Chinese and English

  - GenericAgent is a self-evolving agent that grows a skill tree from a 3.3K-line seed, achieving full system control with 6x less token consumption

  - Updated both READMEs to include GenericAgent in the tools table

  ## What Changed

  - Added `docs/generic_agent.zh-CN.md`
  - Added `docs/generic_agent.md`
  - Updated `README.md`
  - Updated `README.zh-CN.md`