### PR TITLE
docs: add Operit guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
+| **Operit** | Open-source Android AI Agent that provides all-around assistant capabilities. | [Guide](./docs/operit.md) |
 | **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,6 +24,7 @@
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
+| **Operit** | 开源 Android AI Agent，提供全方位的助理能力。 | [指南](./docs/operit.zh-CN.md) |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |

--- a/docs/operit.md
+++ b/docs/operit.md
@@ -1,0 +1,33 @@
+[English](./operit.md) | [简体中文](./operit.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Operit
+
+Operit is an open-source Android AI Agent that provides all-around assistant capabilities. DeepSeek V4 can be used through Operit's built-in DeepSeek setup or through an OpenAI-compatible endpoint.
+
+#### 1. Install Operit
+
+- Download the latest APK from the [Operit official website](https://operit.app/), or use the [GitHub releases page](https://github.com/AAswordman/Operit/releases).
+- Launch Operit and complete the first-run onboarding.
+
+See the official [Operit beginner guide](https://operit.app/#/guide/new) for the full onboarding walkthrough.
+
+#### 2. Configure DeepSeek
+
+During first-run setup, tap `Get token`. Operit will open its built-in DeepSeek page. Create an API Key there, then paste it back into Operit to start chatting.
+
+Operit will automatically fill in `deepseek-v4-flash`.
+
+DeepSeek V4 supports up to a 1M-token context window. You can adjust the context amount you want to use in Operit's context compression settings.
+
+To configure it manually, open `Settings` -> `Model and Parameter Configuration`, create a configuration, and use:
+
+```text
+Provider: DeepSeek
+Endpoint: https://api.deepseek.com/v1/chat/completions
+API Key: <your DeepSeek API Key>
+Model: deepseek-v4-pro or deepseek-v4-flash
+```
+
+#### 3. Get Started
+
+Return to the chat page, select the DeepSeek model, and send a test message.

--- a/docs/operit.zh-CN.md
+++ b/docs/operit.zh-CN.md
@@ -1,0 +1,33 @@
+[English](./operit.md) | [简体中文](./operit.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Operit
+
+Operit 是一款开源 Android AI Agent，提供全方位的助理能力。DeepSeek V4 可以通过 Operit 内置的 DeepSeek 引导接入，也可以通过 OpenAI 兼容端点手动配置。
+
+#### 1. 安装 Operit
+
+- 前往 [Operit 官网](https://operit.app/) 下载最新 APK，也可以使用 [GitHub Releases 页面](https://github.com/AAswordman/Operit/releases)。
+- 启动 Operit，并完成首次引导。
+
+完整首次引导可参考官方 [Operit 新手指南](https://operit.app/#/guide/new)。
+
+#### 2. 配置 DeepSeek
+
+首次启动时，点击 `获取 token`，Operit 会自动跳转到软件内置的 DeepSeek 官网页面。创建 API Key 后，回到 Operit 粘贴即可开始对话。
+
+Operit 会自动填写 `deepseek-v4-flash`。
+
+DeepSeek V4 支持最高 100 万 token 上下文，可以在 Operit 的上下文压缩设置里修改想要使用的上下文量。
+
+如果需要手动配置，打开 `设置` -> `模型与参数配置`，新建一个配置，并填写：
+
+```text
+供应商: DeepSeek
+端点: https://api.deepseek.com/v1/chat/completions
+API Key: <你的 DeepSeek API Key>
+模型: deepseek-v4-pro 或 deepseek-v4-flash
+```
+
+#### 3. 开始使用
+
+回到聊天页，选择 DeepSeek 模型，发送一条消息测试即可。


### PR DESCRIPTION
See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.

## Summary

Add an Operit integration guide for configuring DeepSeek V4 in Operit, including English and Simplified Chinese documentation.

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing)
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes
