### PR TITLE
Add Momoka integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,25 @@ Each guide walks through installation, configuration, and first run — so you c
 
 ## Contents
 
-| Tool            | Description                                                                                                 | Guide                          |
-| --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
-| **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
-| **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
-| **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
-| **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
-| **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
-| **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
-| **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
-| **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
-| **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
-| **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
-| **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
-| **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
-| **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
-| **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
-| **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
+| Tool                    | Description                                                                                                                                 | Guide                             |
+|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
+| **Claude Code**         | AI coding assistant that runs in the terminal.                                                                                              | [Guide](./docs/claude_code.md)    |
+| **GitHub Copilot**      | AI peer programmer built into VS Code.                                                                                                      | [Guide](./docs/github_copilot.md) |
+| **GitHub Copilot CLI**  | Terminal-native AI coding assistant with agentic capabilities.                                                                              | [Guide](./docs/copilot_cli.md)    |
+| **Kilo Code**           | AI coding assistant available as a CLI and editor extension.                                                                                | [Guide](./docs/kilo_code.md)      |
+| **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration.                                                            | [Guide](./docs/workbuddy.md)      |
+| **OpenCode**            | Open-source AI coding assistant available in terminal, web, and other forms.                                                                | [Guide](./docs/opencode.md)       |
+| **Oh My Pi**            | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows.                            | [Guide](./docs/oh-my-pi.md)       |
+| **OpenClaw**            | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills.                                 | [Guide](./docs/openclaw.md)       |
+| **AstrBot**             | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.                                       | [Guide](./docs/astrbot.md)        |
+| **Deep Code**           | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills.          | [Guide](./docs/deepcode.md)       |
+| **Hermes**              | Open-source self-improving AI agent built by Nous Research.                                                                                 | [Guide](./docs/hermes.md)         |
+| **nanobot**             | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more.                                                     | [Guide](./docs/nanobot.md)        |
+| **Crush**               | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.                                        | [Guide](./docs/crush.md)          |
+| **Pi**                  | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.                                             | [Guide](./docs/pi_mono.md)        |
+| **Reasonix**            | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                                                      | [Guide](./docs/reasonix.md)       |
+| **Langcli**             | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models                                 | [Guide](./docs/langcli.md)        |
+| **Momoka**              | Open-source AI agent assistant that supports DeepSeek V4 and other models, extensible via MCP and Skills. Supports Discord, Feishu, and QQ. | [Guide](./docs/momoka_en.md)      |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@ Each guide walks through installation, configuration, and first run — so you c
 
 ## Contents
 
-| Tool                    | Description                                                                                                                                 | Guide                             |
-|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
-| **Claude Code**         | AI coding assistant that runs in the terminal.                                                                                              | [Guide](./docs/claude_code.md)    |
-| **GitHub Copilot**      | AI peer programmer built into VS Code.                                                                                                      | [Guide](./docs/github_copilot.md) |
-| **GitHub Copilot CLI**  | Terminal-native AI coding assistant with agentic capabilities.                                                                              | [Guide](./docs/copilot_cli.md)    |
-| **Kilo Code**           | AI coding assistant available as a CLI and editor extension.                                                                                | [Guide](./docs/kilo_code.md)      |
-| **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration.                                                            | [Guide](./docs/workbuddy.md)      |
-| **OpenCode**            | Open-source AI coding assistant available in terminal, web, and other forms.                                                                | [Guide](./docs/opencode.md)       |
-| **Oh My Pi**            | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows.                            | [Guide](./docs/oh-my-pi.md)       |
-| **OpenClaw**            | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills.                                 | [Guide](./docs/openclaw.md)       |
-| **AstrBot**             | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.                                       | [Guide](./docs/astrbot.md)        |
-| **Deep Code**           | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills.          | [Guide](./docs/deepcode.md)       |
-| **Hermes**              | Open-source self-improving AI agent built by Nous Research.                                                                                 | [Guide](./docs/hermes.md)         |
-| **nanobot**             | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more.                                                     | [Guide](./docs/nanobot.md)        |
-| **Crush**               | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.                                        | [Guide](./docs/crush.md)          |
-| **Pi**                  | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.                                             | [Guide](./docs/pi_mono.md)        |
-| **Reasonix**            | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                                                      | [Guide](./docs/reasonix.md)       |
-| **Langcli**             | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models                                 | [Guide](./docs/langcli.md)        |
-| **Momoka**              | Open-source AI agent assistant that supports DeepSeek V4 and other models, extensible via MCP and Skills. Supports Discord, Feishu, and QQ. | [Guide](./docs/momoka_en.md)      |
+| Tool            | Description                                                                                                 | Guide                          |
+| --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
+| **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
+| **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
+| **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
+| **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
+| **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
+| **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
+| **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
+| **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
+| **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
+| **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
+| **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
+| **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
+| **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
+| **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
+| **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
+| **Momoka**      | Open-source AI agent assistant that supports DeepSeek V4 and other models, extensible via MCP and Skills. | [Guide](./docs/momoka_en.md)      |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,24 +13,25 @@
 
 ## 目录
 
