### PR TITLE
docs: add Anda Bot integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **Anda Bot** | Open-source Rust terminal agent with graph-based long-term memory, long-horizon reasoning, subagents, external tool use, and IM integrations. | [Guide](./docs/anda_bot.md) |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Each guide walks through installation, configuration, and first run — so you c
 
 | Tool            | Description                                                                                                 | Guide                          |
 | --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **Anda Bot** | Open-source Rust terminal agent with graph-based long-term memory, long-horizon reasoning, subagents, external tool use, and IM integrations. | [Guide](./docs/anda_bot.md) |
 | **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
@@ -32,7 +33,6 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
-| **Anda Bot** | Open-source Rust terminal agent with graph-based long-term memory, long-horizon reasoning, subagents, external tool use, and IM integrations. | [Guide](./docs/anda_bot.md) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,6 +32,7 @@
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **Anda Bot** | Rust 编写的开源终端智能体，具备知识图谱长期记忆、长程推理、外部工具调用、Subagents，并可接入微信、飞书、Telegram 等 IM。| [指南](./docs/anda_bot.zh-CN.md) |
 
 ## 相关资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,7 @@
 
 | 工具            | 简介                                                                  | 指南                                |
 | --------------- | --------------------------------------------------------------------- | ----------------------------------- |
+| **Anda Bot** | Rust 编写的开源终端智能体，具备知识图谱长期记忆、长程推理、外部工具调用、Subagents，并可接入微信、飞书、Telegram 等 IM。| [指南](./docs/anda_bot.zh-CN.md) |
 | **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
@@ -32,8 +33,6 @@
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
-| **Anda Bot** | Rust 编写的开源终端智能体，具备知识图谱长期记忆、长程推理、外部工具调用、Subagents，并可接入微信、飞书、Telegram 等 IM。| [指南](./docs/anda_bot.zh-CN.md) |
-
 ## 相关资源
 
 - [DeepSeek 开放平台](https://platform.deepseek.com/) — 获取 API Key。

--- a/docs/anda_bot.md
+++ b/docs/anda_bot.md
@@ -1,0 +1,75 @@
+[English](./anda_bot.md) | [简体中文](./anda_bot.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Anda Bot
+
+Anda Bot is an open-source Rust agent that runs in the terminal and can also connect to IM platforms such as WeChat, Feishu/Lark, Telegram, Discord, and IRC. Its core is a graph-based long-term memory system powered by Anda Hippocampus: it can learn useful knowledge from experience, recall relationships and timelines across sessions, run long-horizon reasoning tasks, use external tools including Claude Code and Codex, and coordinate work through a powerful subagents system.
+
+#### 1. Install Anda Bot
+
+Install the latest release with Homebrew:
+
+```bash
+brew install ldclabs/tap/anda
+```
+
+Or install with the one-line script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ldclabs/anda-bot/main/scripts/install.sh | sh
+```
+
+On Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/ldclabs/anda-bot/main/scripts/install.ps1 | iex
+```
+
+You can also run it from source with a recent Rust toolchain:
+
+```bash
+git clone https://github.com/ldclabs/anda-bot.git
+cd anda-bot
+cargo run -p anda_bot --
+```
+
+#### 2. Configure DeepSeek
+
+Start Anda Bot once to create the default configuration file:
+
+```bash
+anda
+```
+
+Edit `~/.anda/config.yaml` and configure DeepSeek as the active provider:
+
+```yaml
+model:
+  active: "deepseek-v4-pro"
+  providers:
+    - family: anthropic
+      model: "deepseek-v4-pro"
+      api_base: "https://api.deepseek.com/anthropic"
+      api_key: "YOUR_API_KEY" # optional when DEEPSEEK_API_KEY is set
+      labels: ["pro", "hippocampus"]
+      disabled: false
+```
+
+You can also export the API key before launching Anda Bot:
+
+```bash
+export DEEPSEEK_API_KEY="YOUR_API_KEY"
+```
+
+The `hippocampus` label lets Anda Bot prefer this provider for memory formation and recall support.
+
+#### 3. Start Using Anda Bot
+
+Run the terminal UI:
+
+```bash
+anda
+```
+
+After editing `config.yaml`, use `/reload` in the terminal UI to reload the model configuration, or run `anda restart` to restart the agent.
+
+To connect Anda Bot to chat platforms, configure `channels` in `~/.anda/config.yaml`. Supported channel families include IRC, Telegram, WeChat, Discord, and Lark/Feishu.

--- a/docs/anda_bot.zh-CN.md
+++ b/docs/anda_bot.zh-CN.md
@@ -1,0 +1,75 @@
+[English](./anda_bot.md) | [简体中文](./anda_bot.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Anda Bot
+
+Anda Bot 是一个 Rust 编写的开源智能体，运行在终端内，也可以接入微信、飞书/Lark、Telegram、Discord、IRC 等 IM 平台。它的核心是基于 Anda Hippocampus 的知识图谱长期记忆系统：能从经验中自主学习精华，在跨会话中召回关系与时间线，执行长程推理任务，擅长使用 Claude Code、Codex 等外部工具，并通过强大的 Subagents 系统协同完成复杂工作。
+
+#### 1. 安装 Anda Bot
+
+通过 Homebrew 安装最新发布版：
+
+```bash
+brew install ldclabs/tap/anda
+```
+
+或通过一行安装脚本安装：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ldclabs/anda-bot/main/scripts/install.sh | sh
+```
+
+Windows PowerShell：
+
+```powershell
+irm https://raw.githubusercontent.com/ldclabs/anda-bot/main/scripts/install.ps1 | iex
+```
+
+也可以使用较新的 Rust 工具链从源码运行：
+
+```bash
+git clone https://github.com/ldclabs/anda-bot.git
+cd anda-bot
+cargo run -p anda_bot --
+```
+
+#### 2. 配置 DeepSeek
+
+先启动一次 Anda Bot，生成默认配置文件：
+
+```bash
+anda
+```
+
+编辑 `~/.anda/config.yaml`，将 DeepSeek 配置为当前模型提供方：
+
+```yaml
+model:
+  active: "deepseek-v4-pro"
+  providers:
+    - family: anthropic
+      model: "deepseek-v4-pro"
+      api_base: "https://api.deepseek.com/anthropic"
+      api_key: "YOUR_API_KEY" # 设置 DEEPSEEK_API_KEY 时可留空
+      labels: ["pro", "hippocampus"]
+      disabled: false
+```
+
+你也可以在启动 Anda Bot 前导出 API Key：
+
+```bash
+export DEEPSEEK_API_KEY="YOUR_API_KEY"
+```
+
+`hippocampus` 标签表示这一路模型可优先用于长期记忆的生成与召回支持。
+
+#### 3. 开始使用
+
+运行终端 UI：
+
+```bash
+anda
+```
+
+修改 `config.yaml` 后，可以在终端 UI 中输入 `/reload` 重新加载模型配置，或者运行 `anda restart` 重启智能体。
+
+如需接入聊天平台，可在 `~/.anda/config.yaml` 中配置 `channels`。当前支持 IRC、Telegram、WeChat、Discord、Lark/飞书 等渠道。


### PR DESCRIPTION
Anda Bot 是一个 Rust 编写的开源智能体，运行在终端内，也可以接入微信、飞书/Lark、Telegram、Discord、IRC 等 IM 平台。它的核心是基于 Anda Hippocampus 的知识图谱长期记忆系统：能从经验中自主学习精华，在跨会话中召回关系与时间线，执行长程推理任务，擅长使用 Claude Code、Codex 等外部工具，并通过强大的 Subagents 系统协同完成复杂工作。