### PR TITLE
docs: add guide for Ctrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **Ctrl** | A lightweight AI agent — a pure JavaScript, open-source terminal coding assistant designed for DeepSeek‑V4. | [Guide](./docs/ctrl.md) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,6 +32,7 @@
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **Ctrl** | 专为deepseek-v4的纯JS开源终端编程助手，轻量AI智能体 | [指南](./docs/ctrl.zh-CN.md) |
 
 ## 相关资源
 

--- a/docs/ctrl.md
+++ b/docs/ctrl.md
@@ -1,0 +1,139 @@
+# ⏺ Ctrl
+
+> DeepSeek-powered CLI developer assistant — an AI partner in your terminal that writes code, debugs, manages files, and remembers things.
+
+Ctrl is a command-line AI assistant. It doesn't just chat — it **reads/writes files**, **executes commands**, **manages TODOs**, **remembers** your preferences long-term, and can even **self-evolve** by proposing new tools and rules for your approval.
+
+---
+
+## Features
+
+| Capability | Description |
+|---|---|
+| 💬 **Chat** | Streaming conversation via DeepSeek API, with reasoning content display |
+| 📁 **File Ops** | Read, create, edit, delete files — with colorized diff on edit |
+| ⚡ **Commands** | Execute PowerShell / cmd commands (with safety guard) |
+| ✅ **Todos** | Persistent todo list with `pending` / `in_progress` / `done` / `failed` statuses |
+| 🧠 **Memory** | User preference learning + keyword memory + vector semantic search |
+| 🔄 **Sessions** | Create, switch, delete sessions — isolated conversation contexts |
+| 🛠 **Self-improve** | AI proposes new tools / rules — takes effect after you approve |
+| 🎨 **Pretty CLI** | Brain spinner animation, colorized diff, icon-rich tool-call display |
+
+---
+
+## Prerequisites
+
+- **Node.js** >= 18
+- **DeepSeek API Key** ([get one here](https://platform.deepseek.com/))
+
+---
+
+## Install
+
+```bash
+# Clone
+git clone https://github.com/Kontirol/KontirolClaw.git
+cd KontirolClaw
+
+# Install dependencies
+npm install
+
+# Configure API Key (pick one)
+# Option 1: Environment variable (recommended)
+set CTRL_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxx      # Windows CMD
+$env:CTRL_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxxxxx"    # PowerShell
+
+# Option 2: Config file (writes to ~/.ctrl/config.json)
+node -e "import('./src/config.js').then(m=>m.saveConfig({apiKey:'sk-xxx'}))"
+
+# Start
+npm start
+```
+
+> 💡 You can also set `CTRL_BASE_URL` (custom API endpoint) and `CTRL_MODEL` (model name). Default model: `deepseek-v4-pro`.
+
+---
+
+## Usage
+
+### Basic Chat
+
+```
+Ctrl > Write me an Express server
+Ctrl > What's wrong with this function?
+Ctrl > Remember: I prefer TypeScript
+Ctrl > exit
+```
+
+### Session Commands
+
+| Command | Action |
+|---|---|
+| `:new [name]` | Create a new session |
+| `:switch <ID>` | Switch to a session |
+| `:sessions` / `:list` | List all sessions |
+| `:delete <ID>` | Delete a session |
+| `:help` | Show help |
+| `Esc` | Abort current request |
+| `exit` | Quit |
+
+### What the AI Can Do
+
+Just ask naturally — Ctrl will invoke the right tool automatically.
+
+| Ask | Tool invoked |
+|---|---|
+| "Read package.json" | `read_file` |
+| "Create src/utils.ts" | `create_file` |
+| "Change the port in app.ts to 8080" | `edit_file` |
+| "Run npm run build" | `exec_command` |
+| "Make a todo list" | `todo_create` |
+| "Remember: my project is called CineMax" | `memory_store` |
+
+---
+
+## Architecture
+
+```
+Ctrl/
+├── src/
+│   ├── index.js           # Entry: REPL loop, streaming chat
+│   ├── config.js          # Config (env vars / ~/.ctrl/config.json)
+│   ├── tools/
+│   │   ├── definition.js  # OpenAI tool schemas
+│   │   └── executor.js    # Tool execution logic
+│   ├── memory/
+│   │   ├── preferences.js # User preferences + long-term memory
+│   │   ├── vector.js      # Lightweight RAG vector memory
+│   │   ├── sessions.js    # Multi-session management
+│   │   └── self-improve.js # Custom tools + prompt proposals
+│   └── ui/
+│       ├── banner.js      # Startup banner, tool-call display
+│       ├── spinner.js     # Brain spinner animation (stderr)
+│       └── diff.js        # Colorized file diff
+├── package.json
+└── README.md
+```
+
+### Memory System (4 layers)
+
+| Layer | Trigger | Storage |
+|---|---|---|
+| **Preferences** | AI auto-learns | `~/.ctrl/preferences.json` |
+| **Long-term Memory** | User says "Remember..." | `~/.ctrl/memory.json` |
+| **Vector Memory** | AI auto-summarizes | `~/.ctrl/vectors.json` (with similarity scoring) |
+| **Self-improvement** | AI proposes when needed | `~/.ctrl/custom_tools.json` / `custom_prompt.txt` |
+
+---
+
+## Safety
+
+- Commands are filtered through a **blocklist** (prevents `rm -rf /`, `format`, etc.)
+- File operations are **scoped to the current working directory**
+- Self-improvement proposals require **your explicit approval** before taking effect
+
+---
+
+## License
+
+ISC © [nijat (Ctrl)](https://github.com/Kontirol)

--- a/docs/ctrl.zh-CN.md
+++ b/docs/ctrl.zh-CN.md
@@ -1,0 +1,139 @@
+# ⏺ Ctrl
+
+> 基于 DeepSeek 的 CLI 开发者助手 — 在终端里拥有一个能写代码、调试、管文件、记事情的 AI 搭档。
+
+Ctrl 是一个运行在命令行中的 AI 助手。它不只是聊天 — 它可以**读写文件**、**执行命令**、**管理待办**、**长期记忆**用户偏好，甚至会**自我进化**（提出新工具 / 新规则，等你批准）。
+
+---
+
+## 功能
+
+| 能力 | 说明 |
+|---|---|
+| 💬 **对话** | 基于 DeepSeek API 的流式对话，支持推理内容展示 |
+| 📁 **文件操作** | 读取、创建、编辑、删除文件，编辑时展示彩色 diff |
+| ⚡ **命令执行** | 在 PowerShell / cmd 中执行命令（带安全防护） |
+| ✅ **待办管理** | 持久化的待办列表，支持 `pending` / `in_progress` / `done` / `failed` 状态 |
+| 🧠 **长期记忆** | 用户偏好学习 + 关键词记忆 + 向量语义搜索 |
+| 🔄 **多会话** | 创建、切换、删除会话，互不干扰 |
+| 🛠 **自我优化** | AI 可以提出新工具 / 新规则，经你批准后生效 |
+| 🎨 **美化 CLI** | Brain 微调器动画、彩色 diff、图标化工具调用展示 |
+
+---
+
+## 前置条件
+
+- **Node.js** >= 18
+- **DeepSeek API Key**（[获取地址](https://platform.deepseek.com/)）
+
+---
+
+## 安装
+
+```bash
+# 克隆仓库
+git clone https://github.com/Kontirol/KontirolClaw.git
+cd KontirolClaw
+
+# 安装依赖
+npm install
+
+# 配置 API Key（二选一）
+# 方式 1：环境变量（推荐）
+set CTRL_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxx      # Windows CMD
+$env:CTRL_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxxxxx"    # PowerShell
+
+# 方式 2：配置文件（写入 ~/.ctrl/config.json）
+node -e "import('./src/config.js').then(m=>m.saveConfig({apiKey:'sk-xxx'}))"
+
+# 启动
+npm start
+```
+
+> 💡 也可配置 `CTRL_BASE_URL`（自定义 API 地址）和 `CTRL_MODEL`（模型名），默认 `deepseek-v4-pro`。
+
+---
+
+## 使用
+
+### 基本对话
+
+```
+Ctrl > 帮我写一个 Express 服务器
+Ctrl > 这个函数有什么问题？
+Ctrl > 记住：我喜欢用 TypeScript
+Ctrl > exit
+```
+
+### 会话命令
+
+| 命令 | 作用 |
+|---|---|
+| `:new [名称]` | 创建新会话 |
+| `:switch <ID>` | 切换到指定会话 |
+| `:sessions` / `:list` | 列出所有会话 |
+| `:delete <ID>` | 删除会话 |
+| `:help` | 显示帮助 |
+| `Esc` | 中断当前请求 |
+| `exit` | 退出程序 |
+
+### AI 可以做的事
+
+自然对话即可，Ctrl 会自动调用对应工具：
+
+| 你说 | 调用的工具 |
+|---|---|
+| "读取 package.json" | `read_file` |
+| "创建 src/utils.ts" | `create_file` |
+| "把 app.ts 里端口改成 8080" | `edit_file` |
+| "执行 npm run build" | `exec_command` |
+| "帮我列个 todo" | `todo_create` |
+| "记住：我的项目叫 CineMax" | `memory_store` |
+
+---
+
+## 架构
+
+```
+Ctrl/
+├── src/
+│   ├── index.js           # 入口：REPL 循环、流式对话
+│   ├── config.js          # 配置管理（环境变量 / ~/.ctrl/config.json）
+│   ├── tools/
+│   │   ├── definition.js  # 所有工具的函数定义（OpenAI tool schema）
+│   │   └── executor.js    # 工具执行逻辑
+│   ├── memory/
+│   │   ├── preferences.js # 用户偏好 + 长期记忆（~/.ctrl/memory.json）
+│   │   ├── vector.js      # 向量语义记忆（轻量级 RAG）
+│   │   ├── sessions.js    # 多会话管理（~/.ctrl/sessions/）
+│   │   └── self-improve.js # 自我优化：自定义工具 + 提示词提案
+│   └── ui/
+│       ├── banner.js      # 启动横幅、工具调用美化输出
+│       ├── spinner.js     # 微调器动画（stderr）
+│       └── diff.js        # 文件变更 diff 美化
+├── package.json
+└── README.md
+```
+
+### 记忆系统（四层）
+
+| 层级 | 触发方式 | 存储 |
+|---|---|---|
+| **偏好** | AI 自动学习 | `~/.ctrl/preferences.json` |
+| **长期记忆** | 用户说「记住 xxx」 | `~/.ctrl/memory.json` |
+| **向量记忆** | AI 自动总结对话 | `~/.ctrl/vectors.json`（带相似度评分） |
+| **自我优化** | AI 发现不足时提案 | `~/.ctrl/custom_tools.json` / `custom_prompt.txt` |
+
+---
+
+## 安全
+
+- 命令执行有**黑名单**防护（阻止 `rm -rf /`、`format` 等危险命令）
+- 文件操作限制在**当前工作目录**内，不能越界
+- 自我优化提案需要**你手动确认**才会生效
+
+---
+
+## 许可
+
+ISC © [nijat (Ctrl)](https://github.com/Kontirol)


### PR DESCRIPTION
ctrl
This PR adds the usage guide for **Ctrl**, a lightweight open-source terminal AI coding assistant.

- Pure JavaScript implementation
- Designed for DeepSeek-V4
- Available in both English (`ctrl.md`) and Chinese (`ctrl.zh-CN.md`)

Please review when you have a moment. Thanks!