-| 工具            | 简介                                                                  | 指南                                |
-| --------------- | --------------------------------------------------------------------- | ----------------------------------- |
-| **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |
-| **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
-| **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
-| **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
-| **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
-| **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
-| **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
-| **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
-| **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
-| **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
-| **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
-| **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |
-| **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
-| **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
-| **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
-| **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
+| 工具                      | 简介                                                                  | 指南                                   |
+|-------------------------|---------------------------------------------------------------------|--------------------------------------|
+| **Claude Code**         | 运行在终端内的 AI 编程助手。                                                    | [指南](./docs/claude_code.zh-CN.md)    |
+| **GitHub Copilot**      | 内置于 VS Code 的 AI 编程助手。                                              | [指南](./docs/github_copilot.zh-CN.md) |
+| **GitHub Copilot CLI**  | 终端原生的 AI 编程助手，支持 Agent 能力。                                          | [指南](./docs/copilot_cli.zh-CN.md)    |
+| **Kilo Code**           | 支持 CLI 和编辑器扩展的 AI 编程助手。                                             | [指南](./docs/kilo_code.zh-CN.md)      |
+| **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。                                | [指南](./docs/workbuddy.zh-CN.md)      |
+| **OpenCode**            | 开源 AI 编程助手，提供终端、网页等多种运行形式。                                          | [指南](./docs/opencode.zh-CN.md)       |
+| **Oh My Pi**            | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。       | [指南](./docs/oh-my-pi.zh-CN.md)       |
+| **OpenClaw**            | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。                            | [指南](./docs/openclaw.zh-CN.md)       |
+| **AstrBot**             | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。            | [指南](./docs/astrbot.zh-CN.md)        |
+| **Deep Code**           | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。    | [指南](./docs/deepcode.zh-CN.md)       |
+| **Hermes**              | 开源自我进化 AI 助手。                                                       | [指南](./docs/hermes.zh-CN.md)         |
+| **nanobot**             | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。                                      | [指南](./docs/nanobot.zh-CN.md)        |
+| **Crush**               | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。                                  | [指南](./docs/crush.zh-CN.md)          |
+| **Pi**                  | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。                                      | [指南](./docs/pi_mono.zh-CN.md)        |
+| **Reasonix**            | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。             | [指南](./docs/reasonix.zh-CN.md)       |
+| **Langcli**             | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。                  | [指南](./docs/langcli.zh-CN.md)        |
+| **Momoka**              | 开源的AI Agent助手，支持Deepseek v4等模型并可通过MCP、Skills进行拓展。支持接入Discord、飞书、QQ。 | [指南](./docs/momoka_cn.md)            |
 
 ## 相关资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,25 +13,25 @@
 
 ## 目录
 
