### PR TITLE
Add English Cline CLI DeepSeek guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | Tool            | Description                                                                                                 | Guide                          |
 | --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
+| **Cline CLI** | Command-line AI coding assistant powered by Cline. | [Guide](./docs/cline_cli.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |

--- a/docs/cline_cli.md
+++ b/docs/cline_cli.md
@@ -1,0 +1,70 @@
+[English](./cline_cli.md) | [简体中文](./cline_cli.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Cline CLI
+
+Cline CLI is the command-line version of Cline, an AI coding assistant that can read and edit files, run shell commands, and work from your terminal.
+
+#### 1. Install Cline CLI
+
+- Install [Node.js](https://nodejs.org/en/download/) 20+.
+- Run the following command in your terminal to install Cline CLI:
+
+```
+npm install -g cline
+```
+
+- After installation, run the following command. If the version number is displayed, the installation is successful:
+
+```
+cline version
+```
+
+#### 2. Start the Authentication Wizard
+
+Run the Cline authentication wizard:
+
+```
+cline auth
+```
+
+When the welcome screen appears, select **Use your own API key**.
+
+This option is also called **Bring your own API key** in Cline documentation. It means Cline will use your DeepSeek API key directly, so DeepSeek handles model billing and rate limits for your requests.
+
+#### 3. Select DeepSeek as the Provider
+
+In the provider picker, select **DeepSeek**.
+
+If you prefer non-interactive setup, Cline also exposes DeepSeek as the `deepseek` provider id.
+
+#### 4. Enter Your DeepSeek API Key
+
+Paste your [DeepSeek API Key](https://platform.deepseek.com/api_keys) when prompted.
+
+Keep this key private. An API key is a credential that lets Cline call DeepSeek on your behalf, similar to a password for programmatic access.
+
+#### 5. Select a Model
+
+Choose one of the available DeepSeek models:
+
+- `deepseek-chat` — general coding and chat tasks.
+- `deepseek-reasoner` — reasoning-heavy tasks where step-by-step problem solving is useful.
+
+After selecting a model, authentication is complete.
+
+#### 6. Start Cline
+
+```
+cd /path/to/my-project
+cline
+```
+
+#### Optional: Configure DeepSeek with Flags
+
+The wizard path above is the easiest way to configure DeepSeek. For scripted setup, you can also skip the wizard and pass the DeepSeek provider, API key, and model directly:
+
+```
+cline auth -p deepseek -k <your DeepSeek API Key> -m deepseek-chat
+```
+
+Use `deepseek-reasoner` instead of `deepseek-chat` if you want the reasoning model.


### PR DESCRIPTION
## Problem

The repository does not currently include an English guide for configuring Cline CLI with DeepSeek.

## Fix

- Add `docs/cline_cli.md` with an English Cline CLI setup flow.
- Link the new guide from `README.md`.
- Keep the optional command-line setup DeepSeek-specific with `cline auth -p deepseek`.

## Evidence

- Checked local `cline auth --help` for the auth flags.
- Compared the documented provider id, model ids, and auth flow against Cline's official CLI and DeepSeek provider documentation.
