### PR TITLE
docs: add dscode integration guide (bilingual)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
-| **DSCode** | Open-source terminal AI coding agent built as a DeepSeek-native harness — Skills, MCP, memory system, permission control. | [Guide](./docs/dscode.md) |
+| **dscode** | Open-source terminal AI agent for creators — connects creative MCP tools, with Skills, memory, and permission control. | [Guide](./docs/dscode.md) |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **DSCode** | Open-source terminal AI coding agent built as a DeepSeek-native harness — Skills, MCP, memory system, permission control. | [Guide](./docs/dscode.md) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,6 +32,7 @@
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **DSCode** | 专为 DeepSeek 打造的开源终端 AI 编程 Agent —— Skills、MCP、记忆系统、权限控制。 | [指南](./docs/dscode.zh-CN.md) |
 
 ## 相关资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,7 +32,7 @@
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
-| **DSCode** | 专为 DeepSeek 打造的开源终端 AI 编程 Agent —— Skills、MCP、记忆系统、权限控制。 | [指南](./docs/dscode.zh-CN.md) |
+| **dscode** | 面向创作者的开源终端 AI Agent —— 链接创作 MCP 工具，内置 Skills、记忆与权限控制。 | [指南](./docs/dscode.zh-CN.md) |
 
 ## 相关资源
 

--- a/docs/dscode.md
+++ b/docs/dscode.md
@@ -1,12 +1,12 @@
 [English](./dscode.md) | [简体中文](./dscode.zh-CN.md) · [← Back](../README.md)
 
-# Integrate with DSCode
+# Integrate with dscode
 
-DSCode is an open-source terminal AI coding agent built specifically as a DeepSeek harness — analogous to how Claude Code is the harness for Claude models. It provides file operations, shell execution, code search, permission control, session persistence, context management, memory system, Skills system, and MCP protocol support.
+Unlike general-purpose coding agents built for developers, dscode is an open-source terminal AI agent positioned to connect creative MCP tools — serving creators, writers, and content makers. Built as a DeepSeek-native harness, it provides file operations, shell execution, code search, permission control, session persistence, context management, memory system, Skills system, and MCP protocol support.
 
 - **GitHub:** <https://github.com/wangcan26/dscode>
 
