### PR TITLE
Add GoAgent integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
+| **GoAgent** | Open-source Go / Weiqi / Baduk agent that combines KataGo, board evidence, local knowledge, and LLM tools for grounded teaching. | [Guide](./docs/goagent.md) |
 | **Codex** | OpenAI's coding agent. | [Guide](./docs/codex.md) |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,6 +18,7 @@
 | **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
+| **GoAgent** | 开源围棋智能体，结合 KataGo、棋盘证据、本地知识库与 LLM 工具，为学生提供有证据的讲棋与训练建议。 | [指南](./docs/goagent.zh-CN.md) |
 | **Codex** | OpenAI 的编程 Agent。 | [指南](./docs/codex.zh-CN.md) |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |

--- a/docs/goagent.md
+++ b/docs/goagent.md
@@ -1,0 +1,60 @@
+[English](./goagent.md) | [简体中文](./goagent.zh-CN.md) · [← Back](../README.md)
+
+# Integrate DeepSeek with GoAgent
+
+[GoAgent](https://github.com/wimi321/GoAgent) is an open-source Go / Weiqi / Baduk agent. It combines KataGo analysis, board evidence, local knowledge, student profiles, and LLM tool use so the teacher can explain moves from evidence instead of guessing.
+
+GoAgent can use DeepSeek through its OpenAI-compatible LLM provider. For current-move reviews that attach board screenshots, use a DeepSeek-compatible endpoint or proxy that supports image input. If your endpoint is text-only, DeepSeek is still useful for SGF, KataGo, knowledge-base, and tool-grounded teaching tasks.
+
+#### 1. Install GoAgent
+
+Download the latest desktop release from [GoAgent Releases](https://github.com/wimi321/GoAgent/releases).
+
+To run from source:
+
+```
+git clone https://github.com/wimi321/GoAgent.git
+cd GoAgent
+pnpm install
+pnpm dev
+```
+
+#### 2. Get a DeepSeek API Key
+
+Create an API key in the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+#### 3. Configure DeepSeek in GoAgent
+
+Open **Settings** in GoAgent and configure the LLM provider:
+
+- **Base URL**: `https://api.deepseek.com`
+- **API Key**: your DeepSeek API key
+- **Model**: `deepseek-v4-pro` or `deepseek-v4-flash`
+
+If GoAgent shows a model refresh or connection test button, use it after saving the credentials.
+
+For long game reviews, prefer DeepSeek V4's 1M context mode when your endpoint exposes it. If your compatible proxy supports `reasoning_effort`, use `max` with `deepseek-v4-pro` for deeper reviews, and use `high` or the provider default for faster interactive teaching.
+
+#### 4. Start a Teaching Session
+
+In GoAgent:
+
+1. Import an SGF file or load a game from the game library.
+2. Make sure KataGo is configured and the win-rate graph has analysis data.
+3. Ask the teacher to analyze the current move, a move range, or the full game.
+
+Example prompts:
+
+```
+Analyze the current move using KataGo evidence and local knowledge.
+Find the three most important turning points in this game.
+Review moves 80-120 and explain what the student should train next.
+```
+
+GoAgent's teacher can call tools for game records, KataGo analysis, trace packets, board images, knowledge retrieval, and student profiles. The final answer should be grounded in tool results rather than unsupported claims.
+
+#### 5. Notes
+
+- Do not send private games to an external model provider unless you are comfortable with that provider's data policy.
+- Use `deepseek-v4-flash` for lower-latency chat and `deepseek-v4-pro` for deeper reviews.
+- For image-based board reading, make sure the selected OpenAI-compatible endpoint accepts image messages.

--- a/docs/goagent.zh-CN.md
+++ b/docs/goagent.zh-CN.md
@@ -1,0 +1,60 @@
+[English](./goagent.md) | [简体中文](./goagent.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 在 GoAgent 中接入 DeepSeek
+
+[GoAgent](https://github.com/wimi321/GoAgent) 是一个开源的围棋智能体，面向 Go / Weiqi / Baduk 学习与复盘场景。它结合 KataGo 分析、棋盘证据、本地知识库、学生画像和 LLM 工具调用，让老师基于证据讲棋，而不是凭空猜测。
+
+GoAgent 可以通过 OpenAI-compatible LLM Provider 接入 DeepSeek。对于需要棋盘截图的当前手讲解，请使用支持图片输入的 DeepSeek 兼容端点或代理；如果你的端点只支持文本，DeepSeek 仍然可以用于 SGF、KataGo 数据、知识库和工具结果驱动的讲解任务。
+
+#### 1. 安装 GoAgent
+
+从 [GoAgent Releases](https://github.com/wimi321/GoAgent/releases) 下载最新版桌面应用。
+
+也可以从源码运行：
+
+```
+git clone https://github.com/wimi321/GoAgent.git
+cd GoAgent
+pnpm install
+pnpm dev
+```
+
+#### 2. 获取 DeepSeek API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 创建 API Key。
+
+#### 3. 在 GoAgent 中配置 DeepSeek
+
+打开 GoAgent 的 **设置**，配置 LLM Provider：
+
+- **Base URL**：`https://api.deepseek.com`
+- **API Key**：你的 DeepSeek API Key
+- **模型**：`deepseek-v4-pro` 或 `deepseek-v4-flash`
+
+保存后，如果 GoAgent 提供模型刷新或连接测试按钮，可以先执行一次测试。
+
+做长棋局复盘时，如果端点支持 DeepSeek V4 的 100 万 token 上下文，建议优先开启。若兼容代理支持 `reasoning_effort`，深度复盘可为 `deepseek-v4-pro` 选择 `max`；日常快速讲棋可选择 `high` 或保持服务商默认设置。
+
+#### 4. 开始讲棋
+
+在 GoAgent 中：
+
+1. 导入 SGF，或从棋谱库载入棋局。
+2. 确认 KataGo 已配置，并且胜率图已有分析数据。
+3. 让老师分析当前手、指定手数区间或整盘棋。
+
+示例：
+
+```
+结合 KataGo 证据和本地知识库分析当前手。
+找出这盘棋最重要的三个转折点。
+复盘 80-120 手，并告诉我学生下一步应该练什么。
+```
+
+GoAgent 老师可以调用棋谱、KataGo 分析、Trace Packet、棋盘图片、知识库检索和学生画像等工具。最终讲解应以工具结果为依据，而不是没有证据的判断。
+
+#### 5. 注意事项
+
+- 如果棋谱包含隐私内容，请确认你愿意把相关文本或图片发送给所选择的模型服务商。
+- 想要更低延迟，可以使用 `deepseek-v4-flash`；想要更深入的复盘，可以使用 `deepseek-v4-pro`。
+- 如果需要基于棋盘截图读图，请确认当前 OpenAI-compatible 端点支持图片消息。


### PR DESCRIPTION
## Summary

Adds a bilingual DeepSeek integration guide for GoAgent, an open-source Go / Weiqi / Baduk agent that combines KataGo analysis, board evidence, local knowledge, and LLM tool use for grounded teaching.

## Changes

- Add GoAgent to the English and Simplified Chinese tool tables.
- Add `docs/goagent.md` and `docs/goagent.zh-CN.md`.
- Document DeepSeek V4 Pro/Flash model names, 1M context guidance, and `reasoning_effort` suggestions where supported.
- Clarify the image-input boundary for board screenshot reviews while keeping DeepSeek usable for SGF, KataGo, knowledge-base, and tool-grounded teaching tasks.

## Checks

- Confirmed no deprecated DeepSeek model names were introduced.
- Ran `git diff --check`.
