### PR TITLE
docs: update Pi models.json config - move thinkingLevelMap out of com…

### DIFF
--- a/docs/pi_mono.md
+++ b/docs/pi_mono.md
@@ -52,16 +52,17 @@ Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compat
             "cacheRead": 0.145,
             "cacheWrite": 0
           },
+          "thinkingLevelMap": {
+            "off": "off",
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high",
+            "xhigh": "max"
+          },
           "compat": {
             "requiresReasoningContentOnAssistantMessages": true,
-            "thinkingFormat": "deepseek",
-            "reasoningEffortMap": {
-              "minimal": "high",
-              "low": "high",
-              "medium": "high",
-              "high": "high",
-              "xhigh": "max"
-            }
+            "thinkingFormat": "deepseek"
           }
         },
         {
@@ -77,16 +78,17 @@ Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compat
             "cacheRead": 0.028,
             "cacheWrite": 0
           },
+          "thinkingLevelMap": {
+            "off": "off",
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high",
+            "xhigh": "max"
+          },
           "compat": {
             "requiresReasoningContentOnAssistantMessages": true,
-            "thinkingFormat": "deepseek",
-            "reasoningEffortMap": {
-              "minimal": "high",
-              "low": "high",
-              "medium": "high",
-              "high": "high",
-              "xhigh": "max"
-            }
+            "thinkingFormat": "deepseek"
           }
         }
       ]

--- a/docs/pi_mono.zh-CN.md
+++ b/docs/pi_mono.zh-CN.md
@@ -52,16 +52,17 @@ Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI
             "cacheRead": 0.145,
             "cacheWrite": 0
           },
+          "thinkingLevelMap": {
+            "off": "off",
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high",
+            "xhigh": "max"
+          },
           "compat": {
             "requiresReasoningContentOnAssistantMessages": true,
-            "thinkingFormat": "deepseek",
-            "reasoningEffortMap": {
-              "minimal": "high",
-              "low": "high",
-              "medium": "high",
-              "high": "high",
-              "xhigh": "max"
-            }
+            "thinkingFormat": "deepseek"
           }
         },
         {
@@ -77,16 +78,17 @@ Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI
             "cacheRead": 0.028,
             "cacheWrite": 0
           },
+          "thinkingLevelMap": {
+            "off": "off",
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high",
+            "xhigh": "max"
+          },
           "compat": {
             "requiresReasoningContentOnAssistantMessages": true,
-            "thinkingFormat": "deepseek",
-            "reasoningEffortMap": {
-              "minimal": "high",
-              "low": "high",
-              "medium": "high",
-              "high": "high",
-              "xhigh": "max"
-            }
+            "thinkingFormat": "deepseek"
           }
         }
       ]


### PR DESCRIPTION
 改动： 在 Pi 的 models.json 配置示例中：

 1. 将 thinkingLevelMap 从 compat 块中提升到模型配置顶层：这是 Pi 新版本推荐的配置结构，思维等级映射现在作为模型的一级属性，而不是兼容选项的一部分。
 2. 映射：minimal、low、medium 现在映射为 null（表示 DeepSeek 不支持这些等级），而不是像之前那样全部映射到 high。high → high、xhigh → max 依然有效。