### PR TITLE
docs: add dotcraft integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
+| **DotCraft** | Project-scoped Agent Harness where Desktop, TUI, CLI, bots, and automations share sessions, skills, tools, and observability. | [Guide](./docs/dotcraft.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,6 +26,7 @@
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
+| **DotCraft** | 项目级 Agent Harness，让 Desktop、TUI、CLI、机器人和自动化共享会话、技能、工具与可观测能力。 | [指南](./docs/dotcraft.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |

--- a/docs/dotcraft.md
+++ b/docs/dotcraft.md
@@ -23,20 +23,6 @@ Install the package for your operating system and launch DotCraft Desktop.
 
 Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
 
-For local config files, it is recommended to store the key in an environment variable:
-
-```sh
-DEEPSEEK_API_KEY="sk-your-deepseek-api-key"
-```
-
-On Windows PowerShell:
-
-```powershell
-setx DEEPSEEK_API_KEY "sk-your-deepseek-api-key"
-```
-
-Restart DotCraft Desktop after setting a new environment variable.
-
 #### 3. Configure DeepSeek in Desktop
 
 Open a real project folder as your DotCraft workspace, then open **Settings -> Model Providers** and create a provider:
@@ -47,7 +33,7 @@ Open a real project folder as your DotCraft workspace, then open **Settings -> M
 | Display name | `DeepSeek` |
 | Protocol | `openai` |
 | Endpoint | `https://api.deepseek.com/v1` |
-| API Key | `${DEEPSEEK_API_KEY}` or your DeepSeek API key |
+| API Key | Your DeepSeek API key |
 | Model | `deepseek-v4-pro` |
 | Reasoning | Enabled |
 | Reasoning effort | Extra High |

--- a/docs/dotcraft.md
+++ b/docs/dotcraft.md
@@ -1,0 +1,92 @@
+[English](./dotcraft.md) | [简体中文](./dotcraft.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with DotCraft
+
+DotCraft is a project-scoped .NET/C# Agent Harness. Desktop, TUI, CLI, bots, and automations share the same workspace sessions, skills, tools, approvals, and observability surface.
+
+- **GitHub:** <https://github.com/DotHarness/dotcraft>
+- **Documentation:** <https://dotharness.github.io/dotcraft/en/>
+
+DotCraft connects to DeepSeek through the OpenAI-compatible Chat Completions API. Its Deep Thinking adapter preserves `reasoning_content` during tool-call rounds, and DeepSeek V4 model context windows can be configured as 1,000,000 tokens.
+
+#### 1. Install DotCraft
+
+Download the latest DotCraft Desktop release from:
+
+```text
+https://github.com/DotHarness/dotcraft/releases
+```
+
+Install the package for your operating system and launch DotCraft Desktop.
+
+#### 2. Get a DeepSeek API Key
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+For local config files, it is recommended to store the key in an environment variable:
+
+```sh
+DEEPSEEK_API_KEY="sk-your-deepseek-api-key"
+```
+
+On Windows PowerShell:
+
+```powershell
+setx DEEPSEEK_API_KEY "sk-your-deepseek-api-key"
+```
+
+Restart DotCraft Desktop after setting a new environment variable.
+
+#### 3. Configure DeepSeek in Desktop
+
+Open a real project folder as your DotCraft workspace, then open **Settings -> Model Providers** and create a provider:
+
+| Field | Value |
+|-------|-------|
+| Provider id | `deepseek` |
+| Display name | `DeepSeek` |
+| Protocol | `openai` |
+| Endpoint | `https://api.deepseek.com/v1` |
+| API Key | `${DEEPSEEK_API_KEY}` or your DeepSeek API key |
+| Model | `deepseek-v4-pro` |
+| Reasoning | Enabled |
+| Reasoning effort | Extra High |
+| Context window | `1000000` tokens |
+
+Use `deepseek-v4-flash` as the lighter model option when you prefer lower latency or cost.
+
+DotCraft's built-in Deep Thinking adapter applies to DeepSeek models and DeepSeek endpoints automatically. During tool-call conversations, it round-trips the model's reasoning metadata with assistant tool calls so thinking mode remains compatible with agent workflows.
+
+#### 4. First Run
+
+In DotCraft Desktop:
+
+1. Open the project workspace.
+2. Create a new session.
+3. Select the DeepSeek provider and `deepseek-v4-pro` model if they are not already selected.
+4. Send a repository-understanding request:
+
+```text
+Read this repository's README and docs, then tell me how to start the project.
+```
+
+The session should stream an answer through DeepSeek V4 Pro. Reasoning content is displayed according to DotCraft's default reasoning display behavior.
+
+#### Other DotCraft Entry Points
+
+After Desktop setup, the same workspace configuration can be reused by other DotCraft entry points:
+
+| Entry point | Use case |
+|-------------|----------|
+| Desktop | Graphical workspace, provider setup, sessions, traces, approvals |
+| TUI | Full terminal interface connected through DotCraft AppServer |
+| CLI | One-shot project tasks and local automation commands |
+| ACP | Editor and IDE integrations through Agent Client Protocol |
+| Bots and automations | Shared workspace sessions for chat platforms and scheduled tasks |
+
+#### Resources
+
+- [DotCraft](https://github.com/DotHarness/dotcraft)
+- [DotCraft Getting Started](https://dotharness.github.io/dotcraft/en/getting-started)
+- [DotCraft Configuration Guide](https://dotharness.github.io/dotcraft/en/config_guide)
+- [DeepSeek API Docs](https://api-docs.deepseek.com/)

--- a/docs/dotcraft.zh-CN.md
+++ b/docs/dotcraft.zh-CN.md
@@ -23,20 +23,6 @@ https://github.com/DotHarness/dotcraft/releases
 
 前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
 
-如果使用本地配置文件，推荐把 API Key 放到环境变量中：
-
-```sh
-DEEPSEEK_API_KEY="sk-your-deepseek-api-key"
-```
-
-Windows PowerShell：
-
-```powershell
-setx DEEPSEEK_API_KEY "sk-your-deepseek-api-key"
-```
-
-设置新的环境变量后，请重启 DotCraft Desktop。
-
 #### 3. 在 Desktop 中配置 DeepSeek
 
 在 DotCraft 中打开一个真实项目目录作为工作区，然后进入 **Settings -> Model Providers**，创建一个 provider：
@@ -47,7 +33,7 @@ setx DEEPSEEK_API_KEY "sk-your-deepseek-api-key"
 | Display name | `DeepSeek` |
 | Protocol | `openai` |
 | Endpoint | `https://api.deepseek.com/v1` |
-| API Key | `${DEEPSEEK_API_KEY}` 或你的 DeepSeek API Key |
+| API Key | 你的 DeepSeek API Key |
 | Model | `deepseek-v4-pro` |
 | Reasoning | Enabled |
 | Reasoning effort | Extra High |

--- a/docs/dotcraft.zh-CN.md
+++ b/docs/dotcraft.zh-CN.md
@@ -1,0 +1,92 @@
+[English](./dotcraft.md) | [简体中文](./dotcraft.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 DotCraft
+
+DotCraft 是一个项目级 .NET/C# Agent Harness。Desktop、TUI、CLI、机器人与自动化入口共享同一个工作区中的会话、技能、工具、审批和可观测能力。
+
+- **GitHub：** <https://github.com/DotHarness/dotcraft>
+- **文档：** <https://dotharness.github.io/dotcraft/>
+
+DotCraft 通过 OpenAI 兼容的 Chat Completions API 接入 DeepSeek。它内置 Deep Thinking 适配器，可在工具调用轮次中保留 `reasoning_content`，并可将 DeepSeek V4 的上下文窗口配置为 100 万 token。
+
+#### 1. 安装 DotCraft
+
+从以下地址下载最新 DotCraft Desktop release：
+
+```text
+https://github.com/DotHarness/dotcraft/releases
+```
+
+安装适合你操作系统的包，然后启动 DotCraft Desktop。
+
+#### 2. 获取 DeepSeek API Key
+
+前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
+
+如果使用本地配置文件，推荐把 API Key 放到环境变量中：
+
+```sh
+DEEPSEEK_API_KEY="sk-your-deepseek-api-key"
+```
+
+Windows PowerShell：
+
+```powershell
+setx DEEPSEEK_API_KEY "sk-your-deepseek-api-key"
+```
+
+设置新的环境变量后，请重启 DotCraft Desktop。
+
+#### 3. 在 Desktop 中配置 DeepSeek
+
+在 DotCraft 中打开一个真实项目目录作为工作区，然后进入 **Settings -> Model Providers**，创建一个 provider：
+
+| 字段 | 值 |
+|------|----|
+| Provider id | `deepseek` |
+| Display name | `DeepSeek` |
+| Protocol | `openai` |
+| Endpoint | `https://api.deepseek.com/v1` |
+| API Key | `${DEEPSEEK_API_KEY}` 或你的 DeepSeek API Key |
+| Model | `deepseek-v4-pro` |
+| Reasoning | Enabled |
+| Reasoning effort | Extra High |
+| Context window | `1000000` tokens |
+
+如果更看重低延迟或成本，可以将 `deepseek-v4-flash` 作为轻量模型选项。
+
+DotCraft 内置的 Deep Thinking 适配器会自动作用于 DeepSeek 模型和 DeepSeek endpoint。在工具调用对话中，它会把模型返回的 reasoning 元数据和 assistant 工具调用一起回传，从而让 thinking mode 与 agent 工作流保持兼容。
+
+#### 4. 首次运行
+
+在 DotCraft Desktop 中：
+
+1. 打开项目工作区。
+2. 新建一个 session。
+3. 如果尚未选中，请选择 DeepSeek provider 和 `deepseek-v4-pro` 模型。
+4. 发送一个仓库理解请求：
+
+```text
+请阅读这个仓库的 README 和 docs，告诉我这个项目怎么启动。
+```
+
+此时 session 应该会通过 DeepSeek V4 Pro 流式返回回答。Reasoning 内容会按照 DotCraft 默认的 reasoning 展示行为显示。
+
+#### 其他 DotCraft 入口
+
+完成 Desktop 配置后，同一个工作区配置可被 DotCraft 的其他入口复用：
+
+| 入口 | 适合场景 |
+|------|----------|
+| Desktop | 图形化工作区、provider 配置、会话、trace、审批 |
+| TUI | 通过 DotCraft AppServer 连接的完整终端界面 |
+| CLI | 一次性项目任务和本地自动化命令 |
+| ACP | 通过 Agent Client Protocol 接入编辑器和 IDE |
+| 机器人与自动化 | 面向聊天平台和定时任务的共享工作区会话 |
+
+#### 相关资源
+
+- [DotCraft](https://github.com/DotHarness/dotcraft)
+- [DotCraft 快速开始](https://dotharness.github.io/dotcraft/getting-started)
+- [DotCraft 配置指南](https://dotharness.github.io/dotcraft/config_guide)
+- [DeepSeek API 文档](https://api-docs.deepseek.com/zh-cn/)


### PR DESCRIPTION
## Summary

This PR adds a DotCraft integration guide for using DeepSeek V4 models inside DotCraft.

DotCraft is a project-scoped .NET/C# Agent Harness where Desktop, TUI, CLI, bots, and automations share sessions, skills, tools, approvals, and observability.

Changes included:

- Add English guide: `docs/dotcraft.md`
- Add Simplified Chinese guide: `docs/dotcraft.zh-CN.md`
- Add DotCraft entries to both `README.md` and `README.zh-CN.md`
- Use a Desktop-first setup flow: installation → DeepSeek provider configuration → first run

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing)
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes
