### PR TITLE
Add zot integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **zot**          | Lightweight coding agent harness with TUI/JSON/RPC modes, structured tools, reviewable file diffs, skills, extensions, and optional guardrails.| [Guide](./docs/zot.md)     |
 
 ## Resources
 

--- a/docs/zot.md
+++ b/docs/zot.md
@@ -1,0 +1,121 @@
+[English](./zot.md) | [简体中文](./zot.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with zot
+
+zot is a lightweight coding agent harness written in Go, shipped as a single static binary. It comes with built-in DeepSeek support through DeepSeek's OpenAI-compatible chat API, four built-in tools (read, write, edit, bash), three run modes (interactive TUI, print, JSON), and an extension system in any language via subprocess + JSON-RPC.
+
+#### 1. Install zot
+
+- **Linux / macOS** (one-liner):
+
+```bash
+curl -fsSL https://www.zot.sh/install.sh | bash
+```
+
+- **Windows** (PowerShell):
+
+```powershell
+iwr -useb https://www.zot.sh/install.ps1 | iex
+```
+
+- **Via Go**:
+
+```bash
+go install github.com/patriceckhart/zot/cmd/zot@latest
+```
+
+- After installation, verify by running:
+
+```bash
+zot --help
+```
+
+#### 2. Configure DeepSeek Provider
+
+zot has built-in DeepSeek support, so no manual provider configuration is required. The default settings are:
+
+- **model**: `deepseek-v4-pro`
+- **base URL**: `https://api.deepseek.com/v1`
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+Set the environment variable:
+
+Linux / Mac users:
+
+```bash
+export DEEPSEEK_API_KEY="<your DeepSeek API Key>"
+```
+
+Windows users:
+
+```powershell
+$env:DEEPSEEK_API_KEY="<your DeepSeek API Key>"
+```
+
+Alternatively, run `zot` and type `/login`, then pick **api key** to paste your DeepSeek key. zot probes `/v1/models` once and stores the key under `deepseek` in `$ZOT_HOME/auth.json` (mode 0600).
+
+Credential lookup order for DeepSeek:
+
+1. `--api-key` flag
+2. `DEEPSEEK_API_KEY` environment variable
+3. `$ZOT_HOME/auth.json`
+
+> **Note:** DeepSeek does not offer a subscription OAuth flow. Authentication is API-key only.
+
+#### 3. Run and Select Model
+
+- Enter the project directory and run zot with the DeepSeek provider:
+
+```bash
+cd /path/to/my-project
+zot --provider deepseek
+```
+
+- Catalog ships with two models, both selectable via `/model` in the TUI:
+  - `deepseek-v4-pro` (reasoning)
+  - `deepseek-v4-flash`
+
+- To pick a specific model directly:
+
+```bash
+zot --provider deepseek --model deepseek-v4-flash
+```
+
+- To use a custom-compatible endpoint (mirror, gateway, self-host):
+
+```bash
+zot --provider deepseek \
+    --base-url https://my-deepseek-mirror.example.com/v1 \
+    --api-key "$DEEPSEEK_API_KEY"
+```
+
+#### 4. Add Custom Models (Optional)
+
+Place a `models.json` in `$ZOT_HOME` to add models that aren't in the baked-in catalog:
+
+- **macOS**: `~/Library/Application Support/zot/models.json`
+- **Linux**: `~/.local/state/zot/models.json`
+- **Windows**: `%LOCALAPPDATA%\zot\models.json`
+
+```json
+{
+  "providers": {
+    "deepseek": {
+      "models": [
+        {
+          "id": "deepseek-v5-preview",
+          "name": "DeepSeek V5 Preview",
+          "reasoning": true,
+          "contextWindow": 128000,
+          "maxTokens": 8192
+        }
+      ]
+    }
+  }
+}
+```
+
+> **Note on text-only mode:** DeepSeek's chat-completions endpoint currently rejects the multimodal content schema. When the active provider is `deepseek`, zot silently drops image parts from outgoing messages and keeps only the text. Switching back to a vision-capable model re-sends the image normally because the session file still stores it.
+
+For more configuration options, see the [zot README](https://github.com/patriceckhart/zot/blob/main/README.md).

--- a/docs/zot.zh-CN.md
+++ b/docs/zot.zh-CN.md
@@ -1,0 +1,121 @@
+[English](./zot.md) | [简体中文](./zot.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 zot
+
+zot 是一个用 Go 编写的轻量级编码代理框架，以单个静态二进制文件分发。它内置了对 DeepSeek 的支持（通过 DeepSeek 的 OpenAI 兼容聊天 API），提供四个内置工具（read、write、edit、bash）、三种运行模式（交互式 TUI、print、JSON），以及通过子进程 + JSON-RPC 实现的任意语言扩展系统。
+
+#### 1. 安装 zot
+
+- **Linux / macOS**（一键脚本）：
+
+```bash
+curl -fsSL https://www.zot.sh/install.sh | bash
+```
+
+- **Windows**（PowerShell）：
+
+```powershell
+iwr -useb https://www.zot.sh/install.ps1 | iex
+```
+
+- **通过 Go 安装**：
+
+```bash
+go install github.com/patriceckhart/zot/cmd/zot@latest
+```
+
+- 安装结束后，执行以下命令验证安装：
+
+```bash
+zot --help
+```
+
+#### 2. 配置 DeepSeek 供应商
+
+zot 已内置 DeepSeek 支持，无需手动配置供应商。默认设置如下：
+
+- **模型**：`deepseek-v4-pro`
+- **基础 URL**：`https://api.deepseek.com/v1`
+
+其中 API Key 在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取。
+
+设置环境变量：
+
+Linux / Mac 用户：
+
+```bash
+export DEEPSEEK_API_KEY="<你的 DeepSeek API Key>"
+```
+
+Windows 用户：
+
+```powershell
+$env:DEEPSEEK_API_KEY="<你的 DeepSeek API Key>"
+```
+
+或者，运行 `zot` 并输入 `/login`，然后选择 **api key** 粘贴你的 DeepSeek 密钥。zot 会请求一次 `/v1/models` 进行验证，并将密钥以 `deepseek` 为键存储在 `$ZOT_HOME/auth.json` 中（权限 0600）。
+
+DeepSeek 的凭证查找顺序：
+
+1. `--api-key` 参数
+2. `DEEPSEEK_API_KEY` 环境变量
+3. `$ZOT_HOME/auth.json`
+
+> **注意：** DeepSeek 不提供订阅式 OAuth 登录，仅支持通过 API Key 认证。
+
+#### 3. 运行并选择模型
+
+- 进入项目目录并使用 DeepSeek 供应商运行 zot：
+
+```bash
+cd /path/to/my-project
+zot --provider deepseek
+```
+
+- 内置目录提供两个模型，均可在 TUI 中通过 `/model` 切换：
+  - `deepseek-v4-pro`（支持推理）
+  - `deepseek-v4-flash`
+
+- 也可以直接指定模型：
+
+```bash
+zot --provider deepseek --model deepseek-v4-flash
+```
+
+- 使用自定义兼容端点（镜像、网关或自托管）：
+
+```bash
+zot --provider deepseek \
+    --base-url https://my-deepseek-mirror.example.com/v1 \
+    --api-key "$DEEPSEEK_API_KEY"
+```
+
+#### 4. 添加自定义模型（可选）
+
+在 `$ZOT_HOME` 目录中放置 `models.json` 文件，可以添加内置目录之外的模型：
+
+- **macOS**：`~/Library/Application Support/zot/models.json`
+- **Linux**：`~/.local/state/zot/models.json`
+- **Windows**：`%LOCALAPPDATA%\zot\models.json`
+
+```json
+{
+  "providers": {
+    "deepseek": {
+      "models": [
+        {
+          "id": "deepseek-v5-preview",
+          "name": "DeepSeek V5 Preview",
+          "reasoning": true,
+          "contextWindow": 128000,
+          "maxTokens": 8192
+        }
+      ]
+    }
+  }
+}
+```
+
+> **关于纯文本模式的说明：** DeepSeek 的 chat-completions 接口当前不支持多模态内容格式。当前激活的供应商为 `deepseek` 时，zot 会自动从外发消息中移除图片部分，仅保留文本内容。切换回支持视觉的模型后，由于会话文件仍保留了图片数据，图片会被正常重新发送。
+
+更多配置选项请参阅 [zot README](https://github.com/patriceckhart/zot/blob/main/README.md)。


### PR DESCRIPTION
Adds [zot](https://github.com/patriceckhart/zot) to the awesome-deepseek-agent list.

zot is a lightweight coding agent harness written in Go (single static binary) with built-in DeepSeek support via DeepSeek's OpenAI-compatible chat API.

### Changes

- `docs/zot.md` — English integration guide (install, configure DeepSeek, run, custom models)
- `docs/zot.zh-CN.md` — Simplified Chinese translation
- `README.md` — Added zot row to the agents table

The guide structure follows the conventions used in existing entries (e.g. `docs/pi_mono.md`).