### PR TITLE
feat: add Bash Agent integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Each guide walks through installation, configuration, and first run — so you c
 
 | Tool            | Description                                                                                                 | Guide                          |
 | --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| **Bash Agent** | Minimal AI coding agent runtime — pure Bash + AWK, zero dependencies, cache-first architecture with 99% cache hit rate. | [Guide](./docs/bash_agent.md) |
 | **AstrBot** | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs. | [Guide](./docs/astrbot.md) |
+| **Bash Agent** | Minimal AI coding agent runtime — pure Bash + AWK, zero dependencies, cache-first architecture with 99% cache hit rate. | [Guide](./docs/bash_agent.md) |
 | **Cherry Studio** | Open-source cross-platform desktop AI client with 300+ assistants, MCP support, knowledge bases, and multi-model chat. | [Guide](./docs/cherry_studio.md) |
 | **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
 | **Cline** | AI coding assistant extension for VS Code supporting multiple API providers. | [Guide](./docs/cline.md) |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Each guide walks through installation, configuration, and first run — so you c
 
 | Tool            | Description                                                                                                 | Guide                          |
 | --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **Bash Agent** | Minimal AI coding agent runtime — pure Bash + AWK, zero dependencies, cache-first architecture with 99% cache hit rate. | [Guide](./docs/bash_agent.md) |
 | **AstrBot** | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs. | [Guide](./docs/astrbot.md) |
 | **Cherry Studio** | Open-source cross-platform desktop AI client with 300+ assistants, MCP support, knowledge bases, and multi-model chat. | [Guide](./docs/cherry_studio.md) |
 | **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,7 @@
 
 | 工具            | 简介                                                                  | 指南                                |
 | --------------- | --------------------------------------------------------------------- | ----------------------------------- |
+| **Bash Agent** | 极简 AI 编程 Agent 运行时 —— 纯 Bash + AWK，零依赖，Cache-First 架构，缓存命中率 99%。 | [指南](./docs/bash_agent.zh-CN.md) |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
 | **Cherry Studio** | 开源跨平台桌面 AI 客户端，内置 300+ 助手、MCP、知识库与多模型对话。 | [指南](./docs/cherry_studio.zh-CN.md) |
 | **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,8 +15,8 @@
 
 | 工具            | 简介                                                                  | 指南                                |
 | --------------- | --------------------------------------------------------------------- | ----------------------------------- |
-| **Bash Agent** | 极简 AI 编程 Agent 运行时 —— 纯 Bash + AWK，零依赖，Cache-First 架构，缓存命中率 99%。 | [指南](./docs/bash_agent.zh-CN.md) |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
+| **Bash Agent** | 极简 AI 编程 Agent 运行时 —— 纯 Bash + AWK，零依赖，Cache-First 架构，缓存命中率 99%。 | [指南](./docs/bash_agent.zh-CN.md) |
 | **Cherry Studio** | 开源跨平台桌面 AI 客户端，内置 300+ 助手、MCP、知识库与多模型对话。 | [指南](./docs/cherry_studio.zh-CN.md) |
 | **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |
 | **Cline** | 运行在 VS Code 中的 AI 编程助手扩展，支持多种 API 供应商。 | [指南](./docs/cline.zh-CN.md) |

