### PR TITLE
Add AlayaCore integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,25 @@ Each guide walks through installation, configuration, and first run — so you c
 
 ## Contents
 
-| Tool            | Description                                                                                                 | Guide                          |
-| --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
-| **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
-| **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
-| **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
-| **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
-| **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
-| **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
-| **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
-| **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
-| **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
-| **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
-| **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
-| **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
-| **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
-| **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
-| **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
+| Tool                    | Description                                                                                                                        | Guide                             |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| **Claude Code**         | AI coding assistant that runs in the terminal.                                                                                     | [Guide](./docs/claude_code.md)    |
+| **GitHub Copilot**      | AI peer programmer built into VS Code.                                                                                             | [Guide](./docs/github_copilot.md) |
+| **GitHub Copilot CLI**  | Terminal-native AI coding assistant with agentic capabilities.                                                                     | [Guide](./docs/copilot_cli.md)    |
+| **Kilo Code**           | AI coding assistant available as a CLI and editor extension.                                                                       | [Guide](./docs/kilo_code.md)      |
+| **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration.                                                   | [Guide](./docs/workbuddy.md)      |
+| **OpenCode**            | Open-source AI coding assistant available in terminal, web, and other forms.                                                       | [Guide](./docs/opencode.md)       |
+| **Oh My Pi**            | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows.                   | [Guide](./docs/oh-my-pi.md)       |
+| **OpenClaw**            | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills.                        | [Guide](./docs/openclaw.md)       |
+| **AstrBot**             | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.                              | [Guide](./docs/astrbot.md)        |
+| **Deep Code**           | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md)       |
+| **Hermes**              | Open-source self-improving AI agent built by Nous Research.                                                                        | [Guide](./docs/hermes.md)         |
+| **nanobot**             | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more.                                            | [Guide](./docs/nanobot.md)        |
+| **Crush**               | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.                               | [Guide](./docs/crush.md)          |
+| **Pi**                  | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.                                    | [Guide](./docs/pi_mono.md)        |
+| **Reasonix**            | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                                             | [Guide](./docs/reasonix.md)       |
+| **Langcli**             | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models                        | [Guide](./docs/langcli.md)        |
+| **AlayaCore**           | Fast, minimal AI Agent (~8MB static binary, zero runtime deps) with interactive TUI and plain mode.               | [Guide](./docs/alayacore.md)      |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
+| **AlayaCore** | 快速、精简的终端 AI Agent（约 8MB 静态二进制，零运行时依赖），支持交互式 TUI 和纯文本模式。 | [指南](./docs/alayacore.zh-CN.md) |
 
 ## 相关资源
 

