### PR TITLE
Add deepclaude — Claude Code agent loop with DeepSeek V4 Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
-| **cheapclaude** | Shell script that runs Claude Code's agent loop with DeepSeek V4 Pro. Supports remote control via local proxy. | [Guide](./docs/cheapclaude.md) |
+| **deepclaude** | Shell script that runs Claude Code's agent loop with DeepSeek V4 Pro. Supports remote control via local proxy. | [Guide](./docs/deepclaude.md) |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
+| **cheapclaude** | Shell script that runs Claude Code's agent loop with DeepSeek V4 Pro. Supports remote control via local proxy. | [Guide](./docs/cheapclaude.md) |
 
 ## Resources
 

--- a/docs/cheapclaude.md
+++ b/docs/cheapclaude.md
@@ -1,0 +1,89 @@
+[← Back](../README.md)
+
+# cheapclaude
+
+A shell script that runs Claude Code's autonomous agent loop with DeepSeek V4 Pro — same UX, 17x cheaper.
+
+**GitHub:** [github.com/aattaran/cheapclaude](https://github.com/aattaran/cheapclaude)
+
+## What it does
+
+Claude Code is the best autonomous coding agent — but it costs $200/month with usage caps. cheapclaude swaps the model to DeepSeek V4 Pro ($0.87/M output) while keeping Claude Code's tool loop, file editing, bash execution, and autonomous multi-step coding.
+
+Supports DeepSeek (direct), OpenRouter, and Fireworks AI as backends.
+
+## Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed (`npm install -g @anthropic-ai/claude-code`)
+- [DeepSeek API key](https://platform.deepseek.com/api_keys) (or OpenRouter/Fireworks key)
+
+## Quick Start
+
+#### 1. Set your API key
+
+**Linux / Mac:**
+```bash
+export DEEPSEEK_API_KEY="sk-your-key-here"
+```
+
+**Windows (PowerShell):**
+```powershell
+setx DEEPSEEK_API_KEY "sk-your-key-here"
+```
+
+#### 2. Download cheapclaude
+
+```bash
+git clone https://github.com/aattaran/cheapclaude.git
+cd cheapclaude
+chmod +x cheapclaude.sh   # Linux/Mac only
+```
+
+#### 3. Run it
+
+**Linux / Mac:**
+```bash
+./cheapclaude.sh
+```
+
+**Windows:**
+```powershell
+powershell -ExecutionPolicy Bypass -File cheapclaude.ps1
+```
+
+## Commands
+
+```bash
+cheapclaude                      # DeepSeek V4 Pro (default)
+cheapclaude -b or                # OpenRouter (cheapest, US servers)
+cheapclaude -b fw                # Fireworks AI (fastest, US servers)
+cheapclaude -b anthropic         # Normal Claude Code
+cheapclaude --remote             # Remote control (browser) + DeepSeek
+cheapclaude --remote -b or       # Remote control + OpenRouter
+cheapclaude --status             # Show keys and backends
+cheapclaude --cost               # Pricing comparison
+cheapclaude --benchmark          # Latency test
+```
+
+## Remote Control
+
+`cheapclaude --remote` starts a Claude Code remote-control session with DeepSeek as the brain. It launches a local HTTP proxy that routes model API calls to DeepSeek while keeping Anthropic's bridge auth intact.
+
+```
+claude remote-control
+  ├── Bridge WebSocket → Anthropic (hardcoded, auth)
+  └── Model API calls  → local proxy → DeepSeek ($0.87/M)
+```
+
+Requires a claude.ai subscription (the bridge is Anthropic infrastructure).
+
+## Pricing
+
+| Backend | Input/M | Output/M | Cache Hit/M |
+|---|---|---|---|
+| DeepSeek | $0.44 | $0.87 | $0.004 |
+| OpenRouter | $0.44 | $0.87 | (provider) |
+| Fireworks | $1.74 | $3.48 | (provider) |
+| Anthropic | $3.00 | $15.00 | $0.30 |
+
+Heavy daily use costs ~$2-5/day vs $200/month on Anthropic Max.

--- a/docs/deepclaude.md
+++ b/docs/deepclaude.md
@@ -1,14 +1,14 @@
 [← Back](../README.md)
 
-# cheapclaude
+# deepclaude
 
 A shell script that runs Claude Code's autonomous agent loop with DeepSeek V4 Pro — same UX, 17x cheaper.
 
-**GitHub:** [github.com/aattaran/cheapclaude](https://github.com/aattaran/cheapclaude)
+**GitHub:** [github.com/aattaran/deepclaude](https://github.com/aattaran/deepclaude)
 
 ## What it does
 
-Claude Code is the best autonomous coding agent — but it costs $200/month with usage caps. cheapclaude swaps the model to DeepSeek V4 Pro ($0.87/M output) while keeping Claude Code's tool loop, file editing, bash execution, and autonomous multi-step coding.
+Claude Code is the best autonomous coding agent — but it costs $200/month with usage caps. deepclaude swaps the model to DeepSeek V4 Pro ($0.87/M output) while keeping Claude Code's tool loop, file editing, bash execution, and autonomous multi-step coding.
 
 Supports DeepSeek (direct), OpenRouter, and Fireworks AI as backends.
 
@@ -31,43 +31,43 @@ export DEEPSEEK_API_KEY="sk-your-key-here"
 setx DEEPSEEK_API_KEY "sk-your-key-here"
 ```
 
-#### 2. Download cheapclaude
+#### 2. Download deepclaude
 
 ```bash
-git clone https://github.com/aattaran/cheapclaude.git
-cd cheapclaude
-chmod +x cheapclaude.sh   # Linux/Mac only
+git clone https://github.com/aattaran/deepclaude.git
+cd deepclaude
+chmod +x deepclaude.sh   # Linux/Mac only
 ```
 
 #### 3. Run it
 
 **Linux / Mac:**
 ```bash
-./cheapclaude.sh
+./deepclaude.sh
 ```
 
 **Windows:**
 ```powershell
-powershell -ExecutionPolicy Bypass -File cheapclaude.ps1
+powershell -ExecutionPolicy Bypass -File deepclaude.ps1
 ```
 
 ## Commands
 
 ```bash
-cheapclaude                      # DeepSeek V4 Pro (default)
-cheapclaude -b or                # OpenRouter (cheapest, US servers)
-cheapclaude -b fw                # Fireworks AI (fastest, US servers)
-cheapclaude -b anthropic         # Normal Claude Code
-cheapclaude --remote             # Remote control (browser) + DeepSeek
-cheapclaude --remote -b or       # Remote control + OpenRouter
-cheapclaude --status             # Show keys and backends
-cheapclaude --cost               # Pricing comparison
-cheapclaude --benchmark          # Latency test
+deepclaude                      # DeepSeek V4 Pro (default)
+deepclaude -b or                # OpenRouter (cheapest, US servers)
+deepclaude -b fw                # Fireworks AI (fastest, US servers)
+deepclaude -b anthropic         # Normal Claude Code
+deepclaude --remote             # Remote control (browser) + DeepSeek
+deepclaude --remote -b or       # Remote control + OpenRouter
+deepclaude --status             # Show keys and backends
+deepclaude --cost               # Pricing comparison
+deepclaude --benchmark          # Latency test
 ```
 
 ## Remote Control
 
-`cheapclaude --remote` starts a Claude Code remote-control session with DeepSeek as the brain. It launches a local HTTP proxy that routes model API calls to DeepSeek while keeping Anthropic's bridge auth intact.
+`deepclaude --remote` starts a Claude Code remote-control session with DeepSeek as the brain. It launches a local HTTP proxy that routes model API calls to DeepSeek while keeping Anthropic's bridge auth intact.
 
 ```
 claude remote-control


### PR DESCRIPTION
## Summary
- Adds **deepclaude** to the agent list — a shell script that runs Claude Code's autonomous agent loop with DeepSeek V4 Pro at 17x lower cost
- Includes guide doc at `docs/deepclaude.md`
- Supports DeepSeek (direct), OpenRouter, and Fireworks AI backends
- Includes HTTP proxy for remote control browser sessions

## Links
- GitHub: https://github.com/aattaran/deepclaude
- Works on Windows (PowerShell) and macOS/Linux (bash)