### PR TITLE
Add Tday integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
+| **Tday** | Desktop launcher that runs every coding-agent harness (Pi, Claude Code, Codex, OpenCode) in browser-style tabs with one shared provider config, local-inference autodetect, unified memory, and cross-agent token analytics. | [Guide](./docs/tday.md) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
+| **Tday** | 桌面启动器，通过浏览器式标签页同时运行多种编程 Agent（Pi、Claude Code、Codex、OpenCode），并提供统一的供应商配置、本地推理自动发现、跨 Agent 长期记忆与 Token 用量分析。 | [指南](./docs/tday.zh-CN.md) |
 
 ## 相关资源
 

--- a/docs/tday.md
+++ b/docs/tday.md
@@ -4,6 +4,12 @@
 
 [Tday](https://github.com/unbug/tday) is a desktop launcher that runs every coding-agent harness (Pi, Claude Code, Codex, OpenCode, …) inside browser-style tabs, with one shared provider config, auto-discovered local inference servers, unified long-term memory, and cross-agent token analytics. DeepSeek is a first-class built-in provider.
 
+<p align="center">
+  <a href="https://x.com/i/status/2049935301808935356">
+    <img alt="Tday Demo" src="https://github.com/user-attachments/assets/5d7ac6d9-cf0a-4eb3-b865-71ffbd11806b" width="800" />
+  </a>
+</p>
+
 #### 1. Install Tday
 
 Download the latest release for your platform from the [Tday Releases](https://github.com/unbug/tday/releases/latest) page:

--- a/docs/tday.md
+++ b/docs/tday.md
@@ -1,0 +1,84 @@
+[English](./tday.md) | [简体中文](./tday.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Tday
+
+[Tday](https://github.com/unbug/tday) is a desktop launcher that runs every coding-agent harness (Pi, Claude Code, Codex, OpenCode, …) inside browser-style tabs, with one shared provider config, auto-discovered local inference servers, unified long-term memory, and cross-agent token analytics. DeepSeek is a first-class built-in provider.
+
+#### 1. Install Tday
+
+Download the latest release for your platform from the [Tday Releases](https://github.com/unbug/tday/releases/latest) page:
+
+- **macOS** — `Tday-<version>-mac-arm64.dmg` (Apple Silicon) or `Tday-<version>-mac-x64.dmg` (Intel)
+- **Windows** — `Tday-<version>-win-x64.exe`
+- **Linux** — `Tday-<version>-linux-x86_64.AppImage` or `Tday-<version>-linux-x64.tar.gz`
+
+Or build from source:
+
+```bash
+git clone https://github.com/unbug/tday.git
+cd tday
+pnpm install
+pnpm build:core   # builds the Rust tday-core binary
+pnpm dev          # launches the desktop app
+```
+
+> **Prerequisites for source builds:** Node.js ≥ 20, pnpm ≥ 9, Rust ≥ 1.78.
+
+Tday bundles adapters for `pi`, `claude-code`, `codex`, and `opencode`. Install whichever harness(es) you plan to use globally via `npm i -g`, e.g.:
+
+```bash
+npm install -g @mariozechner/pi-coding-agent
+npm install -g @anthropic-ai/claude-code
+npm install -g @openai/codex
+npm install -g opencode-ai
+```
+
+#### 2. Configure the DeepSeek Provider
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+**Option A — Use the Settings UI (recommended)**
+
+1. Launch Tday.
+2. Open **Settings → Providers** and click **+ Add provider**.
+3. From the vendor picker, choose **DeepSeek**.
+4. Fill in:
+   - **Base URL**: `https://api.deepseek.com` (the default OpenAI-compatible endpoint; do not append `/v1`)
+   - **API Key**: paste your DeepSeek API Key
+   - **Model**: pick from the latest-models dropdown (e.g. `deepseek-v4-pro` or `deepseek-v4-flash`) or type a model id
+5. (Optional) Toggle **Use this provider/model for all agents** to share the same DeepSeek config across every harness you launch.
+6. Save.
+
+**Option B — Edit `~/.tday/providers.json` directly**
+
+```json
+{
+  "providers": {
+    "deepseek": {
+      "vendor": "deepseek",
+      "baseUrl": "https://api.deepseek.com",
+      "apiKey": "<your DeepSeek API Key>",
+      "models": [
+        { "id": "deepseek-v4-pro",   "name": "DeepSeek V4 Pro" },
+        { "id": "deepseek-v4-flash", "name": "DeepSeek V4 Flash" }
+      ]
+    }
+  },
+  "defaultProvider": "deepseek",
+  "defaultModel": "deepseek-v4-pro"
+}
+```
+
+Restart Tday after editing the file.
+
+#### 3. Open a Tab and Start Coding
+
+1. Press **Cmd+T** (macOS) / **Ctrl+T** (Windows / Linux) to open a new agent tab, or click **+** in the tab bar.
+2. From the dropdown, pick the harness you want — **Pi**, **Claude Code**, **Codex**, or **OpenCode**.
+3. Set the working directory for the tab (browse or paste a path, then press **Enter** to commit).
+4. Tday spawns the agent in a real PTY with your DeepSeek provider injected via env vars and the matching CLI flag, so the agent uses DeepSeek instead of its own default provider.
+5. Inside the agent, switch models any time with `/model` (or whatever shortcut your chosen harness exposes) and pick `deepseek-v4-pro` for the strongest reasoning or `deepseek-v4-flash` for faster, cheaper turns.
+
+> **Tip:** Open multiple tabs side by side — e.g. Pi on `~/projects/api`, Claude Code on `~/projects/web` — all sharing the same DeepSeek key and model. Tabs and their working directories persist across restarts.
+
+For more details (architecture, roadmap, local-inference autodetect, token analytics, long-term memory), see the [Tday README](https://github.com/unbug/tday#readme).

--- a/docs/tday.md
+++ b/docs/tday.md
@@ -10,6 +10,14 @@
   </a>
 </p>
 
+<p align="center">
+  <img alt="Tday Agents settings — bind DeepSeek to every harness" src="https://github.com/user-attachments/assets/77499913-ef2b-40a0-a0d3-88b779e337a0" width="800" />
+</p>
+
+<p align="center">
+  <img alt="Tday Providers settings" src="https://github.com/user-attachments/assets/1964db7f-2db3-4eed-92a7-65eb172d33ed" width="800" />
+</p>
+
 #### 1. Install Tday
 
 Download the latest release for your platform from the [Tday Releases](https://github.com/unbug/tday/releases/latest) page:

--- a/docs/tday.md
+++ b/docs/tday.md
@@ -4,18 +4,27 @@
 
 [Tday](https://github.com/unbug/tday) is a desktop launcher that runs every coding-agent harness (Pi, Claude Code, Codex, OpenCode, …) inside browser-style tabs, with one shared provider config, auto-discovered local inference servers, unified long-term memory, and cross-agent token analytics. DeepSeek is a first-class built-in provider.
 
-<p align="center">
+<a href="https://github.com/unbug/tday/releases"><img src="https://img.shields.io/badge/release-latest-blue"></a>
+
+<p>
   <a href="https://x.com/i/status/2049935301808935356">
-    <img alt="Tday Demo" src="https://github.com/user-attachments/assets/5d7ac6d9-cf0a-4eb3-b865-71ffbd11806b" width="800" />
+    <img src="https://github.com/user-attachments/assets/ba6c8041-173f-44bb-90d6-cd72071260df">
   </a>
 </p>
 
-<p align="center">
-  <img alt="Tday Agents settings — bind DeepSeek to every harness" src="https://github.com/user-attachments/assets/77499913-ef2b-40a0-a0d3-88b779e337a0" width="800" />
+<p>
+  <img src="https://github.com/user-attachments/assets/c196629b-5ee4-46dd-b1e3-d0ba86ab66b9">
+  <img src="https://github.com/user-attachments/assets/27bf23af-a5f6-4457-8cc7-7f6085829733">
 </p>
 
-<p align="center">
-  <img alt="Tday Providers settings" src="https://github.com/user-attachments/assets/1964db7f-2db3-4eed-92a7-65eb172d33ed" width="800" />
+<p>
+  <img src="https://github.com/user-attachments/assets/9dc6b149-80d4-4175-839a-3102960f2457">
+  <img src="https://github.com/user-attachments/assets/4990e941-0b65-4d25-9d3e-b46e3dd1f67e">
+</p>
+
+<p>
+  <img src="https://github.com/user-attachments/assets/2512a05f-e373-469f-859c-16b745da82a4">
+  <img src="https://github.com/user-attachments/assets/01c3ef52-3080-4d73-811d-0cb7759d275d">
 </p>
 
 #### 1. Install Tday

--- a/docs/tday.zh-CN.md
+++ b/docs/tday.zh-CN.md
@@ -1,0 +1,84 @@
+[English](./tday.md) | [简体中文](./tday.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Tday
+
+[Tday](https://github.com/unbug/tday) 是一个桌面启动器，通过浏览器式标签页同时运行多种编程 Agent（Pi、Claude Code、Codex、OpenCode 等），并提供统一的供应商配置、本地推理服务自动发现、跨 Agent 的长期记忆与 Token 用量分析。DeepSeek 是 Tday 内置的一等供应商。
+
+#### 1. 安装 Tday
+
+从 [Tday Releases](https://github.com/unbug/tday/releases/latest) 页面下载对应平台的最新版本：
+
+- **macOS** —— `Tday-<version>-mac-arm64.dmg`（Apple Silicon）或 `Tday-<version>-mac-x64.dmg`（Intel）
+- **Windows** —— `Tday-<version>-win-x64.exe`
+- **Linux** —— `Tday-<version>-linux-x86_64.AppImage` 或 `Tday-<version>-linux-x64.tar.gz`
+
+也可以从源码构建：
+
+```bash
+git clone https://github.com/unbug/tday.git
+cd tday
+pnpm install
+pnpm build:core   # 构建 Rust tday-core 二进制
+pnpm dev          # 启动桌面应用
+```
+
+> **源码构建依赖：** Node.js ≥ 20、pnpm ≥ 9、Rust ≥ 1.78。
+
+Tday 内置了 `pi`、`claude-code`、`codex`、`opencode` 适配器。请通过 `npm i -g` 全局安装你计划使用的 Agent，例如：
+
+```bash
+npm install -g @mariozechner/pi-coding-agent
+npm install -g @anthropic-ai/claude-code
+npm install -g @openai/codex
+npm install -g opencode-ai
+```
+
+#### 2. 配置 DeepSeek 供应商
+
+请前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
+
+**方式 A —— 使用 Settings UI（推荐）**
+
+1. 启动 Tday。
+2. 进入 **Settings → Providers**，点击 **+ Add provider**。
+3. 在供应商选择器中选择 **DeepSeek**。
+4. 填写：
+   - **Base URL**：`https://api.deepseek.com`（DeepSeek 的 OpenAI 兼容端点，无需追加 `/v1`）
+   - **API Key**：粘贴你的 DeepSeek API Key
+   - **Model**：在最新模型下拉列表中选择（如 `deepseek-v4-pro` 或 `deepseek-v4-flash`），也可手动输入模型 ID
+5. （可选）开启 **Use this provider/model for all agents**，让所有启动的 Agent 共享同一份 DeepSeek 配置。
+6. 保存。
+
+**方式 B —— 直接编辑 `~/.tday/providers.json`**
+
+```json
+{
+  "providers": {
+    "deepseek": {
+      "vendor": "deepseek",
+      "baseUrl": "https://api.deepseek.com",
+      "apiKey": "<your DeepSeek API Key>",
+      "models": [
+        { "id": "deepseek-v4-pro",   "name": "DeepSeek V4 Pro" },
+        { "id": "deepseek-v4-flash", "name": "DeepSeek V4 Flash" }
+      ]
+    }
+  },
+  "defaultProvider": "deepseek",
+  "defaultModel": "deepseek-v4-pro"
+}
+```
+
+修改文件后重启 Tday 即可生效。
+
+#### 3. 打开标签页开始编码
+
+1. 按 **Cmd+T**（macOS）/ **Ctrl+T**（Windows / Linux）新建一个 Agent 标签页，或点击标签栏的 **+** 按钮。
+2. 从下拉菜单中选择要使用的 Agent —— **Pi**、**Claude Code**、**Codex** 或 **OpenCode**。
+3. 设置该标签页的工作目录（浏览或粘贴路径，按 **Enter** 提交）。
+4. Tday 会在真实 PTY 中启动 Agent，并通过环境变量与对应的 CLI 参数注入 DeepSeek 配置，让 Agent 使用 DeepSeek 而不是它自带的默认供应商。
+5. 进入 Agent 后，可随时通过 `/model`（或所选 Agent 提供的快捷方式）切换模型 —— 选择 `deepseek-v4-pro` 获得最强推理能力，或选择 `deepseek-v4-flash` 获得更快更省的响应。
+
+> **小贴士：** 你可以同时打开多个标签页，例如在 `~/projects/api` 中运行 Pi，在 `~/projects/web` 中运行 Claude Code，它们共享同一份 DeepSeek Key 和模型配置。标签页与工作目录在应用重启后会自动恢复。
+
+更多内容（架构、路线图、本地推理自动发现、Token 用量分析、长期记忆等）请查阅 [Tday README](https://github.com/unbug/tday#readme)。

--- a/docs/tday.zh-CN.md
+++ b/docs/tday.zh-CN.md
@@ -4,18 +4,27 @@
 
 [Tday](https://github.com/unbug/tday) 是一个桌面启动器，通过浏览器式标签页同时运行多种编程 Agent（Pi、Claude Code、Codex、OpenCode 等），并提供统一的供应商配置、本地推理服务自动发现、跨 Agent 的长期记忆与 Token 用量分析。DeepSeek 是 Tday 内置的一等供应商。
 
-<p align="center">
+<a href="https://github.com/unbug/tday/releases"><img src="https://img.shields.io/badge/release-latest-blue"></a>
+
+<p>
   <a href="https://x.com/i/status/2049935301808935356">
-    <img alt="Tday 演示" src="https://github.com/user-attachments/assets/5d7ac6d9-cf0a-4eb3-b865-71ffbd11806b" width="800" />
+    <img src="https://github.com/user-attachments/assets/ba6c8041-173f-44bb-90d6-cd72071260df">
   </a>
 </p>
 
-<p align="center">
-  <img alt="Tday Agents 设置 — 将 DeepSeek 绑定到每个 harness" src="https://github.com/user-attachments/assets/77499913-ef2b-40a0-a0d3-88b779e337a0" width="800" />
+<p>
+  <img src="https://github.com/user-attachments/assets/c196629b-5ee4-46dd-b1e3-d0ba86ab66b9">
+  <img src="https://github.com/user-attachments/assets/27bf23af-a5f6-4457-8cc7-7f6085829733">
 </p>
 
-<p align="center">
-  <img alt="Tday Providers 设置" src="https://github.com/user-attachments/assets/1964db7f-2db3-4eed-92a7-65eb172d33ed" width="800" />
+<p>
+  <img src="https://github.com/user-attachments/assets/9dc6b149-80d4-4175-839a-3102960f2457">
+  <img src="https://github.com/user-attachments/assets/4990e941-0b65-4d25-9d3e-b46e3dd1f67e">
+</p>
+
+<p>
+  <img src="https://github.com/user-attachments/assets/2512a05f-e373-469f-859c-16b745da82a4">
+  <img src="https://github.com/user-attachments/assets/01c3ef52-3080-4d73-811d-0cb7759d275d">
 </p>
 
 #### 1. 安装 Tday

--- a/docs/tday.zh-CN.md
+++ b/docs/tday.zh-CN.md
@@ -4,6 +4,12 @@
 
 [Tday](https://github.com/unbug/tday) 是一个桌面启动器，通过浏览器式标签页同时运行多种编程 Agent（Pi、Claude Code、Codex、OpenCode 等），并提供统一的供应商配置、本地推理服务自动发现、跨 Agent 的长期记忆与 Token 用量分析。DeepSeek 是 Tday 内置的一等供应商。
 
+<p align="center">
+  <a href="https://x.com/i/status/2049935301808935356">
+    <img alt="Tday 演示" src="https://github.com/user-attachments/assets/5d7ac6d9-cf0a-4eb3-b865-71ffbd11806b" width="800" />
+  </a>
+</p>
+
 #### 1. 安装 Tday
 
 从 [Tday Releases](https://github.com/unbug/tday/releases/latest) 页面下载对应平台的最新版本：

--- a/docs/tday.zh-CN.md
+++ b/docs/tday.zh-CN.md
@@ -10,6 +10,14 @@
   </a>
 </p>
 
+<p align="center">
+  <img alt="Tday Agents 设置 — 将 DeepSeek 绑定到每个 harness" src="https://github.com/user-attachments/assets/77499913-ef2b-40a0-a0d3-88b779e337a0" width="800" />
+</p>
+
+<p align="center">
+  <img alt="Tday Providers 设置" src="https://github.com/user-attachments/assets/1964db7f-2db3-4eed-92a7-65eb172d33ed" width="800" />
+</p>
+
 #### 1. 安装 Tday
 
 从 [Tday Releases](https://github.com/unbug/tday/releases/latest) 页面下载对应平台的最新版本：


### PR DESCRIPTION
Adds an integration guide for [Tday](https://github.com/unbug/tday) — a desktop launcher that runs multiple coding agent harnesses (Pi, Claude Code, Codex, OpenCode, etc.) in browser-style tabs, sharing one provider configuration, auto-discovering local inference servers, unifying long-term memory, and offering cross-agent token usage analytics. DeepSeek is a built-in first-class provider.

### Changes
- New docs

  - docs/tday.md (English)
  - docs/tday.zh-CN.md (Simplified Chinese)
  - Cover: installation, configuring the DeepSeek API key in the Providers panel, binding DeepSeek to each harness in the Agents panel (with deepseek-v4-flash model override), and setting the default agent for new tabs.
- Index updates

  - Added a Tday row to the Contents table in README.md and README.zh-CN.md.
### Visuals


[![latest](https://img.shields.io/badge/release-latest-blue)](https://github.com/unbug/tday/releases)

<p align="center">
  <a href="https://x.com/i/status/2049935301808935356">
    <img
      width="1200"
      height="800"
      alt="Tday Demo Video on X"
      src="https://github.com/user-attachments/assets/ba6c8041-173f-44bb-90d6-cd72071260df"
    />
  </a>
</p>

<p align="center">
  <img
    width="49%"
    alt="Tday Screenshot 1"
    src="https://github.com/user-attachments/assets/c196629b-5ee4-46dd-b1e3-d0ba86ab66b9"
  />
  <img
    width="49%"
    alt="Tday Screenshot 2"
    src="https://github.com/user-attachments/assets/27bf23af-a5f6-4457-8cc7-7f6085829733"
  />
</p>

<p align="center">
  <img
    width="49%"
    alt="Tday Screenshot 3"
    src="https://github.com/user-attachments/assets/9dc6b149-80d4-4175-839a-3102960f2457"
  />
  <img
    width="49%"
    alt="Tday Screenshot 4"
    src="https://github.com/user-attachments/assets/4990e941-0b65-4d25-9d3e-b46e3dd1f67e"
  />
</p>

<p align="center">
  <img
    width="49%"
    alt="Tday Screenshot 5"
    src="https://github.com/user-attachments/assets/2512a05f-e373-469f-859c-16b745da82a4"
  />
  <img
    width="49%"
    alt="Tday Screenshot 6"
    src="https://github.com/user-attachments/assets/01c3ef52-3080-4d73-811d-0cb7759d275d"
  />
</p>
