### PR TITLE
add Droid integration guide for DeepSeek models

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
+| **Droid** | AI-native software development agent that runs in the terminal, supporting BYOK and custom models. | [Guide](./docs/droid.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,7 @@
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
+| **Droid** | 运行在终端中的 AI 原生软件开发 Agent，支持 BYOK 和自定义模型。 | [指南](./docs/droid.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |

--- a/docs/droid.md
+++ b/docs/droid.md
@@ -22,7 +22,7 @@ npm install -g droid
 
 #### 2. Configure DeepSeek as a Custom Model
 
-Open `~/.factory/settings.json` and add to `customModels`:
+Open `~/.factory/settings.json`, first delete the built-in programs and add the following:
 
 ```json
 {

--- a/docs/droid.md
+++ b/docs/droid.md
@@ -1,0 +1,97 @@
+[English](./droid.md) | [简体中文](./droid.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Droid
+
+Droid is an AI-native software development agent that runs in the terminal.
+
+#### 1. Install Droid
+
+```bash
+# macOS / Linux
+curl -fsSL https://app.factory.ai/cli | sh
+
+# Homebrew
+brew install --cask droid
+
+# Windows
+irm https://app.factory.ai/cli/windows | iex
+
+# npm
+npm install -g droid
+```
+
+#### 2. Configure DeepSeek as a Custom Model
+
+Open `~/.factory/settings.json` and add to `customModels`:
+
+```json
+{
+  "customModels": [
+    {
+      "model": "deepseek-v4-pro",
+      "id": "custom:deepseek-v4-pro-0",
+      "index": 0,
+      "baseUrl": "https://api.deepseek.com/anthropic",
+      "apiKey": "${DEEPSEEK_API_KEY}",
+      "displayName": "deepseek-v4-pro",
+      "noImageSupport": true,
+      "provider": "anthropic"
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "id": "custom:deepseek-v4-flash-1",
+      "index": 1,
+      "baseUrl": "https://api.deepseek.com/anthropic",
+      "apiKey": "${DEEPSEEK_API_KEY}",
+      "displayName": "deepseek-v4-flash",
+      "noImageSupport": true,
+      "provider": "anthropic"
+    }
+  ]
+}
+```
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+#### 3. Login to Droid
+
+Run `droid` in your terminal and follow the prompts to log in to Factory via browser using your Google account.
+
+#### 4. Set Chinese Interface (Optional)
+
+If the interface is not in your preferred language, set the environment variable:
+
+```bash
+# macOS / Linux
+export LANG=zh_CN
+
+# Windows
+$env:LANG="zh_CN"
+```
+
+Then run `droid` again.
+
+#### 5. Optional Settings
+
+**Reasoning Effort:** Add `reasoningEffort` to `~/.factory/settings.json` (default: `none`):
+
+```json
+{
+  "reasoningEffort": "high"
+}
+```
+
+Options:
+- `none` — No reasoning, fastest response
+- `low` — Low reasoning, suitable for simple tasks
+- `medium` — Medium reasoning, recommended for daily tasks
+- `high` — High reasoning, best for complex tasks
+
+**Other Settings:** Run `/settings` in Droid to open the settings panel:
+
+- Default compaction token limit — Set context window size
+- Preferences:
+  - Cloud session sync — Recommended to disable
+  - Show thinking process in main view — Recommended to enable
+  - Show context window usage rate — Recommended to enable
+- Other settings as needed

--- a/docs/droid.zh-CN.md
+++ b/docs/droid.zh-CN.md
@@ -1,0 +1,97 @@
+[English](./droid.md) | [简体中文](./droid.zh-CN.md) · [← Back](../README.zh-CN.md)
+
+# 集成 Droid
+
+Droid 是一款运行在终端中的 AI 原生软件开发 Agent。
+
+#### 1. 安装 Droid
+
+```bash
+# macOS / Linux
+curl -fsSL https://app.factory.ai/cli | sh
+
+# Homebrew
+brew install --cask droid
+
+# Windows
+irm https://app.factory.ai/cli/windows | iex
+
+# npm
+npm install -g droid
+```
+
+#### 2. 配置 DeepSeek 为自定义模型
+
+打开 `~/.factory/settings.json`，在 `customModels` 中添加：
+
+```json
+{
+  "customModels": [
+    {
+      "model": "deepseek-v4-pro",
+      "id": "custom:deepseek-v4-pro-0",
+      "index": 0,
+      "baseUrl": "https://api.deepseek.com/anthropic",
+      "apiKey": "${DEEPSEEK_API_KEY}",
+      "displayName": "deepseek-v4-pro",
+      "noImageSupport": true,
+      "provider": "anthropic"
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "id": "custom:deepseek-v4-flash-1",
+      "index": 1,
+      "baseUrl": "https://api.deepseek.com/anthropic",
+      "apiKey": "${DEEPSEEK_API_KEY}",
+      "displayName": "deepseek-v4-flash",
+      "noImageSupport": true,
+      "provider": "anthropic"
+    }
+  ]
+}
+```
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
+
+#### 3. 登录 Droid
+
+终端输入 `droid` 打开，根据提示在浏览器中登录 Factory，使用 Google 账号登录。
+
+#### 4. 设置中文界面（可选）
+
+若界面不是中文，设置用户环境变量：
+
+```bash
+# macOS / Linux
+export LANG=zh_CN
+
+# Windows
+$env:LANG="zh_CN"
+```
+
+再次终端输入 `droid` 打开即可使用中文界面。
+
+#### 5. 可选设置
+
+**设置推理强度：** 在 `~/.factory/settings.json` 中添加 `reasoningEffort` 字段（默认 `none`）：
+
+```json
+{
+  "reasoningEffort": "high"
+}
+```
+
+可选值：
+- `none` — 不推理，响应最快
+- `low` — 低推理，简单任务适用
+- `medium` — 中等推理，日常任务推荐
+- `high` — 高推理，复杂任务效果最佳
+
+**其他设置：** 在 Droid 中输入 `/settings` 打开设置面板：
+
+- Default compaction token limit — 设置上下文窗口大小
+- 偏好设置：
+  - 云端会话同步 — 建议关闭
+  - 在主视图中显示思考过程 — 建议打开
+  - 显示上下文窗口使用率 — 建议打开
+- 其他设置根据个人需要调整

--- a/docs/droid.zh-CN.md
+++ b/docs/droid.zh-CN.md
@@ -22,7 +22,7 @@ npm install -g droid
 
 #### 2. 配置 DeepSeek 为自定义模型
 
-打开 `~/.factory/settings.json`，在 `customModels` 中添加：
+打开 `~/.factory/settings.json`，先删除内置的程序再添加如下：
 
 ```json
 {


### PR DESCRIPTION
Add a new integration guide for [Droid](https://factory.ai) — an AI-native
     software development agent that runs in the terminal.

     This PR includes:
     - `docs/droid.md` — English guide covering installation, DeepSeek model
       configuration via BYOK (Anthropic provider), login, and optional settings
     - `docs/droid.zh-CN.md` — Chinese version of the guide
     - Updated `README.md` and `README.zh-CN.md` tables to link the new guides