### PR TITLE
docs: fix GitHub Copilot extension reference

### DIFF
--- a/docs/github_copilot.md
+++ b/docs/github_copilot.md
@@ -2,13 +2,13 @@
 
 # Integrate with GitHub Copilot
 
-**DeepSeek V4 for Copilot Chat** is a VS Code extension that adds DeepSeek V4 Pro & Flash directly into the GitHub Copilot Chat model picker. You keep Copilot's agent mode, tool calling, skills, and MCP — all powered by DeepSeek.
+**DeepSeek V4 Native Provider for Copilot Chat** is a VS Code extension that adds DeepSeek V4 Pro & Flash directly into the GitHub Copilot Chat model picker. You keep Copilot's agent mode, tool calling, skills, and MCP — all powered by DeepSeek.
 
 #### 1. Install the Extension
 
 - Install [VS Code](https://code.visualstudio.com/) 1.116 or later.
 - Make sure you have a GitHub Copilot subscription (Free / Pro / Enterprise — the free tier works).
-- Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot).
+- Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Laurent00TT.deepseek-v4-vscode-chat).
 
 #### 2. Get a DeepSeek API Key
 

--- a/docs/github_copilot.zh-CN.md
+++ b/docs/github_copilot.zh-CN.md
@@ -2,13 +2,13 @@
 
 # 接入 GitHub Copilot
 
-**DeepSeek V4 for Copilot Chat** 是一个 VS Code 插件，将 DeepSeek V4 Pro 和 Flash 直接添加到 GitHub Copilot 的模型选择器中。你仍可使用 Copilot 的 Agent 模式、工具调用、Skills 和 MCP — 全部由 DeepSeek 驱动。
+**DeepSeek V4 Native Provider for Copilot Chat** 是一个 VS Code 插件，将 DeepSeek V4 Pro 和 Flash 直接添加到 GitHub Copilot 的模型选择器中。你仍可使用 Copilot 的 Agent 模式、工具调用、Skills 和 MCP — 全部由 DeepSeek 驱动。
 
 #### 1. 安装插件
 
 - 安装 [VS Code](https://code.visualstudio.com/) 1.116 或更高版本。
 - 确保已有 GitHub Copilot 订阅（Free / Pro / Enterprise 均可，免费版即可使用）。
-- 从 [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot) 安装插件。
+- 从 [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Laurent00TT.deepseek-v4-vscode-chat) 安装插件。
 
 #### 2. 获取 DeepSeek API Key
 


### PR DESCRIPTION
## Summary

- Fixes the GitHub Copilot guide to reference the correct DeepSeek VS Code extension.
- Updates the extension name and Marketplace item in both English and Chinese guides.
- Scope is intentionally limited to plugin reference corrections only.

## Why

The previous guide referenced a different extension, which can lead users to install the wrong plugin.

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names) (N/A: docs-only change)
- [x] 1M context is configured or mentioned (N/A: docs-only change)
- [x] Max thinking effort level is supported (N/A: docs-only change)
- [x] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing) (N/A: docs-only change)
- [x] Config fields are verified to work in the agent (N/A: docs-only change)
- [x] No workarounds for already-fixed upstream bugs (N/A: docs-only change)

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order (N/A: README unchanged)
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in docs/assets/ with descriptive filenames and reasonable sizes (N/A: no images)