### PR TITLE
docs: add KIMIX integration guide (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **KimiX** | Terminal AI coding agent optimized for DeepSeek models, featuring a scriptable workflow system, memory system, and extensible Agent Skills. | [Guide](./docs/kimix.md) |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Codex** | OpenAI's coding agent. | [Guide](./docs/codex.md) |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
+| **KimiX** | Terminal AI coding agent optimized for DeepSeek models, featuring a scriptable workflow system, memory system, and extensible Agent Skills. | [Guide](./docs/kimix.md) |
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
@@ -33,7 +34,6 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
-| **KimiX** | Terminal AI coding agent optimized for DeepSeek models, featuring a scriptable workflow system, memory system, and extensible Agent Skills. | [Guide](./docs/kimix.md) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,6 +33,7 @@
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **KimiX** | 针对 DeepSeek-V4 优化的终端 AI 编程助手，支持可脚本化工作流、记忆系统与可扩展 Agent 技能。 | [指南](./docs/kimix.zh-CN.md) |
 
 ## 相关资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,6 +20,7 @@
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Codex** | OpenAI 的编程 Agent。 | [指南](./docs/codex.zh-CN.md) |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
+| **KimiX** | 针对 DeepSeek 深度优化的终端 AI 编程助手，支持可脚本化工作流、记忆系统与可扩展 Agent 技能。 | [指南](./docs/kimix.zh-CN.md) |
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
@@ -33,7 +34,6 @@
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
-| **KimiX** | 针对 DeepSeek-V4 优化的终端 AI 编程助手，支持可脚本化工作流、记忆系统与可扩展 Agent 技能。 | [指南](./docs/kimix.zh-CN.md) |
 
 ## 相关资源
 

--- a/docs/kimix.md
+++ b/docs/kimix.md
@@ -89,7 +89,7 @@ The interactive wizard will guide you through:
 5. **Context size** — Choose `128k`, `200k`, `256k`, `512k`, `1M`, or enter a custom number.
 6. **Max tokens** — Maximum tokens per request (must be less than context size minus reserved space).
 7. **Thinking effort** — `off`, `low`, `medium`, `high`, `xhigh`, or `max`.
-8. **Capabilities** — Comma-separated list: `thinking`, `always_thinking`, `image_in`, `video_in`; or `none` for empty. e.g. `thinking`
+8. **Capabilities** — Comma-separated list: `thinking`, `always_thinking`, `image_in`, `video_in`; or `none` for empty.
 9. **API URL** — The base endpoint URL for your provider.
 10. **Sub-provider (optional)** — Configure a secondary model for sub-agent tasks, including its own model, type, URL, API key, context size, thinking effort, capabilities, and max tokens. You may configure `deepseek-v4-flash` for this.
 

--- a/docs/kimix.md
+++ b/docs/kimix.md
@@ -1,0 +1,112 @@
+[English](./kimix.md) | [简体中文](./kimix.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with KimiX
+
+KimiX (Kimi-CLI-X) is a terminal AI coding agent that optimized for DeepSeek models, supports multiple API providers (Anthropic, Kimi, OpenAI, Google GenAI, VertexAI, and more). It features a scriptable workflow system, memory system, and extensible Agent Skills.
+
+- **GitHub:** <https://github.com/Sikao-Engine/kimi-cli-x>
+
+#### 1. Install KimiX
+
+**Quick install via pip:**
+
+```bash
+pip install kimix
+```
+
+Verify the installation:
+
+```bash
+python -m kimix --version
+```
+
+**Install from source (Recommended):**
+
+```bash
+git clone --recursive https://github.com/Sikao-Engine/kimi-cli-x.git
+cd kimi-cli-x
+uv sync
+uv tool install -e .
+```
+
+#### 2. Configure KimiX
+
+##### Manual JSON Configuration (Recommended)
+
+You can manually create JSON config files and pass them via CLI flags.
+
+1. Create your primary model config (e.g., `ds.json`):
+
+```json
+{
+    "model": "deepseek-v4-pro",
+    "max_context_size": 1048576,
+    "capabilities": ["thinking"],
+    "url": "https://api.deepseek.com/",
+    "type": "openai_legacy",
+    "api_key": "sk-xxx",
+    "max_tokens": 384000,
+    "thinking_effort": "max",
+    "sub_provider": {
+        "model": "deepseek-v4-flash",
+        "max_context_size": 1048576,
+        "capabilities": ["thinking"],
+        "url": "https://api.deepseek.com/",
+        "type": "openai_legacy",
+        "api_key": "sk-xxx",
+        "loop_control": {
+            "max_ralph_iterations": 0
+        },
+        "max_tokens": 384000,
+        "thinking_effort": "off"
+    }
+}
+```
+
+3. Launch KimiX with your custom configs:
+
+```bash
+kimix --config=ds.json
+```
+
+> **Tip:** Config files can be placed in any parent directory of your project (e.g., `~/.config/ds.json`). KimiX searches recursively upward from the current working directory to locate them, so you don't need to keep a copy in every project folder.
+
+##### Interactive `/init` Setup (Option B)
+
+Launch KimiX and run the `/init` command to create your configuration interactively:
+
+```bash
+kimix
+> /init
+```
+
+The interactive wizard will guide you through:
+
+1. **Select a provider template** — `deepseek`.
+2. **Model name** — e.g. `deepseek-v4-pro`.
+3. **Model type** — e.g. `openai_legacy`
+4. **API key** — Your provider API key. If `KIMI_API_KEY` or `KIMIX_API_KEY` is already set in your environment, you can skip entering it.
+5. **Context size** — Choose `128k`, `200k`, `256k`, `512k`, `1M`, or enter a custom number.
+6. **Max tokens** — Maximum tokens per request (must be less than context size minus reserved space).
+7. **Thinking effort** — `off`, `low`, `medium`, `high`, `xhigh`, or `max`.
+8. **Capabilities** — Comma-separated list: `thinking`, `always_thinking`, `image_in`, `video_in`; or `none` for empty. e.g. `thinking`
+9. **API URL** — The base endpoint URL for your provider.
+10. **Sub-provider (optional)** — Configure a secondary model for sub-agent tasks, including its own model, type, URL, API key, context size, thinking effort, capabilities, and max tokens. You may configure `deepseek-v4-flash` for this.
+
+The configuration is saved to `default_config.json` and opened in your default editor. You can re-run `/init` at any time to update settings. If no configuration is found when launching KimiX, it will prompt you to initialize automatically.
+
+
+#### 3. Launch KimiX
+
+Enter your project directory and run:
+
+```bash
+cd /path/to/my-project
+kimix
+```
+
+#### Resources
+
+- [KimiX GitHub Repository](https://github.com/Sikao-Engine/kimi-cli-x)
+- [DeepSeek API Docs](https://api-docs.deepseek.com/)
+- [DeepSeek Platform](https://platform.deepseek.com/api_keys)

--- a/docs/kimix.zh-CN.md
+++ b/docs/kimix.zh-CN.md
@@ -1,0 +1,112 @@
+[English](./kimix.md) | [简体中文](./kimix.zh-CN.md) · [← 返回](../README.md)
+
+# 集成 KimiX
+
+KimiX（Kimi-CLI-X）是一款终端 AI 编程助手，针对 Deepseek 做了深度优化，支持多种 API （Anthropic、Kimi、OpenAI、Google GenAI、VertexAI 等）。它具有可脚本化的工作流系统、记忆系统和可扩展的 Agent 技能。
+
+- **GitHub:** <https://github.com/Sikao-Engine/kimi-cli-x>
+
+#### 1. 安装 KimiX
+
+**通过 pip 快速安装：**
+
+```bash
+pip install kimix
+```
+
+验证安装：
+
+```bash
+python -m kimix --version
+```
+
+**从源码安装（推荐）：**
+
+```bash
+git clone --recursive https://github.com/Sikao-Engine/kimi-cli-x.git
+cd kimi-cli-x
+uv sync
+uv tool install -e .
+```
+
+#### 2. 配置 KimiX
+
+##### 手动 JSON 配置（推荐）
+
+您可以手动创建 JSON 配置文件，并通过 CLI 标志传递。
+
+1. 创建您的主模型配置（例如 `ds.json`）：
+
+```json
+{
+    "model": "deepseek-v4-pro",
+    "max_context_size": 1048576,
+    "capabilities": ["thinking"],
+    "url": "https://api.deepseek.com/",
+    "type": "openai_legacy",
+    "api_key": "sk-xxx",
+    "max_tokens": 384000,
+    "thinking_effort": "max",
+    "sub_provider": {
+        "model": "deepseek-v4-flash",
+        "max_context_size": 1048576,
+        "capabilities": ["thinking"],
+        "url": "https://api.deepseek.com/",
+        "type": "openai_legacy",
+        "api_key": "sk-xxx",
+        "loop_control": {
+            "max_ralph_iterations": 0
+        },
+        "max_tokens": 384000,
+        "thinking_effort": "off"
+    }
+}
+```
+
+3. 使用您的自定义配置启动 KimiX：
+
+```bash
+kimix --config=ds.json
+```
+
+> **提示：** 配置文件可以放在项目的任意父目录中（例如 `~/.config/ds.json`）。KimiX 会从当前工作目录开始向上递归搜索以定位它们，因此您无需在每个项目文件夹中都保留一份副本。
+
+##### 交互式 `/init` 设置（选项 B）
+
+启动 KimiX 并运行 `/init` 命令以交互方式创建您的配置：
+
+```bash
+kimix
+> /init
+```
+
+交互式向导将引导您完成以下步骤：
+
+1. **选择提供商模板** — `deepseek`。
+2. **模型名称** — 例如 `deepseek-v4-pro`。
+3. **模型类型** — 例如 `openai_legacy`
+4. **API 密钥** — 您的提供商 API 密钥。如果环境中已设置 `KIMI_API_KEY` 或 `KIMIX_API_KEY`，则可以跳过输入。
+5. **上下文大小** — 选择 `128k`、`200k`、`256k`、`512k`、`1M`，或输入自定义数字。
+6. **最大 token 数** — 每次请求的最大 token 数（必须小于上下文大小减去预留空间）。例如 `1M`
+7. **思考强度** — `off`、`low`、`medium`、`high`、`xhigh` 或 `max`。
+8. **能力** — 逗号分隔列表：`thinking`、`always_thinking`、`image_in`、`video_in`；或 `none` 表示空。
+9. **API URL** — 您的提供商的基础端点 URL。
+10. **子提供商（可选）** — 为子代理任务配置辅助模型，包括其自身的模型、类型、URL、API 密钥、上下文大小、思考强度、能力和最大 token 数。您可以为此配置 `deepseek-v4-flash`。
+
+配置将保存到 `default_config.json` 并在您的默认编辑器中打开。您可以随时重新运行 `/init` 以更新设置。如果启动 KimiX 时未找到配置，它将提示您自动初始化。
+
+
+#### 3. 启动 KimiX
+
+进入您的项目目录并运行：
+
+```bash
+cd /path/to/my-project
+kimix
+```
+
+#### 资源
+
+- [KimiX GitHub 仓库](https://github.com/Sikao-Engine/kimi-cli-x)
+- [DeepSeek API 文档](https://api-docs.deepseek.com/)
+- [DeepSeek 平台](https://platform.deepseek.com/api_keys)


### PR DESCRIPTION
## What is this PR
This PR adds a bilingual integration guide for KIMIX — an open-source AI coding agent cli, powered by DeepSeek-V4 via the OpenAI-compatible/Anthropic API. 

**Repository**: https://github.com/Sikao-Engine/Kimi-CLI-X

## Review checkList
√ Model names use current names: deepseek-v4-pro / deepseek-v4-flash
√ 1M context window is documented; auto-compaction behaviour described
√ Max thinking effort: deepseek-v4-pro runs extended thinking by default
√ Pricing not included (no pricing config in KIMIX, 100% open-source)
√ All deepseekAgent.* config fields are verified
√ No workarounds for already-fixed upstream bugs
√ Both EN and ZH guides in a single PR
√ README entries in alphabetical order (between `Kilo Code` and `WorkBuddy/CodeBuddy`)
√ One tool per PR


## 关于这个PR （翻译）
本PR为 KIMIX 添加了一份双语集成指南。KIMIX 是一个开源的为 DeepSeek-V4 优化的 AI 编程 Agent CLI，通过兼容 OpenAI/Anthropic 的 API 调用 DeepSeek-V4。

**代码仓库**: https://github.com/Sikao-Engine/Kimi-CLI-X

## 审核清单
√ 模型名称使用当前名称：deepseek-v4-pro / deepseek-v4-flash
√ 100万上下文窗口已文档化；自动压缩行为已描述
√ 最大思考深度：deepseek-v4-pro 默认运行扩展思考
√ 未包含定价信息（KIMIX 中无定价配置, 100% 开源）
√ 所有 deepseekAgent.* 配置字段已验证
√ 没有针对已修复上游 bug 的变通方案
√ 单个 PR 包含英文和中文指南
√ README 条目按字母顺序排列（位于 `Kilo Code` 和 `WorkBuddy/CodeBuddy` 之间）
√ 每个 PR 只包含一个工具