### PR TITLE
docs: link Factory AI Droid in README tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
+| **Factory AI Droid** | AI software engineering agent with custom model configuration via `~/.factory/settings.json`. | [Guide](./docs/deepseek-droid-guide.md) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
+| **Factory AI Droid** | 通过 `~/.factory/settings.json` 配置自定义模型的 AI 软件工程 Agent。 | [指南](./docs/deepseek-droid-guide-zh.md) |
 
 ## 相关资源
 


### PR DESCRIPTION
The Factory AI Droid guides at `docs/deepseek-droid-guide.md` and `docs/deepseek-droid-guide-zh.md` (added in #14 and #15) aren't linked from the Tools tables in either README. This PR adds the row to both, matching the existing entry style.

## Test plan

- [x] English README link resolves to `docs/deepseek-droid-guide.md`
- [x] Chinese README link resolves to `docs/deepseek-droid-guide-zh.md`
- [x] Existing rows unchanged
