### PR TITLE
fix(pi): add missing thinkingLevelMap to enable xhigh thinking level in Pi

### DIFF
--- a/docs/pi_mono.md
+++ b/docs/pi_mono.md
@@ -46,6 +46,7 @@ Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compat
           "maxTokens": 384000,
           "input": ["text"],
           "reasoning": true,
+          "thinkingLevelMap": { "minimal": "high", "low": "high", "medium": "high", "high": "high", "xhigh": "max" },
           "cost": {
             "input": 1.74,
             "output": 3.48,
@@ -71,6 +72,7 @@ Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compat
           "maxTokens": 384000,
           "input": ["text"],
           "reasoning": true,
+          "thinkingLevelMap": { "minimal": "high", "low": "high", "medium": "high", "high": "high", "xhigh": "max" },
           "cost": {
             "input": 0.14,
             "output": 0.28,

--- a/docs/pi_mono.md
+++ b/docs/pi_mono.md
@@ -46,7 +46,7 @@ Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compat
           "maxTokens": 384000,
           "input": ["text"],
           "reasoning": true,
-          "thinkingLevelMap": { "minimal": "high", "low": "high", "medium": "high", "high": "high", "xhigh": "max" },
+          "thinkingLevelMap": { "minimal": null, "low": null, "medium": null, "high": "high", "xhigh": "max" },
           "cost": {
             "input": 1.74,
             "output": 3.48,
@@ -72,7 +72,7 @@ Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compat
           "maxTokens": 384000,
           "input": ["text"],
           "reasoning": true,
-          "thinkingLevelMap": { "minimal": "high", "low": "high", "medium": "high", "high": "high", "xhigh": "max" },
+          "thinkingLevelMap": { "minimal": null, "low": null, "medium": null, "high": "high", "xhigh": "max" },
           "cost": {
             "input": 0.14,
             "output": 0.28,

--- a/docs/pi_mono.zh-CN.md
+++ b/docs/pi_mono.zh-CN.md
@@ -46,6 +46,7 @@ Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI
           "maxTokens": 384000,
           "input": ["text"],
           "reasoning": true,
+          "thinkingLevelMap": { "minimal": "high", "low": "high", "medium": "high", "high": "high", "xhigh": "max" },
           "cost": {
             "input": 1.74,
             "output": 3.48,
@@ -71,6 +72,7 @@ Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI
           "maxTokens": 384000,
           "input": ["text"],
           "reasoning": true,
+          "thinkingLevelMap": { "minimal": "high", "low": "high", "medium": "high", "high": "high", "xhigh": "max" },
           "cost": {
             "input": 0.14,
             "output": 0.28,

--- a/docs/pi_mono.zh-CN.md
+++ b/docs/pi_mono.zh-CN.md
@@ -46,7 +46,7 @@ Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI
           "maxTokens": 384000,
           "input": ["text"],
           "reasoning": true,
-          "thinkingLevelMap": { "minimal": "high", "low": "high", "medium": "high", "high": "high", "xhigh": "max" },
+          "thinkingLevelMap": { "minimal": null, "low": null, "medium": null, "high": "high", "xhigh": "max" },
           "cost": {
             "input": 1.74,
             "output": 3.48,
@@ -72,7 +72,7 @@ Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI
           "maxTokens": 384000,
           "input": ["text"],
           "reasoning": true,
-          "thinkingLevelMap": { "minimal": "high", "low": "high", "medium": "high", "high": "high", "xhigh": "max" },
+          "thinkingLevelMap": { "minimal": null, "low": null, "medium": null, "high": "high", "xhigh": "max" },
           "cost": {
             "input": 0.14,
             "output": 0.28,


### PR DESCRIPTION
## Summary

The Pi configuration guide is missing the `thinkingLevelMap` field in the DeepSeek model definitions.

## Problem

Without `thinkingLevelMap`, Pi's `getSupportedThinkingLevels()` filters out the `xhigh` level — it requires `xhigh` to be explicitly defined. Users following this guide cannot use `--thinking xhigh` even though the API-level `reasoningEffortMap` correctly maps it.

## Fix

Add `thinkingLevelMap` to both `deepseek-v4-pro` and `deepseek-v4-flash` in both English and Chinese docs.