### PR TITLE
docs: add DeepSeekX integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **DeepSeekX** | Codex-derived terminal coding agent adapted for DeepSeek-V4, with direct DeepSeek API access, sandboxed tools, MCP, and 1M-context model metadata. | [Guide](./docs/deepseekx.md) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,6 +33,7 @@
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **DeepSeekX** | 基于 Codex 改造的终端编程 Agent，面向 DeepSeek-V4 适配，支持直接访问 DeepSeek API、沙箱化工具、MCP 与 100 万 token 模型元数据。 | [指南](./docs/deepseekx.zh-CN.md) |
 
 ## 相关资源
 

--- a/docs/deepseekx.md
+++ b/docs/deepseekx.md
@@ -1,0 +1,122 @@
+[English](./deepseekx.md) | [简体中文](./deepseekx.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with DeepSeekX
+
+DeepSeekX is a downstream adaptation of OpenAI Codex CLI for DeepSeek API
+usage. It does not redesign the Codex core agent workflow; the main change is
+a DeepSeek `/chat/completions` adapter plus DeepSeek-oriented provider, model,
+packaging, and user-facing defaults.
+
+- **GitHub:** <https://github.com/meomeo-dev/deepseekx>
+
+#### 1. Install DeepSeekX
+
+- Install [Node.js](https://nodejs.org/en/download/) 18+.
+- Install the CLI from npm:
+
+```sh
+npm install -g @meomeo-dev/deepseekx
+```
+
+Verify the installation:
+
+```sh
+deepseekx --version
+```
+
+#### 2. Get a DeepSeek API Key
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+DeepSeekX reads it from the `DEEPSEEK_API_KEY` environment variable:
+
+```sh
+export DEEPSEEK_API_KEY="sk-..."
+```
+
+#### 3. Start in a project directory
+
+```sh
+cd /path/to/my-project
+deepseekx
+```
+
+DeepSeekX uses `~/.deepseekx` as its default user directory and
+`.deepseekx/config.toml` for project-level settings. It does not read the
+upstream Codex user directory by default.
+
+#### 4. Optional configuration
+
+Create `~/.deepseekx/config.toml`:
+
+```toml
+model_provider = "deepseek"
+model = "deepseek-v4-pro"
+model_reasoning_effort = "xhigh"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "https://api.deepseek.com"
+env_key = "DEEPSEEK_API_KEY"
+wire_api = "chat"
+requires_openai_auth = false
+```
+
+DeepSeekX exposes `deepseek-v4-pro` and `deepseek-v4-flash`. Its built-in model
+metadata uses a 384K default context window and a 1M maximum context window for
+DeepSeek V4. Reasoning effort supports `high` and `xhigh`; `xhigh` maps to
+DeepSeek's max reasoning effort.
+
+Because the Codex configuration model is kept aligned with upstream Codex, most
+`config.toml` concepts such as profiles, sandbox mode, approval policy, MCP,
+tools, and project configuration follow the Codex configuration documentation.
+Adjust only the DeepSeek-specific provider, model, API key, and config
+directory values shown above.
+
+#### Project profiles
+
+Create `.deepseekx/config.toml` in a repository:
+
+```toml
+model = "deepseek-v4-flash"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[profiles.pro]
+model_provider = "deepseek"
+model = "deepseek-v4-pro"
+model_reasoning_effort = "xhigh"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+```
+
+Run a profile:
+
+```sh
+deepseekx --profile pro
+```
+
+#### Features
+
+- Direct DeepSeek Chat Completions integration, no local translation proxy
+  required.
+- Sandboxed local command execution with approval controls.
+- MCP client support for configured MCP servers and tools.
+- Project-level config under `.deepseekx/config.toml`.
+- DeepSeek-specific model catalog, tool instructions, and prompt templates.
+
+#### Troubleshooting
+
+- `401` or authentication errors: check `DEEPSEEK_API_KEY`.
+- `402` or payment errors: check your DeepSeek Platform balance.
+- Config changes do not apply: confirm whether the value is set in the command
+  line, project config, or user config. DeepSeekX applies command-line
+  overrides first, then project config, then user config.
+- Tool execution is blocked: review `approval_policy` and `sandbox_mode`.
+
+#### Resources
+
+- [DeepSeekX](https://github.com/meomeo-dev/deepseekx)
+- [Codex configuration reference](https://developers.openai.com/codex/config-reference)
+- [DeepSeek API Docs](https://api-docs.deepseek.com/)

--- a/docs/deepseekx.zh-CN.md
+++ b/docs/deepseekx.zh-CN.md
@@ -1,0 +1,116 @@
+[English](./deepseekx.md) | [简体中文](./deepseekx.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 DeepSeekX
+
+DeepSeekX 是 OpenAI Codex CLI 的 DeepSeek 下游适配版本。它不重新设计
+Codex core agent workflow；主要改动是增加 DeepSeek `/chat/completions`
+接口适配，并默认使用 DeepSeek 相关的 provider、model、打包和用户界面行为。
+
+- **GitHub：** <https://github.com/meomeo-dev/deepseekx>
+
+#### 1. 安装 DeepSeekX
+
+- 安装 [Node.js](https://nodejs.org/en/download/) 18+。
+- 通过 npm 安装 CLI：
+
+```sh
+npm install -g @meomeo-dev/deepseekx
+```
+
+验证安装：
+
+```sh
+deepseekx --version
+```
+
+#### 2. 获取 DeepSeek API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API
+Key。DeepSeekX 从 `DEEPSEEK_API_KEY` 环境变量读取：
+
+```sh
+export DEEPSEEK_API_KEY="sk-..."
+```
+
+#### 3. 在项目目录启动
+
+```sh
+cd /path/to/my-project
+deepseekx
+```
+
+DeepSeekX 默认用户目录是 `~/.deepseekx`，项目级配置文件是
+`.deepseekx/config.toml`。它不会默认读取上游 Codex 的用户目录。
+
+#### 4. 可选配置
+
+创建 `~/.deepseekx/config.toml`：
+
+```toml
+model_provider = "deepseek"
+model = "deepseek-v4-pro"
+model_reasoning_effort = "xhigh"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "https://api.deepseek.com"
+env_key = "DEEPSEEK_API_KEY"
+wire_api = "chat"
+requires_openai_auth = false
+```
+
+DeepSeekX 暴露 `deepseek-v4-pro` 和 `deepseek-v4-flash`。内置模型元数据
+为 DeepSeek V4 配置 384K 默认上下文窗口和 100 万最大上下文窗口。推理强度
+支持 `high` 与 `xhigh`；`xhigh` 会映射到 DeepSeek 的 max 推理强度。
+
+由于配置模型保持与上游 Codex 对齐，`config.toml` 中的 profiles、sandbox
+mode、approval policy、MCP、tools 与项目级配置等概念，基本可以参考 Codex
+配置文档。需要替换的是上方示例中的 DeepSeek provider、model、API key 和
+配置目录。
+
+#### 项目 Profile
+
+在仓库根目录创建 `.deepseekx/config.toml`：
+
+```toml
+model = "deepseek-v4-flash"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[profiles.pro]
+model_provider = "deepseek"
+model = "deepseek-v4-pro"
+model_reasoning_effort = "xhigh"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+```
+
+使用 profile 启动：
+
+```sh
+deepseekx --profile pro
+```
+
+#### 功能特点
+
+- 直接接入 DeepSeek Chat Completions，无需本地转换代理。
+- 支持带审批控制的沙箱化本地命令执行。
+- 支持连接已配置的 MCP servers 与 tools。
+- 支持仓库级 `.deepseekx/config.toml` 配置。
+- 内置 DeepSeek 专用模型目录、工具说明和提示词模板。
+
+#### 故障排查
+
+- `401` 或鉴权错误：检查 `DEEPSEEK_API_KEY`。
+- `402` 或余额错误：检查 DeepSeek 开放平台余额。
+- 配置未生效：确认该值是否同时存在于命令行、项目配置或用户配置中。
+  DeepSeekX 的优先级是命令行、项目配置、用户配置。
+- 工具执行被拦截：检查 `approval_policy` 和 `sandbox_mode`。
+
+#### 相关资源
+
+- [DeepSeekX](https://github.com/meomeo-dev/deepseekx)
+- [Codex 配置参考](https://developers.openai.com/codex/config-reference)
+- [DeepSeek API 文档](https://api-docs.deepseek.com/zh-cn/)


### PR DESCRIPTION
See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.

## Summary

Adds a bilingual DeepSeekX integration guide.

DeepSeekX is a downstream adaptation of OpenAI Codex CLI. It preserves the
Codex core agent workflow and adapts the runtime to DeepSeek `/chat/completions`,
with DeepSeek-oriented provider, model, packaging, and user-facing defaults.

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing)
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes

## Notes

- Pricing is not included in this guide.
- No screenshots or image assets are included.
