### PR TITLE
Add GitHub repo link for Co-Pilot extension installation

### DIFF
--- a/docs/github_copilot.md
+++ b/docs/github_copilot.md
@@ -8,7 +8,7 @@
 
 - Install [VS Code](https://code.visualstudio.com/) 1.116 or later.
 - Make sure you have a GitHub Copilot subscription (Free / Pro / Enterprise — the free tier works).
-- Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot) or its [Github repo](https://github.com/Vizards/deepseek-v4-for-copilot)
+- Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot) or its [GitHub repo](https://github.com/Vizards/deepseek-v4-for-copilot)
 
 #### 2. Get a DeepSeek API Key
 

--- a/docs/github_copilot.md
+++ b/docs/github_copilot.md
@@ -8,7 +8,7 @@
 
 - Install [VS Code](https://code.visualstudio.com/) 1.116 or later.
 - Make sure you have a GitHub Copilot subscription (Free / Pro / Enterprise — the free tier works).
-- Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot) or its [GitHub repo](https://github.com/Vizards/deepseek-v4-for-copilot)
+- Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot) or its [GitHub repo](https://github.com/Vizards/deepseek-v4-for-copilot).
 
 #### 2. Get a DeepSeek API Key
 

--- a/docs/github_copilot.md
+++ b/docs/github_copilot.md
@@ -8,7 +8,7 @@
 
 - Install [VS Code](https://code.visualstudio.com/) 1.116 or later.
 - Make sure you have a GitHub Copilot subscription (Free / Pro / Enterprise — the free tier works).
-- Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot).
+- Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot) or its [Github repo](https://github.com/Vizards/deepseek-v4-for-copilot)
 
 #### 2. Get a DeepSeek API Key
 


### PR DESCRIPTION
Updated installation instructions for the extension to include the GitHub repository link. 

Currently the marketplace link is broken, so this helps people to find the VSIX file they can use to install it.

See issue: https://github.com/deepseek-ai/awesome-deepseek-agent/issues/71


