### PR TITLE
docs: add GenericAgent guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
-| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai-Assistant** | [Open Source] Novel Writing & AI Programming Assistant. Aggregates top large models from home and abroad(DeepSeek/Gemini/Claude/Kimi/ChatGPT, etc.) | [Guide](https://github.com/jiqi136/Ai-Assistant) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai-Assistant** | [Open Source] Novel Writing & AI Programming Assistant. <br>Aggregates top large models from home and abroad(DeepSeek/Gemini/Claude/Kimi/ChatGPT, etc.) | [Guide](https://github.com/jiqi136/Ai-Assistant) |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" />**Ai-Assistant** | [Open Source] Novel Writing & AI Programming Assistant. Aggregates top large models from home and abroad(DeepSeek/Gemini/Claude/Kimi/ChatGPT, etc.) | [Guide](https://github.com/jiqi136/Ai-Assistant) |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
-| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai-Assistant** | [Open Source] Novel Writing & AI Programming Assistant. <br>Aggregates top large models from home and abroad(DeepSeek/Gemini/Claude/Kimi/ChatGPT, etc.) | [Guide](https://github.com/jiqi136/Ai-Assistant) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai-Assistant** | [Open Source] Novel Writing & AI Programming Assistant. <br>Aggregates top large models from home and abroad(DeepSeek/Gemini/Claude/Kimi/ChatGPT, etc.) <br>Self research PC-Gui: A lightweight desktop GUI framework built for AI, natively supporting real-time typewriter streaming output like Gemini! | [Guide](https://github.com/jiqi136/Ai-Assistant) |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
-| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" />**Ai-Assistant** | [Open Source] Novel Writing & AI Programming Assistant. Aggregates top large models from home and abroad(DeepSeek/Gemini/Claude/Kimi/ChatGPT, etc.) | [Guide](https://github.com/jiqi136/Ai-Assistant) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" />
+**Ai-Assistant** | [Open Source] Novel Writing & AI Programming Assistant. Aggregates top large models from home and abroad(DeepSeek/Gemini/Claude/Kimi/ChatGPT, etc.) | [Guide](https://github.com/jiqi136/Ai-Assistant) |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
-| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" />
-**Ai-Assistant** | [Open Source] Novel Writing & AI Programming Assistant. Aggregates top large models from home and abroad(DeepSeek/Gemini/Claude/Kimi/ChatGPT, etc.) | [Guide](https://github.com/jiqi136/Ai-Assistant) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai-Assistant** | [Open Source] Novel Writing & AI Programming Assistant. Aggregates top large models from home and abroad(DeepSeek/Gemini/Claude/Kimi/ChatGPT, etc.) | [Guide](https://github.com/jiqi136/Ai-Assistant) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
-| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai助手** |[公开源码]小说写作&Ai编程助手 绿色便捷版. <br>支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 | [指南](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai助手** |[公开源码]小说写作&Ai编程助手 绿色便捷版. <br>支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 <br>自研PC-Gui: 轻量级AI图形用户界面，具备DeepSeek风格打字机流式输出功能！| [指南](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
 
 ## 相关资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
-| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**小说写作&Ai编程助手 绿色便捷版.** |[公开源码]支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 <br>自研PC-Gui: 轻量级AI图形用户界面，具备DeepSeek风格打字机流式输出功能！| [指南](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**小说写作&Ai编程助手** |[公开源码]支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 <br>自研PC-Gui: 轻量级AI图形用户界面，具备DeepSeek风格打字机流式输出功能！| [指南](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
 
 ## 相关资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
-| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai-Assistant** |[公开源码]小说写作&Ai编程助手 绿色便捷版. <br>支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 | [Guide](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai助手** |[公开源码]小说写作&Ai编程助手 绿色便捷版. <br>支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 | [指南](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
 
 ## 相关资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai-Assistant** |[公开源码]小说写作&Ai编程助手 绿色便捷版. <br>支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 | [Guide](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
 
 ## 相关资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
-| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**Ai助手** |[公开源码]小说写作&Ai编程助手 绿色便捷版. <br>支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 <br>自研PC-Gui: 轻量级AI图形用户界面，具备DeepSeek风格打字机流式输出功能！| [指南](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**小说写作&Ai编程助手 绿色便捷版.** |[公开源码]支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 <br>自研PC-Gui: 轻量级AI图形用户界面，具备DeepSeek风格打字机流式输出功能！| [指南](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
 
 ## 相关资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
-| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**小说写作&Ai编程助手** |[公开源码]支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 <br>自研PC-Gui: 轻量级AI图形用户界面，具备DeepSeek风格打字机流式输出功能！| [指南](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
+| <img src="https://h1.appinn.me/file/1775785742057_20.ico" alt="Icon" width="64" height="auto" /><br>**小说写作&Ai编程助手** |[公开源码]支持DeepSeek最新版本v4-flash与v4-pro.适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 <br>自研PC-Gui: 为 AI 而生，原生支持类 Deepseek实时打字机流式输出的轻量桌面 GUI 框架！| [指南](https://github.com/jiqi136/Ai-Assistant/blob/main/Chinese.md) |
 
 ## 相关资源
 


### PR DESCRIPTION
- Added bilingual integration guides for GenericAgent in Chinese and English
- 
- Updated both READMEs to include GenericAgent in the tools table

README.zh-CN.md:
[公开源码]支持DeepSeek最新版本v4-flash与v4-pro.
适配主流的API路线中转站,中转使用使用国内与海外最热门AI模型 <br>
自研PC-Gui: 为 AI 而生，原生支持类 Deepseek实时打字机流式输出的轻量桌面 GUI 框架！

README.md:
[Open Source] Novel Writing & AI Programming Assistant. <br>
Aggregates top large models from home and abroad(DeepSeek/Gemini/Claude/Kimi/ChatGPT, etc.) <br>
Self research PC-Gui: A lightweight desktop GUI framework built for AI, natively supporting real-time typewriter streaming output like Gemini! 