-#### 1. Install DSCode
+#### 1. Install dscode
 
 - Install [Node.js](https://nodejs.org/en/download/) 20.6+.
 - Clone the repository and install dependencies:
@@ -30,7 +30,7 @@ Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_
 
 #### 3. Configure Model and Thinking Mode
 
-DSCode supports two-level configuration (user-level and project-level):
+dscode supports two-level configuration (user-level and project-level):
 
 - **User-level:** `~/.dscode/config.json`
 - **Project-level:** `<project>/.dscode/config.json`
@@ -55,7 +55,7 @@ Priority: **environment variables > project-level config > user-level config > d
 
 > **Thinking mode:** Set `thinkingLevel` to `xhigh` or `AGENT_THINKING_LEVEL=xhigh` to enable max reasoning effort (`reasoning_effort: "max"`). The underlying pi-ai framework automatically configures 1M context window (`contextWindow: 1000000`) and DeepSeek-specific thinking format.
 
-#### 4. Run DSCode
+#### 4. Run dscode
 
 ```bash
 npm start
@@ -70,7 +70,7 @@ DSCODE_PROJECT_PATH=/path/to/my-project npm start
 Once started, you will see the `you ›` prompt:
 
 ```
-DSCode  (deepseek-v4-pro)
+dscode  (deepseek-v4-pro)
 Type a message. /help for commands. exit to quit.
 
 you ›

--- a/docs/dscode.md
+++ b/docs/dscode.md
@@ -1,0 +1,97 @@
+[English](./dscode.md) | [简体中文](./dscode.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with DSCode
+
+DSCode is an open-source terminal AI coding agent built specifically as a DeepSeek harness — analogous to how Claude Code is the harness for Claude models. It provides file operations, shell execution, code search, permission control, session persistence, context management, memory system, Skills system, and MCP protocol support.
+
+- **GitHub:** <https://github.com/wangcan26/dscode>
+
+#### 1. Install DSCode
+
+- Install [Node.js](https://nodejs.org/en/download/) 20.6+.
+- Clone the repository and install dependencies:
+
+```bash
+git clone https://github.com/wangcan26/dscode.git
+cd dscode
+npm install
+cp .env.example .env
+```
+
+#### 2. Configure DeepSeek API Key
+
+Edit the `.env` file and add your DeepSeek API key:
+
+```bash
+DEEPSEEK_API_KEY=sk-...
+```
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+#### 3. Configure Model and Thinking Mode
+
+DSCode supports two-level configuration (user-level and project-level):
+
+- **User-level:** `~/.dscode/config.json`
+- **Project-level:** `<project>/.dscode/config.json`
+
+Priority: **environment variables > project-level config > user-level config > defaults**
+
+```jsonc
+{
+  "modelId": "deepseek-v4-pro",
+  "thinkingLevel": "xhigh",
+  "maxTokens": 16384
+}
+```
+
+**Key configuration options:**
+
+| Option | Env Variable | Default | Description |
+|--------|-------------|---------|-------------|
+| `modelId` | `AGENT_MODEL` / `DEEPSEEK_MODEL` | `deepseek-v4-flash` | Model ID — `deepseek-v4-pro` or `deepseek-v4-flash` |
+| `thinkingLevel` | `AGENT_THINKING_LEVEL` | Pro: `medium`, Flash: `off` | Thinking level — `off`, `medium`, `high`, or `xhigh` (max effort) |
+| `maxTokens` | `DSCODE_MAX_TOKENS` | `16384` | Max output tokens per turn |
+
+> **Thinking mode:** Set `thinkingLevel` to `xhigh` or `AGENT_THINKING_LEVEL=xhigh` to enable max reasoning effort (`reasoning_effort: "max"`). The underlying pi-ai framework automatically configures 1M context window (`contextWindow: 1000000`) and DeepSeek-specific thinking format.
+
+#### 4. Run DSCode
+
+```bash
+npm start
+```
+
+Or specify the project path:
+
+```bash
+DSCODE_PROJECT_PATH=/path/to/my-project npm start
+```
+
+Once started, you will see the `you ›` prompt:
+
+```
+DSCode  (deepseek-v4-pro)
+Type a message. /help for commands. exit to quit.
+
+you ›
+```
+
+#### Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show all commands |
+| `/reset` | Clear conversation history |
+| `/session list` | List saved sessions |
+| `/session save` | Save current session |
+| `/session load <id>` | Restore a saved session |
+| `/memory list` | View memories |
+| `/memory add <text>` | Add a memory entry |
+| `/skills` | List Skills and their status |
+| `/skills activate <name>` | Activate a Skill |
+| `/drivers` | List loaded drivers |
+| `/permissions` | View permission grants |
+| `/cost` | Show token usage |
+| `/compact` | Manually compact context |
+
+Type `exit` or press `Ctrl+C` twice to quit. Press `Ctrl+C` once to interrupt generation.

--- a/docs/dscode.zh-CN.md
+++ b/docs/dscode.zh-CN.md
@@ -1,0 +1,97 @@
+[English](./dscode.md) | [简体中文](./dscode.zh-CN.md) · [← Back](../README.zh-CN.md)
+
+# 集成 DSCode
+
+DSCode 是一款专为 DeepSeek 模型打造的开源终端 AI 编程 Agent —— 类似于 Claude Code 是 Claude 模型的专属 Harness。提供文件操作、Shell 执行、代码搜索、权限控制、会话持久化、上下文管理、记忆系统、Skills 系统和 MCP 协议支持。
+
+- **GitHub：** <https://github.com/wangcan26/dscode>
+
+#### 1. 安装 DSCode
+
+- 安装 [Node.js](https://nodejs.org/en/download/) 20.6+ 版本。
+- 克隆仓库并安装依赖：
+
+```bash
+git clone https://github.com/wangcan26/dscode.git
+cd dscode
+npm install
+cp .env.example .env
+```
+
+#### 2. 配置 DeepSeek API Key
+
+编辑 `.env` 文件，填入你的 DeepSeek API Key：
+
+```bash
+DEEPSEEK_API_KEY=sk-...
+```
+
+从 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取你的 API Key。
+
+#### 3. 配置模型与思考模式
+
+DSCode 支持两级配置（用户级和项目级）：
+
+- **用户级：** `~/.dscode/config.json`
+- **项目级：** `<project>/.dscode/config.json`
+
+优先级：**环境变量 > 项目级 config.json > 用户级 config.json > 默认值**
+
+```jsonc
+{
+  "modelId": "deepseek-v4-pro",
+  "thinkingLevel": "xhigh",
+  "maxTokens": 16384
+}
+```
+
+**核心配置选项：**
+
+| 选项 | 环境变量 | 默认值 | 说明 |
+|------|---------|--------|------|
+| `modelId` | `AGENT_MODEL` / `DEEPSEEK_MODEL` | `deepseek-v4-flash` | 模型 ID — `deepseek-v4-pro` 或 `deepseek-v4-flash` |
+| `thinkingLevel` | `AGENT_THINKING_LEVEL` | Pro: `medium`，Flash: `off` | 思考强度 — `off`、`medium`、`high` 或 `xhigh`（最大推理） |
+| `maxTokens` | `DSCODE_MAX_TOKENS` | `16384` | 单次最大输出 token 数 |
+
+> **思考模式：** 设置 `thinkingLevel` 为 `xhigh` 或 `AGENT_THINKING_LEVEL=xhigh` 即可启用最大推理强度（`reasoning_effort: "max"`）。底层 pi-ai 框架自动配置 100 万 token 上下文窗口（`contextWindow: 1000000`）和 DeepSeek 专有的 thinking 格式。
+
+#### 4. 运行 DSCode
+
+```bash
+npm start
+```
+
+或指定项目路径：
+
+```bash
+DSCODE_PROJECT_PATH=/path/to/my-project npm start
+```
+
+启动后将看到 `you ›` 提示符：
+
+```
+DSCode  (deepseek-v4-pro)
+Type a message. /help for commands. exit to quit.
+
+you ›
+```
+
+#### Slash 命令
+
+| 命令 | 说明 |
+|------|------|
+| `/help` | 显示所有命令 |
+| `/reset` | 清空对话历史 |
+| `/session list` | 列出已保存会话 |
+| `/session save` | 保存当前会话 |
+| `/session load <id>` | 恢复历史会话 |
+| `/memory list` | 查看记忆 |
+| `/memory add <内容>` | 手动添加记忆 |
+| `/skills` | 列出 Skills 及状态 |
+| `/skills activate <name>` | 激活 Skill |
+| `/drivers` | 列出已加载的驱动 |
+| `/permissions` | 查看当前权限授予 |
+| `/cost` | 显示 token 用量 |
+| `/compact` | 手动压缩上下文 |
+
+输入 `exit` 或按 `Ctrl+C` 两次退出。按 `Ctrl+C` 一次中断生成。

--- a/docs/dscode.zh-CN.md
+++ b/docs/dscode.zh-CN.md
@@ -1,12 +1,12 @@
 [English](./dscode.md) | [简体中文](./dscode.zh-CN.md) · [← Back](../README.zh-CN.md)
 
-# 集成 DSCode
+# 集成 dscode
 
-DSCode 是一款专为 DeepSeek 模型打造的开源终端 AI 编程 Agent —— 类似于 Claude Code 是 Claude 模型的专属 Harness。提供文件操作、Shell 执行、代码搜索、权限控制、会话持久化、上下文管理、记忆系统、Skills 系统和 MCP 协议支持。
+不同于面向开发者的通用编程 Agent，dscode 是一款开源终端 AI Agent，产品定位是链接创作类 MCP 工具，服务创作者而非开发者。作为 DeepSeek 原生 Harness，提供文件操作、Shell 执行、代码搜索、权限控制、会话持久化、上下文管理、记忆系统、Skills 系统以及 MCP 协议支持。
 
 - **GitHub：** <https://github.com/wangcan26/dscode>
 
-#### 1. 安装 DSCode
+#### 1. 安装 dscode
 
 - 安装 [Node.js](https://nodejs.org/en/download/) 20.6+ 版本。
 - 克隆仓库并安装依赖：
@@ -30,7 +30,7 @@ DEEPSEEK_API_KEY=sk-...
 
 #### 3. 配置模型与思考模式
 
-DSCode 支持两级配置（用户级和项目级）：
+dscode 支持两级配置（用户级和项目级）：
 
 - **用户级：** `~/.dscode/config.json`
 - **项目级：** `<project>/.dscode/config.json`
@@ -55,7 +55,7 @@ DSCode 支持两级配置（用户级和项目级）：
 
 > **思考模式：** 设置 `thinkingLevel` 为 `xhigh` 或 `AGENT_THINKING_LEVEL=xhigh` 即可启用最大推理强度（`reasoning_effort: "max"`）。底层 pi-ai 框架自动配置 100 万 token 上下文窗口（`contextWindow: 1000000`）和 DeepSeek 专有的 thinking 格式。
 
-#### 4. 运行 DSCode
+#### 4. 运行 dscode
 
 ```bash
 npm start
@@ -70,7 +70,7 @@ DSCODE_PROJECT_PATH=/path/to/my-project npm start
 启动后将看到 `you ›` 提示符：
 
 ```
-DSCode  (deepseek-v4-pro)
+dscode  (deepseek-v4-pro)
 Type a message. /help for commands. exit to quit.
 
 you ›


### PR DESCRIPTION
## 摘要   
  - 新增 dscode 双语集成指南，dscode 是一款开源终端 AI Agent，产品定位是链接创作类 MCP 工具，服务创作者而非开发者。
  - 支持 100 万 token 上下文窗口、最大推理强度（xhigh → reasoning_effort:               
  max）、Skills、MCP、权限控制                                                          
  - README.md 与 README.zh-CN.md 中的表格条目均已按字母序插入                           
                                                                                        
  ## 检查清单     
  - [x] 模型名称使用当前版本 (deepseek-v4-pro / deepseek-v4-flash)                      
  - [x] 已说明 100 万 token 上下文
  - [x] 支持最大推理强度 (xhigh → reasoning_effort: max)                                
  - [x] 中英文双语版本
  - [x] README 表格按字母序插入