--- a/docs/alayacore.md
+++ b/docs/alayacore.md
@@ -1,0 +1,110 @@
+[English](./alayacore.md) | [简体中文](./alayacore.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with AlayaCore
+
+AlayaCore is a fast, minimal AI Agent that runs in your terminal. It connects to any OpenAI-compatible or Anthropic-compatible LLM and gives it the tools to read, write, and edit files, and execute commands — with streaming output, session persistence, and multi-step agentic tool-calling loops, available in both an interactive TUI and a plain mode for scripting and piping.
+
+AlayaCore is super tiny (~8MB static linked binary) with zero runtime dependencies — no Node.js, no Python, not even libc. This means no libc incompatibility issues, which is a common problem on Linux.
+
+- **GitHub:** <https://github.com/alayacore/alayacore>
+
+#### 1. Install AlayaCore
+
+**Option A: Download from GitHub Releases**
+
+Download the latest binary for your platform from the [GitHub Releases page](https://github.com/alayacore/alayacore/releases).
+
+**Option B: Build with Go**
+
+- Install [Go](https://go.dev/dl/) 1.26.1+.
+- Run:
+
+```sh
+go install github.com/alayacore/alayacore@latest
+```
+
+#### 2. Get a DeepSeek API Key
+
+- Go to <https://platform.deepseek.com/> → sign up / sign in → **API Keys** → **Create API Key**.
+
+#### 3. Configure DeepSeek
+
+AlayaCore stores its configuration in `~/.alayacore/model.conf`. On first run, it creates a default configuration for Ollama. You need to edit it to add DeepSeek.
+
+Press `Ctrl+L` then `e` in the terminal to open the config file in your editor, or edit it directly:
+
+```sh
+# Open the config file
+$EDITOR ~/.alayacore/model.conf
+```
+
+Add the following configuration (replace `YOUR_DEEPSEEK_API_KEY` with your actual key):
+
+```
+name: "DeepSeek V4 Pro"
+protocol_type: "openai"
+base_url: "https://api.deepseek.com/v1"
+api_key: "YOUR_DEEPSEEK_API_KEY"
+model_name: "deepseek-v4-pro"
+context_limit: 1000000
+```
+
+For DeepSeek V4 Flash (faster, cheaper):
+
+```
+name: "DeepSeek V4 Flash"
+protocol_type: "openai"
+base_url: "https://api.deepseek.com/v1"
+api_key: "YOUR_DEEPSEEK_API_KEY"
+model_name: "deepseek-v4-flash"
+context_limit: 1000000
+```
+
+You can also configure multiple models in one file, separated by `---`:
+
+```
+name: "DeepSeek V4 Pro"
+protocol_type: "openai"
+base_url: "https://api.deepseek.com/v1"
+api_key: "YOUR_DEEPSEEK_API_KEY"
+model_name: "deepseek-v4-pro"
+context_limit: 1000000
+---
+name: "DeepSeek V4 Flash"
+protocol_type: "openai"
+base_url: "https://api.deepseek.com/v1"
+api_key: "YOUR_DEEPSEEK_API_KEY"
+model_name: "deepseek-v4-flash"
+context_limit: 1000000
+```
+
+#### 4. Start Using AlayaCore
+
+- Run `alayacore` in your terminal.
+- Press `Ctrl+L` to open the model selector and choose your DeepSeek model.
+- Type a prompt and press `Enter` to start a conversation.
+
+#### Plain IO Mode
+
+Use `--plainio` for scripting and piping without the TUI:
+
+```sh
+# Pipe a prompt from stdin
+echo "Explain what this project does" | alayacore --plainio
+
+# Read a prompt from a file
+alayacore --plainio < myplan.txt
+```
+
+## Tips
+
+- **Model switching:** Press `Ctrl+L` to switch between models at runtime.
+- **Session persistence:** Use `:save my-session.md` or press `Ctrl+S` to save your conversation.
+- **Skills system:** Extend AlayaCore with custom skill packages using the `--skill` flag.
+- **Plain IO mode:** Use `--plainio` for scripting and piping without the TUI.
+
+## Resources
+
+- [AlayaCore Documentation](https://github.com/alayacore/alayacore/tree/main/docs)
+- [DeepSeek Platform](https://platform.deepseek.com/) — get an API key.
+- [DeepSeek API Docs](https://api-docs.deepseek.com/) — API reference and guides.

--- a/docs/alayacore.zh-CN.md
+++ b/docs/alayacore.zh-CN.md
@@ -1,0 +1,110 @@
+[English](./alayacore.md) | [简体中文](./alayacore.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 AlayaCore
+
+AlayaCore 是一个快速、精简的终端 AI Agent。它连接任何 OpenAI 兼容或 Anthropic 兼容的 LLM，赋予其读取、写入、编辑文件和执行命令的能力——支持流式输出、会话持久化和多步骤代理工具调用循环，可在交互式 TUI 和纯文本模式（用于脚本和管道操作）下使用。
+
+AlayaCore 极其小巧（约 8MB 静态链接二进制文件），零运行时依赖——无需 Node.js、Python，甚至不需要 libc。这意味着不会出现 Linux 上常见的 libc 兼容性问题。
+
+- **GitHub:** <https://github.com/alayacore/alayacore>
+
+#### 1. 安装 AlayaCore
+
+**方式一：从 GitHub Releases 下载**
+
+从 [GitHub Releases 页面](https://github.com/alayacore/alayacore/releases) 下载适合你平台的最新二进制文件。
+
+**方式二：使用 Go 构建**
+
+- 安装 [Go](https://go.dev/dl/) 1.26.1+。
+- 运行：
+
+```sh
+go install github.com/alayacore/alayacore@latest
+```
+
+#### 2. 获取 DeepSeek API Key
+
+- 前往 <https://platform.deepseek.com/> → 注册/登录 → **API Keys** → **创建 API Key**。
+
+#### 3. 配置 DeepSeek
+
+AlayaCore 的配置存储在 `~/.alayacore/model.conf`。首次运行时会创建一个默认的 Ollama 配置。你需要编辑它来添加 DeepSeek。
+
+在终端中按 `Ctrl+L` 然后按 `e` 打开配置文件编辑器，或直接编辑：
+
+```sh
+# 打开配置文件
+$EDITOR ~/.alayacore/model.conf
+```
+
+添加以下配置（将 `YOUR_DEEPSEEK_API_KEY` 替换为你的实际密钥）：
+
+```
+name: "DeepSeek V4 Pro"
+protocol_type: "openai"
+base_url: "https://api.deepseek.com/v1"
+api_key: "YOUR_DEEPSEEK_API_KEY"
+model_name: "deepseek-v4-pro"
+context_limit: 1000000
+```
+
+如需使用 DeepSeek V4 Flash（更快、更经济）：
+
+```
+name: "DeepSeek V4 Flash"
+protocol_type: "openai"
+base_url: "https://api.deepseek.com/v1"
+api_key: "YOUR_DEEPSEEK_API_KEY"
+model_name: "deepseek-v4-flash"
+context_limit: 1000000
+```
+
+你也可以在一个文件中配置多个模型，用 `---` 分隔：
+
+```
+name: "DeepSeek V4 Pro"
+protocol_type: "openai"
+base_url: "https://api.deepseek.com/v1"
+api_key: "YOUR_DEEPSEEK_API_KEY"
+model_name: "deepseek-v4-pro"
+context_limit: 1000000
+---
+name: "DeepSeek V4 Flash"
+protocol_type: "openai"
+base_url: "https://api.deepseek.com/v1"
+api_key: "YOUR_DEEPSEEK_API_KEY"
+model_name: "deepseek-v4-flash"
+context_limit: 1000000
+```
+
+#### 4. 开始使用 AlayaCore
+
+- 在终端中运行 `alayacore`。
+- 按 `Ctrl+L` 打开模型选择器，选择你的 DeepSeek 模型。
+- 输入提示并按 `Enter` 开始对话。
+
+#### 纯文本模式
+
+使用 `--plainio` 进行脚本和管道操作，无需 TUI：
+
+```sh
+# 从 stdin 管道输入提示
+echo "解释这个项目是做什么的" | alayacore --plainio
+
+# 从文件读取提示
+alayacore --plainio < myplan.txt
+```
+
+## 技巧
+
+- **模型切换：** 按 `Ctrl+L` 在运行时切换模型。
+- **会话持久化：** 使用 `:save my-session.md` 或按 `Ctrl+S` 保存对话。
+- **技能系统：** 使用 `--skill` 标志扩展 AlayaCore 的自定义技能包。
+- **纯 IO 模式：** 使用 `--plainio` 进行脚本和管道操作，无需 TUI。
+
+## 资源
+
+- [AlayaCore 文档](https://github.com/alayacore/alayacore/tree/main/docs)
+- [DeepSeek 平台](https://platform.deepseek.com/) — 获取 API Key。
+- [DeepSeek API 文档](https://api-docs.deepseek.com/) — API 参考和指南。


### PR DESCRIPTION
PR for [AlayaCore](https://github.com/alayacore/alayacore) integration guide.

- Add docs/alayacore.md (English) and docs/alayacore.zh-CN.md (Chinese)
- Add AlayaCore to tools table in README.md and README.zh-CN.md
- Guide covers installation (GitHub Releases or go install), DeepSeek configuration via model.conf, TUI and plainio mode usage