### PR TITLE
docs: add DeepSeek-TUI guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
+| **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
+| **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
 
 ## 相关资源
 

--- a/docs/deepseek-tui.md
+++ b/docs/deepseek-tui.md
@@ -1,0 +1,86 @@
+[English](./deepseek-tui.md) | [简体中文](./deepseek-tui.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with DeepSeek-TUI
+
+DeepSeek-TUI is an open-source terminal AI coding assistant built in Rust as a Codex-style 13-crate workspace. It talks to `api.deepseek.com` directly, supports DeepSeek-V4-Pro and DeepSeek-V4-Flash with the full 1M-token context window, and ships sandboxed tool execution on macOS (Seatbelt), Linux (Landlock), and Windows.
+
+- **GitHub:** <https://github.com/Hmbown/DeepSeek-TUI>
+
+#### 1. Install DeepSeek-TUI
+
+Choose any of:
+
+```sh
+# npm (cross-platform prebuilt binaries)
+npm install -g deepseek-tui
+
+# Cargo (build from source — Rust 1.85+ required)
+cargo install deepseek-tui-cli
+
+# Or download a release binary from
+#   https://github.com/Hmbown/DeepSeek-TUI/releases
+```
+
+Verify:
+
+```sh
+deepseek --version
+```
+
+#### 2. Get a DeepSeek API Key
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys). On first run, `deepseek auth` walks you through saving it to `~/.deepseek/config.toml`. You can also set `DEEPSEEK_API_KEY` as an environment variable.
+
+#### 3. Enter a project directory and launch
+
+```sh
+cd /path/to/my-project
+deepseek
+```
+
+`deepseek` is the canonical entry point. It dispatches to the interactive TUI by default, or to subcommands like `deepseek doctor`, `deepseek mcp list`, `deepseek serve --http`, `deepseek -p "one-shot prompt"`, and `deepseek --yolo`.
+
+By default DeepSeek-TUI uses **DeepSeek-V4-Pro**. Press `Shift+Tab` to cycle reasoning effort (`off → high → max`). Press `Tab` to cycle modes:
+
+| Mode | What it does |
+|---|---|
+| **Plan** | Read-only investigation. No mutations, no shell. |
+| **Agent** | Multi-step tool use. Side-effectful tools require approval. |
+| **YOLO** | Auto-approve all tools. Lifts workspace boundary. |
+
+#### Key shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Send the prompt |
+| `Shift+Enter` | Insert a newline |
+| `Tab` | Cycle TUI mode (Plan / Agent / YOLO) |
+| `Shift+Tab` | Cycle reasoning effort (off / high / max) |
+| `Esc` | Interrupt the current model turn |
+| `/` | Open the slash-command menu |
+| `?` | Show keybinding help |
+| `Ctrl+C` (twice) | Quit |
+
+#### Configuration
+
+`~/.deepseek/config.toml` is the main config (see `config.example.toml` in the repo for every option). Key environment overrides:
+
+| Variable | Description |
+|---|---|
+| `DEEPSEEK_API_KEY` | API key (overrides config) |
+| `DEEPSEEK_BASE_URL` | API base URL — defaults to `https://api.deepseek.com`; use `https://api.deepseeki.com` for the China endpoint |
+| `DEEPSEEK_MODEL` | Override default model |
+| `DEEPSEEK_PROVIDER` | Switch provider — e.g. `nvidia-nim` (uses `NVIDIA_API_KEY`) |
+| `RUST_LOG` | Logging verbosity (e.g. `RUST_LOG=debug`) |
+
+#### MCP, Skills, and Hooks
+
+- **MCP servers** — configure via `~/.deepseek/mcp.json` or `deepseek mcp add ...`. DeepSeek-TUI is both an MCP client and an MCP server (`deepseek mcp serve`).
+- **Skills** — drop a `SKILL.md` under `~/.deepseek/skills/<name>/` (user-level) or `./.deepseek/skills/<name>/` (project-level).
+- **Hooks** — pre/post lifecycle hooks (stdout / jsonl / webhook) configured in `[hooks]` in `config.toml`.
+- **Sub-agents** — the model can spawn child agents via `agent_spawn` and use the full lifecycle family (`agent_wait`, `agent_result`, `agent_cancel`, ...).
+- **RLM** — built-in recursive-LM tool processes oversized inputs in a sandboxed Python REPL without polluting the parent context.
+
+#### HTTP runtime API
+
+`deepseek serve --http` exposes a `/v1/*` runtime API for embedding DeepSeek-TUI in IDEs and web UIs (sessions, threads, turns, tasks, automations, MCP, skills). See [`docs/RUNTIME_API.md`](https://github.com/Hmbown/DeepSeek-TUI/blob/main/docs/RUNTIME_API.md) for the contract.

--- a/docs/deepseek-tui.zh-CN.md
+++ b/docs/deepseek-tui.zh-CN.md
@@ -1,0 +1,86 @@
+[English](./deepseek-tui.md) | [简体中文](./deepseek-tui.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 DeepSeek-TUI
+
+DeepSeek-TUI 是一款采用 Rust 编写的开源终端 AI 编程助手，使用 Codex 风格的 13-crate 工作区架构。原生对接 `api.deepseek.com`，支持 DeepSeek-V4-Pro 与 DeepSeek-V4-Flash 全 100 万 token 上下文，并在 macOS（Seatbelt）、Linux（Landlock）和 Windows 上提供沙箱化的工具执行能力。
+
+- **GitHub：** <https://github.com/Hmbown/DeepSeek-TUI>
+
+#### 1. 安装 DeepSeek-TUI
+
+任选其一：
+
+```sh
+# npm（跨平台预编译二进制）
+npm install -g deepseek-tui
+
+# Cargo（从源码构建，需要 Rust 1.85+）
+cargo install deepseek-tui-cli
+
+# 或从 GitHub Releases 下载预编译二进制：
+#   https://github.com/Hmbown/DeepSeek-TUI/releases
+```
+
+验证安装：
+
+```sh
+deepseek --version
+```
+
+#### 2. 获取 DeepSeek API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。首次运行时 `deepseek auth` 会引导你保存到 `~/.deepseek/config.toml`，也可直接设置环境变量 `DEEPSEEK_API_KEY`。
+
+#### 3. 进入项目目录并启动
+
+```sh
+cd /path/to/my-project
+deepseek
+```
+
+`deepseek` 是规范的入口命令。默认进入交互式 TUI，也可调用子命令，如 `deepseek doctor`、`deepseek mcp list`、`deepseek serve --http`、`deepseek -p "一次性 prompt"`、`deepseek --yolo` 等。
+
+DeepSeek-TUI 默认使用 **DeepSeek-V4-Pro**。按 `Shift+Tab` 切换推理强度（`off → high → max`）。按 `Tab` 切换模式：
+
+| 模式 | 说明 |
+|---|---|
+| **Plan** | 只读调研模式。不写文件、不执行 shell。 |
+| **Agent** | 多步工具调用。具有副作用的工具需要审批。 |
+| **YOLO** | 自动批准所有工具，并解除工作区边界限制。 |
+
+#### 快捷键
+
+| 按键 | 操作 |
+|-----|------|
+| `Enter` | 发送 prompt |
+| `Shift+Enter` | 插入换行 |
+| `Tab` | 切换模式（Plan / Agent / YOLO） |
+| `Shift+Tab` | 切换推理强度（off / high / max） |
+| `Esc` | 中断当前模型回合 |
+| `/` | 打开 slash 命令菜单 |
+| `?` | 显示快捷键帮助 |
+| `Ctrl+C`（两次） | 退出 |
+
+#### 配置
+
+`~/.deepseek/config.toml` 是主配置文件（仓库中的 `config.example.toml` 列出了全部可用项）。常用环境变量：
+
+| 变量 | 说明 |
+|---|---|
+| `DEEPSEEK_API_KEY` | API Key（覆盖配置文件中的值） |
+| `DEEPSEEK_BASE_URL` | API 基址，默认 `https://api.deepseek.com`；中国区使用 `https://api.deepseeki.com` |
+| `DEEPSEEK_MODEL` | 覆盖默认模型 |
+| `DEEPSEEK_PROVIDER` | 切换提供商，例如 `nvidia-nim`（使用 `NVIDIA_API_KEY`） |
+| `RUST_LOG` | 日志级别，例如 `RUST_LOG=debug` |
+
+#### MCP、Skills 与 Hooks
+
+- **MCP 服务器** —— 在 `~/.deepseek/mcp.json` 中配置，或使用 `deepseek mcp add ...`。DeepSeek-TUI 同时是 MCP 客户端与 MCP 服务器（`deepseek mcp serve`）。
+- **Skills** —— 将 `SKILL.md` 放入 `~/.deepseek/skills/<name>/`（用户级）或 `./.deepseek/skills/<name>/`（项目级）。
+- **Hooks** —— 在 `config.toml` 的 `[hooks]` 中配置生命周期钩子（stdout / jsonl / webhook）。
+- **子 Agent** —— 模型可以通过 `agent_spawn` 派生子 Agent，并使用完整的生命周期工具族（`agent_wait`、`agent_result`、`agent_cancel` 等）。
+- **RLM** —— 内置递归 LM 工具，在沙箱化的 Python REPL 中处理超大输入，不会污染父级上下文。
+
+#### HTTP 运行时 API
+
+`deepseek serve --http` 暴露 `/v1/*` 运行时 API，便于将 DeepSeek-TUI 嵌入 IDE 与 Web UI（sessions、threads、turns、tasks、automations、MCP、skills）。完整接口契约见 [`docs/RUNTIME_API.md`](https://github.com/Hmbown/DeepSeek-TUI/blob/main/docs/RUNTIME_API.md)。


### PR DESCRIPTION
## Summary

Adds a guide for **DeepSeek-TUI** — an open-source Rust terminal coding assistant for DeepSeek-V4.

- **GitHub:** <https://github.com/Hmbown/DeepSeek-TUI>
- **Install:** `npm install -g deepseek-tui` or `cargo install deepseek-tui-cli`
- **Latest release:** v0.8.9 (Rust 1.85+, native DeepSeek-V4-Pro / V4-Flash, 1M context)

## What's added

- `docs/deepseek-tui.md` — English guide (install, API key, modes, key shortcuts, config, MCP/Skills/Hooks, runtime API)
- `docs/deepseek-tui.zh-CN.md` — Simplified Chinese mirror of the same guide
- `README.md` + `README.zh-CN.md` — new row in the Contents table

## Why it might be a fit here

- Native DeepSeek-V4 integration (Chat Completions; experimental Responses behind a feature flag) — talks to `api.deepseek.com` directly, no translation shim.
- Codex-style 13-crate Rust workspace; `deepseek` dispatcher binary plus a TUI binary, with `deepseek serve --http` exposing a `/v1/*` runtime API for IDE / web embedding.
- Sandboxed tool execution: macOS Seatbelt, Linux Landlock, Windows.
- Full agentic surface: file ops + edit_file / apply_patch, grep / file search, web fetch + search, shell with background variants, git / diagnostics / tests, sub-agent lifecycle (`agent_spawn` + `agent_wait` / `agent_result` / `agent_cancel`), plus an `rlm` recursive-LM tool for processing oversized inputs without polluting parent context.
- MCP client + stdio MCP server, Skills, lifecycle Hooks, durable background tasks.
- Plan / Agent / YOLO modes orthogonal to `suggest` / `auto` / `never` approval policies.

Happy to revise the pitch line in the README table or trim the guide if anything reads as too long compared to the existing entries — just let me know.