-| 工具                      | 简介                                                                  | 指南                                   |
-|-------------------------|---------------------------------------------------------------------|--------------------------------------|
-| **Claude Code**         | 运行在终端内的 AI 编程助手。                                                    | [指南](./docs/claude_code.zh-CN.md)    |
-| **GitHub Copilot**      | 内置于 VS Code 的 AI 编程助手。                                              | [指南](./docs/github_copilot.zh-CN.md) |
-| **GitHub Copilot CLI**  | 终端原生的 AI 编程助手，支持 Agent 能力。                                          | [指南](./docs/copilot_cli.zh-CN.md)    |
-| **Kilo Code**           | 支持 CLI 和编辑器扩展的 AI 编程助手。                                             | [指南](./docs/kilo_code.zh-CN.md)      |
-| **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。                                | [指南](./docs/workbuddy.zh-CN.md)      |
-| **OpenCode**            | 开源 AI 编程助手，提供终端、网页等多种运行形式。                                          | [指南](./docs/opencode.zh-CN.md)       |
-| **Oh My Pi**            | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。       | [指南](./docs/oh-my-pi.zh-CN.md)       |
-| **OpenClaw**            | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。                            | [指南](./docs/openclaw.zh-CN.md)       |
-| **AstrBot**             | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。            | [指南](./docs/astrbot.zh-CN.md)        |
-| **Deep Code**           | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。    | [指南](./docs/deepcode.zh-CN.md)       |
-| **Hermes**              | 开源自我进化 AI 助手。                                                       | [指南](./docs/hermes.zh-CN.md)         |
-| **nanobot**             | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。                                      | [指南](./docs/nanobot.zh-CN.md)        |
-| **Crush**               | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。                                  | [指南](./docs/crush.zh-CN.md)          |
-| **Pi**                  | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。                                      | [指南](./docs/pi_mono.zh-CN.md)        |
-| **Reasonix**            | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。             | [指南](./docs/reasonix.zh-CN.md)       |
-| **Langcli**             | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。                  | [指南](./docs/langcli.zh-CN.md)        |
-| **Momoka**              | 开源的AI Agent助手，支持Deepseek v4等模型并可通过MCP、Skills进行拓展。支持接入Discord、飞书、QQ。 | [指南](./docs/momoka_cn.md)            |
+| 工具            | 简介                                                                  | 指南                                |
+| --------------- | --------------------------------------------------------------------- | ----------------------------------- |
+| **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |
+| **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
+| **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
+| **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
+| **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
+| **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
+| **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
+| **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
+| **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
+| **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
+| **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
+| **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |
+| **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
+| **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
+| **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
+| **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
+| **Momoka** | 开源的AI Agent助手，支持Deepseek v4等模型并可通过MCP、Skills进行拓展。 | [指南](./docs/momoka_cn.md)            |
 
 ## 相关资源
 