--- a/docs/bash_agent.md
+++ b/docs/bash_agent.md
@@ -1,0 +1,76 @@
+[English](./bash_agent.md) | [简体中文](./bash_agent.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Bash Agent
+
+**Bash Agent** is a minimal AI coding agent runtime built with pure Bash + AWK — zero runtime dependencies. It runs in any POSIX shell, talks directly to the DeepSeek API, and leverages a cache-first loop to dramatically reduce cost per token.
+
+> **Production Stats (2026-05-07):** 73.7M input tokens, cache hit rate 99%, 215K output tokens. ([DeepSeek分享对话](https://chat.deepseek.com/share/28068py62e711nhg57))
+
+#### 1. Install
+
+No Node.js, Python, or other runtime required. Download the latest release from [GitHub Releases](https://github.com/lloydzhou/bash-agent/releases):
+
+```bash
+# Bash + AWK version (zero dependencies, recommended)
+curl -fsSL https://github.com/lloydzhou/bash-agent/releases/latest/download/agent.sh \
+  -o ~/.local/bin/bash-agent && chmod +x ~/.local/bin/bash-agent
+
+# Go compiled version (auto-detect OS & arch)
+OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m); \
+  [ "$ARCH" = "x86_64" ] && ARCH=amd64; \
+  [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ] && ARCH=arm64; \
+  curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/goagent-${OS}-${ARCH}" \
+  -o ~/.local/bin/goagent && chmod +x ~/.local/bin/goagent
+
+# Rust compiled version (Linux / macOS only)
+OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m); \
+  [ "$ARCH" = "x86_64" ] && ARCH=amd64; \
+  [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ] && ARCH=arm64; \
+  case "$OS" in linux|darwin) SUFFIX="${OS}-${ARCH}" ;; \
+    *) echo "No prebuilt rustagent for $OS/$ARCH, build locally with: cd rust && cargo build --release"; exit 1 ;; \
+  esac; \
+  curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/rustagent-${SUFFIX}" \
+  -o ~/.local/bin/rustagent && chmod +x ~/.local/bin/rustagent
+```
+
+Ensure `~/.local/bin` is in your `PATH`.
+
+#### 2. Configure API Key & Model
+
+Bash Agent uses the Anthropic-compatible API format. Set the environment variables in your shell profile (`~/.zshrc`, `~/.bashrc`, etc.):
+
+```bash
+# Example: add to ~/.zshrc
+deepseek() {
+  DP_P_INNPUT=1 DP_P_OUT=3 DP_P_CACHE=0.02 \
+  ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic \
+  ANTHROPIC_API_KEY=sk-xxxx \
+  bash-agent -m deepseek-v4-flash --max-turns 100 --max-context 1m --max-tokens 81920 --continue $@
+}
+```
+
+Get your API key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+Available models: `deepseek-v4-flash` (cost-efficient), `deepseek-v4-pro` (maximum reasoning).
+
+DeepSeek V4 models support up to **1 million tokens** of context. Bash Agent automatically configures the 1M context window and enables max thinking effort for the best coding experience.
+
+#### 3. Run
+
+Navigate to your project directory and start the agent:
+
+```bash
+cd /path/to/my-project
+bash-agent
+```
+
+Bash Agent will read your project files, send them to DeepSeek with full context caching, and execute the model's suggestions in real time — all from a single Bash script.
+
+### Why Bash Agent?
+
+- **Zero dependencies** — pure Bash + AWK, runs on any POSIX system (Linux, macOS, WSL).
+- **Cache-first architecture** — designed to maximize DeepSeek's context cache, achieving 99% cache hit rate, significantly reducing costs.
+- **1M context** — fully leverages DeepSeek V4's 1 million token context window for large codebases.
+- **Max thinking effort** — supports DeepSeek V4 Pro's `max` reasoning level out of the box.
+- **Lightweight & hackable** — `src/agent.sh` (~1,500 lines) + 1,600 lines of AWK modules, compiled into a single `dist/agent.sh` (under 3,000 lines). Read, modify, and extend in minutes.
+- **Skill extensions** — supports custom skill loading from `.claude/skills/`, `./skills/`, and `~/.claude/skills/`, with a three-layer mechanism: skill-index (summary) → selected-skills (full load via `--skill`) → Skill tool (on-demand read).

--- a/docs/bash_agent.md
+++ b/docs/bash_agent.md
@@ -4,7 +4,7 @@
 
 **Bash Agent** is a minimal AI coding agent runtime built with pure Bash + AWK — zero runtime dependencies. It runs in any POSIX shell, talks directly to the DeepSeek API, and leverages a cache-first loop to dramatically reduce cost per token.
 
-> **Production Stats (2026-05-07):** 73.7M input tokens, cache hit rate 99%, 215K output tokens. ([DeepSeek分享对话](https://chat.deepseek.com/share/28068py62e711nhg57))
+> **Production Stats (2026-05, 11 days):** 723.9M input tokens, avg cache hit rate 99.15%, 2.5M output tokens. ([Dashboard](https://lloydzhou.github.io/bash-agent/))
 
 #### 1. Install
 

--- a/docs/bash_agent.md
+++ b/docs/bash_agent.md
@@ -11,7 +11,10 @@
 No Node.js, Python, or other runtime required. Download the latest release from [GitHub Releases](https://github.com/lloydzhou/bash-agent/releases):
 
 ```bash
-# Bash + AWK version (zero dependencies, recommended)
+# macOS — Homebrew (includes all 4 versions: bash/go/rust/c)
+brew install lloydzhou/tap/bash-agent
+
+# Or manually install Bash version (zero dependencies, single file)
 curl -fsSL https://github.com/lloydzhou/bash-agent/releases/latest/download/agent.sh \
   -o ~/.local/bin/bash-agent && chmod +x ~/.local/bin/bash-agent
 
@@ -22,15 +25,19 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m); \
   curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/goagent-${OS}-${ARCH}" \
   -o ~/.local/bin/goagent && chmod +x ~/.local/bin/goagent
 
-# Rust compiled version (Linux / macOS only)
+# Rust compiled version
 OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m); \
   [ "$ARCH" = "x86_64" ] && ARCH=amd64; \
   [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ] && ARCH=arm64; \
-  case "$OS" in linux|darwin) SUFFIX="${OS}-${ARCH}" ;; \
-    *) echo "No prebuilt rustagent for $OS/$ARCH, build locally with: cd rust && cargo build --release"; exit 1 ;; \
-  esac; \
-  curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/rustagent-${SUFFIX}" \
+  curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/rustagent-${OS}-${ARCH}" \
   -o ~/.local/bin/rustagent && chmod +x ~/.local/bin/rustagent
+
+# C compiled version
+OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m); \
+  [ "$ARCH" = "x86_64" ] && ARCH=amd64; \
+  [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ] && ARCH=arm64; \
+  curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/cagent-${OS}-${ARCH}" \
+  -o ~/.local/bin/cagent && chmod +x ~/.local/bin/cagent
 ```
 
 Ensure `~/.local/bin` is in your `PATH`.
@@ -41,8 +48,17 @@ Bash Agent uses the Anthropic-compatible API format. Set the environment variabl
 
 ```bash
 # Example: add to ~/.zshrc
+
+# Option 1: Use DEEPSEEK_API_KEY (auto-detected, simplest)
+export DEEPSEEK_API_KEY="sk-xxxx"
 deepseek() {
-  DP_P_INNPUT=1 DP_P_OUT=3 DP_P_CACHE=0.02 \
+  DP_P_IN=1 DP_P_OUT=3 DP_P_CACHE=0.02 \
+  bash-agent -m deepseek-v4-flash --max-turns 100 --max-context 1m --max-tokens 81920 --continue $@
+}
+
+# Option 2: Use ANTHROPIC_BASE_URL explicitly
+deepseek() {
+  DP_P_IN=1 DP_P_OUT=3 DP_P_CACHE=0.02 \
   ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic \
   ANTHROPIC_API_KEY=sk-xxxx \
   bash-agent -m deepseek-v4-flash --max-turns 100 --max-context 1m --max-tokens 81920 --continue $@
@@ -72,5 +88,5 @@ Bash Agent will read your project files, send them to DeepSeek with full context
 - **Cache-first architecture** — designed to maximize DeepSeek's context cache, achieving 99% cache hit rate, significantly reducing costs.
 - **1M context** — fully leverages DeepSeek V4's 1 million token context window for large codebases.
 - **Max thinking effort** — supports DeepSeek V4 Pro's `max` reasoning level out of the box.
-- **Lightweight & hackable** — `src/agent.sh` (~1,500 lines) + 1,600 lines of AWK modules, compiled into a single `dist/agent.sh` (under 3,000 lines). Read, modify, and extend in minutes.
+- **Lightweight & hackable** — `src/agent.sh` (~1,600 lines) + 1,600 lines of AWK modules, compiled into a single `dist/agent.sh`. Also available in Go, Rust, and C for compiled performance. Read, modify, and extend in minutes.
 - **Skill extensions** — supports custom skill loading from `.claude/skills/`, `./skills/`, and `~/.claude/skills/`, with a three-layer mechanism: skill-index (summary) → selected-skills (full load via `--skill`) → Skill tool (on-demand read).

--- a/docs/bash_agent.zh-CN.md
+++ b/docs/bash_agent.zh-CN.md
@@ -11,7 +11,10 @@
 无需 Node.js、Python 或其他运行时，从 [GitHub Releases](https://github.com/lloydzhou/bash-agent/releases) 下载最新版本即可：
 
 ```bash
-# Bash + AWK 版本（零依赖，推荐）
+# macOS — Homebrew（包含全部 4 个版本：bash/go/rust/c）
+brew install lloydzhou/tap/bash-agent
+
+# 或手动安装 Bash 版本（零依赖，单文件）
 curl -fsSL https://github.com/lloydzhou/bash-agent/releases/latest/download/agent.sh \
   -o ~/.local/bin/bash-agent && chmod +x ~/.local/bin/bash-agent
 
@@ -22,15 +25,19 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m); \
   curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/goagent-${OS}-${ARCH}" \
   -o ~/.local/bin/goagent && chmod +x ~/.local/bin/goagent
 
-# Rust 编译版本（仅支持 Linux / macOS）
+# Rust 编译版本
 OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m); \
   [ "$ARCH" = "x86_64" ] && ARCH=amd64; \
   [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ] && ARCH=arm64; \
-  case "$OS" in linux|darwin) SUFFIX="${OS}-${ARCH}" ;; \
-    *) echo "No prebuilt rustagent for $OS/$ARCH, build locally with: cd rust && cargo build --release"; exit 1 ;; \
-  esac; \
-  curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/rustagent-${SUFFIX}" \
+  curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/rustagent-${OS}-${ARCH}" \
   -o ~/.local/bin/rustagent && chmod +x ~/.local/bin/rustagent
+
+# C 编译版本
+OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m); \
+  [ "$ARCH" = "x86_64" ] && ARCH=amd64; \
+  [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ] && ARCH=arm64; \
+  curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/cagent-${OS}-${ARCH}" \
+  -o ~/.local/bin/cagent && chmod +x ~/.local/bin/cagent
 ```
 
 确保 `~/.local/bin` 在你的 `PATH` 中。
@@ -41,8 +48,17 @@ Bash Agent 使用 Anthropic 兼容的 API 格式。在 Shell 配置文件（`~/.
 
 ```bash
 # 示例：添加到 ~/.zshrc
+
+# 方式一：使用 DEEPSEEK_API_KEY（自动检测，最简单）
+export DEEPSEEK_API_KEY="sk-xxxx"
 deepseek() {
-  DP_P_INNPUT=1 DP_P_OUT=3 DP_P_CACHE=0.02 \
+  DP_P_IN=1 DP_P_OUT=3 DP_P_CACHE=0.02 \
+  bash-agent -m deepseek-v4-flash --max-turns 100 --max-context 1m --max-tokens 81920 --continue $@
+}
+
+# 方式二：显式指定 ANTHROPIC_BASE_URL
+deepseek() {
+  DP_P_IN=1 DP_P_OUT=3 DP_P_CACHE=0.02 \
   ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic \
   ANTHROPIC_API_KEY=sk-xxxx \
   bash-agent -m deepseek-v4-flash --max-turns 100 --max-context 1m --max-tokens 81920 --continue $@
@@ -72,5 +88,5 @@ Bash Agent 会读取项目文件，通过完整的上下文缓存发送到 DeepS
 - **Cache-First 架构** — 专为最大化 DeepSeek 上下文缓存设计，达到 99% 缓存命中率，显著降低成本。
 - **1M 上下文** — 充分利用 DeepSeek V4 的 100 万 token 上下文窗口，轻松应对大型代码库。
 - **最大思考强度** — 开箱即用支持 DeepSeek V4 Pro 的 `max` 推理级别。
-- **轻量可定制** — `src/agent.sh` 约 1500 行核心代码 + 1600 行 AWK 辅助模块，编译为单个 `dist/agent.sh`（不足 3000 行），几分钟即可阅读、修改和扩展。
+- **轻量可定制** — `src/agent.sh` 约 1600 行核心代码 + 1600 行 AWK 辅助模块，编译为单个 `dist/agent.sh`。同时提供 Go、Rust、C 编译版本，兼顾性能与可定制性。几分钟即可阅读、修改和扩展。
 - **Skill 扩展** — 支持从 `.claude/skills/`、`./skills/` 和 `~/.claude/skills/` 三个目录加载自定义技能，三层机制：skill-index（摘要）→ selected-skills（通过 `--skill` 完整加载）→ Skill 工具（按需读取）。

--- a/docs/bash_agent.zh-CN.md
+++ b/docs/bash_agent.zh-CN.md
@@ -4,7 +4,7 @@
 
 **Bash Agent** 是一个极简的 AI 编程 Agent 运行时，纯 Bash + AWK 实现，零运行时依赖。它在任何 POSIX Shell 中运行，直接对接 DeepSeek API，利用 Cache-First 循环大幅降低每次调用成本。
 
-> **生产数据（2026-05-07）：** 输入 73.7M tokens，缓存命中率 99%，输出 215K tokens。（[DeepSeek分享对话](https://chat.deepseek.com/share/28068py62e711nhg57)）
+> **生产数据（2026 年 5 月，11 天）：** 输入 723.9M tokens，平均缓存命中率 99.15%，输出 2.5M tokens。（[数据看板](https://lloydzhou.github.io/bash-agent/)）
 
 #### 1. 安装
 

--- a/docs/bash_agent.zh-CN.md
+++ b/docs/bash_agent.zh-CN.md
@@ -1,0 +1,76 @@
+[English](./bash_agent.md) | [简体中文](./bash_agent.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Bash Agent
+
+**Bash Agent** 是一个极简的 AI 编程 Agent 运行时，纯 Bash + AWK 实现，零运行时依赖。它在任何 POSIX Shell 中运行，直接对接 DeepSeek API，利用 Cache-First 循环大幅降低每次调用成本。
+
+> **生产数据（2026-05-07）：** 输入 73.7M tokens，缓存命中率 99%，输出 215K tokens。（[DeepSeek分享对话](https://chat.deepseek.com/share/28068py62e711nhg57)）
+
+#### 1. 安装
+
+无需 Node.js、Python 或其他运行时，从 [GitHub Releases](https://github.com/lloydzhou/bash-agent/releases) 下载最新版本即可：
+
+```bash
+# Bash + AWK 版本（零依赖，推荐）
+curl -fsSL https://github.com/lloydzhou/bash-agent/releases/latest/download/agent.sh \
+  -o ~/.local/bin/bash-agent && chmod +x ~/.local/bin/bash-agent
+
+# Go 编译版本（自动检测系统与架构）
+OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m); \
+  [ "$ARCH" = "x86_64" ] && ARCH=amd64; \
+  [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ] && ARCH=arm64; \
+  curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/goagent-${OS}-${ARCH}" \
+  -o ~/.local/bin/goagent && chmod +x ~/.local/bin/goagent
+
+# Rust 编译版本（仅支持 Linux / macOS）
+OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m); \
+  [ "$ARCH" = "x86_64" ] && ARCH=amd64; \
+  [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ] && ARCH=arm64; \
+  case "$OS" in linux|darwin) SUFFIX="${OS}-${ARCH}" ;; \
+    *) echo "No prebuilt rustagent for $OS/$ARCH, build locally with: cd rust && cargo build --release"; exit 1 ;; \
+  esac; \
+  curl -fsSL "https://github.com/lloydzhou/bash-agent/releases/latest/download/rustagent-${SUFFIX}" \
+  -o ~/.local/bin/rustagent && chmod +x ~/.local/bin/rustagent
+```
+
+确保 `~/.local/bin` 在你的 `PATH` 中。
+
+#### 2. 配置 API Key 与模型
+
+Bash Agent 使用 Anthropic 兼容的 API 格式。在 Shell 配置文件（`~/.zshrc`、`~/.bashrc` 等）中设置环境变量：
+
+```bash
+# 示例：添加到 ~/.zshrc
+deepseek() {
+  DP_P_INNPUT=1 DP_P_OUT=3 DP_P_CACHE=0.02 \
+  ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic \
+  ANTHROPIC_API_KEY=sk-xxxx \
+  bash-agent -m deepseek-v4-flash --max-turns 100 --max-context 1m --max-tokens 81920 --continue $@
+}
+```
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
+
+可用模型：`deepseek-v4-flash`（低成本）、`deepseek-v4-pro`（最强推理）。
+
+DeepSeek V4 模型支持高达 **100 万 token** 的上下文。Bash Agent 自动配置 1M 上下文窗口，并默认启用最大思考强度，为你提供最佳编程体验。
+
+#### 3. 运行
+
+进入项目目录并启动 Agent：
+
+```bash
+cd /path/to/my-project
+bash-agent
+```
+
+Bash Agent 会读取项目文件，通过完整的上下文缓存发送到 DeepSeek，并实时执行模型的建议——这一切都来自一个单独的 Bash 脚本。
+
+### 为什么选择 Bash Agent？
+
+- **零依赖** — 纯 Bash + AWK，在任何 POSIX 系统（Linux、macOS、WSL）上运行。
+- **Cache-First 架构** — 专为最大化 DeepSeek 上下文缓存设计，达到 99% 缓存命中率，显著降低成本。
+- **1M 上下文** — 充分利用 DeepSeek V4 的 100 万 token 上下文窗口，轻松应对大型代码库。
+- **最大思考强度** — 开箱即用支持 DeepSeek V4 Pro 的 `max` 推理级别。
+- **轻量可定制** — `src/agent.sh` 约 1500 行核心代码 + 1600 行 AWK 辅助模块，编译为单个 `dist/agent.sh`（不足 3000 行），几分钟即可阅读、修改和扩展。
+- **Skill 扩展** — 支持从 `.claude/skills/`、`./skills/` 和 `~/.claude/skills/` 三个目录加载自定义技能，三层机制：skill-index（摘要）→ selected-skills（通过 `--skill` 完整加载）→ Skill 工具（按需读取）。


### PR DESCRIPTION
Add Bash Agent as a supported tool with bilingual (EN/zh-CN) integration guides.

Bash Agent is a minimal AI coding agent runtime — pure Bash + AWK, zero runtime dependencies. It talks directly to the DeepSeek API via the Anthropic-compatible format and achieves 99% cache hit rate in production (73.7M input tokens tracked).

**Files changed:**
- `docs/bash_agent.md` — English guide (new)
- `docs/bash_agent.zh-CN.md` — Chinese guide (new)
- `README.md` — table entry (alphabetical, before Claude Code)
- `README.zh-CN.md` — table entry (alphabetical, before Claude Code)

See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing)
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes

> **Note:** No images needed for this guide — it's a text-only guide covering install, config, and run steps.