### PR TITLE
Add HalfCopilot integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
+| **HalfCopilot** | Open-source multi-model agent framework CLI with a beautiful chat interface, built-in tools, skills, MCP, and memory. | [Guide](./docs/halfcopilot.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,6 +26,7 @@
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
+| **HalfCopilot** | 开源多模型 Agent 框架 CLI，提供漂亮的聊天界面，内置工具、技能、MCP 和记忆系统。 | [指南](./docs/halfcopilot.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |

--- a/docs/halfcopilot.md
+++ b/docs/halfcopilot.md
@@ -1,0 +1,102 @@
+[English](./halfcopilot.md) | [简体中文](./halfcopilot.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with HalfCopilot
+
+HalfCopilot is an open-source multi-model agent framework CLI with a beautiful chat interface. It supports DeepSeek, MiniMax, Qwen, OpenAI, and Anthropic providers with built-in tools, a skills system, MCP protocol, and persistent memory.
+
+#### 1. Install HalfCopilot
+
+- Install [Node.js](https://nodejs.org/en/download/) 20+.
+- Run the following command in your terminal to install HalfCopilot:
+
+```bash
+npm install -g halfcopilot
+```
+
+- After installation, verify the installation:
+
+```bash
+halfcop --version
+```
+
+#### 2. Configure DeepSeek Provider
+
+HalfCopilot stores its configuration at `~/.halfcopilot/settings.json`. Run the interactive setup to add DeepSeek:
+
+```bash
+halfcop setup
+```
+
+Select **DeepSeek** from the provider list, then enter your API key. The setup automatically configures the following models:
+
+| Model | Context Window | Max Output |
+|-------|---------------|------------|
+| `deepseek-v4-pro` | 131,072 (1M via API) | 8,192 |
+| `deepseek-v4-flash` | 131,072 (1M via API) | 8,192 |
+| `deepseek-chat` | 65,536 | 8,192 |
+| `deepseek-reasoner` | 65,536 | 8,192 |
+
+> **Note:** DeepSeek V4 models support up to **1 million tokens** of context through the API. The `context_window` in HalfCopilot's config reflects the guaranteed limit for prompt caching and sliding window management.
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+#### 3. Run and Select Model
+
+- Start the interactive chat:
+
+```bash
+halfcop
+```
+
+- Use `/model` to list available models and switch by number or name:
+
+```bash
+/model                # List models with indices
+/model 2              # Switch by index
+/model deepseek-v4-pro # Switch by name
+```
+
+- Use `/provider` to switch between configured providers:
+
+```bash
+/provider deepseek    # Switch to DeepSeek
+```
+
+#### 4. Using Agent Features
+
+HalfCopilot provides an agent loop with tool execution, thinking mode support, and skills:
+
+- **Tool use**: File operations, bash, grep, glob — auto-approved or confirmed based on permissions.
+- **Thinking mode**: DeepSeek V4 models with `<think>` tags are rendered inline in the chat interface.
+- **Skills**: Built-in skills for git commits, test running, code review, documentation generation, and refactoring.
+- **MCP support**: Connect external tools via the MCP protocol (configured in `settings.json`).
+
+#### 5. Single Command Mode
+
+Run a single prompt without entering interactive mode:
+
+```bash
+halfcop run "Explain this codebase"
+halfcop run --provider deepseek --model deepseek-v4-pro "Review this file"
+```
+
+#### Configuration Reference
+
+```json
+{
+  "defaultProvider": "deepseek",
+  "defaultModel": "deepseek-v4-pro",
+  "providers": {
+    "deepseek": {
+      "type": "openai-compatible",
+      "baseUrl": "https://api.deepseek.com",
+      "apiKey": "sk-...",
+      "models": {
+        "deepseek-v4-pro": { "contextWindow": 131072, "maxOutput": 8192 },
+        "deepseek-v4-flash": { "contextWindow": 131072, "maxOutput": 8192 }
+      }
+    }
+  },
+  "maxTurns": 50
+}
+```

--- a/docs/halfcopilot.zh-CN.md
+++ b/docs/halfcopilot.zh-CN.md
@@ -1,0 +1,102 @@
+[English](./halfcopilot.md) | [简体中文](./halfcopilot.zh-CN.md) · [← Back](../README.zh-CN.md)
+
+# 集成 HalfCopilot
+
+HalfCopilot 是一个开源的**多模型 Agent 框架 CLI**，提供漂亮的聊天界面，支持 DeepSeek、MiniMax、Qwen、OpenAI、Anthropic 等多家模型供应商，内置工具系统、技能系统、MCP 协议和持久化记忆能力。
+
+#### 1. 安装 HalfCopilot
+
+- 安装 [Node.js](https://nodejs.org/en/download/) 20+。
+- 在终端中运行以下命令安装 HalfCopilot：
+
+```bash
+npm install -g halfcopilot
+```
+
+- 安装完成后验证版本：
+
+```bash
+halfcop --version
+```
+
+#### 2. 配置 DeepSeek 供应商
+
+HalfCopilot 的配置文件位于 `~/.halfcopilot/settings.json`。运行交互式配置来添加 DeepSeek：
+
+```bash
+halfcop setup
+```
+
+在厂商列表中选择 **DeepSeek**，然后输入你的 API Key。配置工具会自动设置以下模型：
+
+| 模型 | 上下文窗口 | 最大输出 |
+|------|-----------|---------|
+| `deepseek-v4-pro` | 131,072（API 支持 1M） | 8,192 |
+| `deepseek-v4-flash` | 131,072（API 支持 1M） | 8,192 |
+| `deepseek-chat` | 65,536 | 8,192 |
+| `deepseek-reasoner` | 65,536 | 8,192 |
+
+> **注意：** DeepSeek V4 系列 API 支持高达 **100 万 token** 上下文。HalfCopilot 配置中的 `context_window` 是 prompt 缓存和滑动窗口管理的有保障限制。
+
+从 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
+
+#### 3. 运行与切换模型
+
+- 启动交互式聊天：
+
+```bash
+halfcop
+```
+
+- 使用 `/model` 查看可用模型并通过编号或名称切换：
+
+```bash
+/model                # 列出模型及编号
+/model 2              # 按编号切换
+/model deepseek-v4-pro # 按名称切换
+```
+
+- 使用 `/provider` 在已配置的厂商间切换：
+
+```bash
+/provider deepseek
+```
+
+#### 4. 使用 Agent 功能
+
+HalfCopilot 提供完整的 Agent 循环，包含工具执行、思考模式和技能系统：
+
+- **工具使用**：文件操作、bash、grep、glob —— 基于权限自动批准或需确认。
+- **思考模式**：DeepSeek V4 模型的 `<think>` 标签内容会在聊天界面中内联渲染。
+- **技能系统**：内置 git 提交、测试运行、代码审查、文档生成和重构技能。
+- **MCP 支持**：通过 MCP 协议连接外部工具（在 `settings.json` 中配置）。
+
+#### 5. 单命令模式
+
+无需进入交互模式，直接执行单个 prompt：
+
+```bash
+halfcop run "解释这段代码"
+halfcop run --provider deepseek --model deepseek-v4-pro "Review this file"
+```
+
+#### 配置参考
+
+```json
+{
+  "defaultProvider": "deepseek",
+  "defaultModel": "deepseek-v4-pro",
+  "providers": {
+    "deepseek": {
+      "type": "openai-compatible",
+      "baseUrl": "https://api.deepseek.com",
+      "apiKey": "sk-...",
+      "models": {
+        "deepseek-v4-pro": { "contextWindow": 131072, "maxOutput": 8192 },
+        "deepseek-v4-flash": { "contextWindow": 131072, "maxOutput": 8192 }
+      }
+    }
+  },
+  "maxTurns": 50
+}
+```


### PR DESCRIPTION
## Add HalfCopilot Integration Guide

HalfCopilot is an open-source multi-model agent framework CLI with a beautiful chat interface, supporting DeepSeek, MiniMax, Qwen, OpenAI, and Anthropic providers.

### Checklist

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] Model names are current (deepseek-v4-pro / deepseek-v4-flash)
- [x] Pricing not included (tool is free and open-source)
- [x] 1M context window mentioned
- [x] Max thinking effort is supported (DeepSeek reasoning via `<think>` tags)
- [x] Config fields are verified to work in the agent

### Files changed
- `docs/halfcopilot.md` — English guide
- `docs/halfcopilot.zh-CN.md` — Chinese guide
- `README.md` — added table entry
- `README.zh-CN.md` — added table entry