--- a/docs/momoka_cn.md
+++ b/docs/momoka_cn.md
@@ -1,0 +1,66 @@
+[English](./momoka_en.md) | [简体中文](./momoka_cn.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Momoka
+
+Momoka 是一个开源的 AI Agent 助手，支持 DeepSeek V4 等模型，可通过 MCP、Skills 进行拓展，支持接入 Discord、飞书、QQ等平台。
+
+## 🚀 快速开始
+
+### 部署
+
+#### 下载发行版本（推荐）
+在[这里](https://github.com/xiaomi2023/Momoka/releases)获取最新的Momoka版本。
+
+或
+
+#### 拉取仓库
+```bash
+git clone https://github.com/xiaomi2023/Momoka
+```
+
+### 安装依赖
+
+```bash
+pip install -r requirements.txt
+python -m rebrowser_playwright install chromium
+```
+
+### 运行
+
+```bash
+python main.py
+```
+
+### 配置
+开始前，需要在[Deepseek 开放平台](https://platform.deepseek.com/)注册并获取API Key。
+
+1、运行后，输入以下命令以配置模型 API 的 Base Url 和 API Key：
+```bash
+/set base_url https://api.XXX.com
+/set api_key sk-***
+```
+
+2、输入 **/model** 以选择模型（例如deepseek-v4-flash）。
+
+3、（可选）输入命令：
+```bash
+/set work_dir C:\\Users\\...
+```
+配置Momoka工作的位置。  
+
+所有配置可能需要重启后才能生效。如果配置过程中出现异常，可以在config.json中配置相关字段）  
+发送测试信息确保一切就绪，然后开始使用吧！
+
+## 拓展能力
+
+- **MCP Server**: 参考 [MCP 集成文档](https://xiaomi2023.github.io/Momoka/mcp_integration/)
+- **Skill**: 参考 [Skill 文档](https://xiaomi2023.github.io/Momoka/skill/)
+- **Momoka Server**: 参考 [Momoka Server 文档](https://xiaomi2023.github.io/Momoka/momoka_server/)
+
+## 接入更多平台
+
+- [Discord](https://xiaomi2023.github.io/Momoka/discord/)
+- [Lark / 飞书](https://xiaomi2023.github.io/Momoka/lark/)
+- [QQ](https://xiaomi2023.github.io/Momoka/qq/)
+
+更多信息请参考 [Momoka 文档](https://xiaomi2023.github.io/Momoka/)。

--- a/docs/momoka_en.md
+++ b/docs/momoka_en.md
@@ -1,0 +1,68 @@
+[English](./momoka_en.md) | [简体中文](./momoka_cn.md) · [← Back](../README.md)
+
+# Integrate with Momoka
+
+Momoka is an open-source AI agent assistant that supports DeepSeek V4 and other models, extensible via MCP and Skills. It supports Discord, Feishu (Lark), QQ, and more.
+
+## 🚀 Quick Start
+
+### Deploy
+
+#### Download a release (recommended)
+Get the latest release from [Momoka Releases](https://github.com/xiaomi2023/Momoka/releases).
+
+Or
+
+#### Clone the repository
+```bash
+git clone https://github.com/xiaomi2023/Momoka
+```
+
+### Install dependencies
+
+```bash
+pip install -r requirements.txt
+python -m rebrowser_playwright install chromium
+```
+
+### Run
+
+```bash
+python main.py
+```
+
+### Configure
+
+Before you start, register and get an API Key from the [DeepSeek Platform](https://platform.deepseek.com/).
+
+1. After running, enter the following commands to configure the model API Base URL and API Key:
+```bash
+/set base_url https://api.XXX.com
+/set api_key sk-***
+```
+
+2. Enter **/model** to select a model (e.g., `deepseek-v4-flash`).
+
+3. (Optional) Enter the command:
+```bash
+/set work_dir C:\\Users\\...
+```
+to configure Momoka's working directory.
+
+All configuration may require a restart to take effect. If any errors occur during configuration, you can also edit the relevant fields directly in `config.json`.
+
+Send a test message to make sure everything is ready, then start using it!
+
+## Extend capabilities
+
+- **MCP Server**: See [MCP Integration Guide](https://xiaomi2023.github.io/Momoka/mcp_integration/)
+- **Skill**: See [Skill Documentation](https://xiaomi2023.github.io/Momoka/skill/)
+- **Momoka Server**: See [Momoka Server Docs](https://xiaomi2023.github.io/Momoka/momoka_server/)
+
+## Connect to more platforms
+
+- [Discord](https://xiaomi2023.github.io/Momoka/discord/)
+- [Lark / Feishu](https://xiaomi2023.github.io/Momoka/lark/)
+- [QQ](https://xiaomi2023.github.io/Momoka/qq/)
+
+For more information, check out the [Momoka Documentation](https://xiaomi2023.github.io/Momoka/).


### PR DESCRIPTION
Adds an integration guide for Momoka — an open-source AI agent assistant that supports DeepSeek V4 and other models, extensible via MCP and Skills.

Changes:
- docs/momoka_en.md (English)
- docs/momoka_cn.md (Simplified Chinese)
- Added a Momoka row to the Contents table in README.md and README.zh-CN.md.