### PR TITLE
[codex] Add callCopilot guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | Tool            | Description                                                                                                 | Guide                          |
 | --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | **AstrBot** | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs. | [Guide](./docs/astrbot.md) |
+| **callCopilot** | Standalone GitHub Copilot CLI BYOK launcher with DeepSeek V4 aliases, 1M prompt-token defaults, and thinking-block preservation. | [Guide](./docs/callcopilot.md) |
 | **Cherry Studio** | Open-source cross-platform desktop AI client with 300+ assistants, MCP support, knowledge bases, and multi-model chat. | [Guide](./docs/cherry_studio.md) |
 | **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
 | **Cline** | AI coding assistant extension for VS Code supporting multiple API providers. | [Guide](./docs/cline.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,6 +16,7 @@
 | 工具            | 简介                                                                  | 指南                                |
 | --------------- | --------------------------------------------------------------------- | ----------------------------------- |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
+| **callCopilot** | GitHub Copilot CLI BYOK 独立启动器，内置 DeepSeek V4 别名、100 万 prompt token 默认值与 thinking block 保留。 | [指南](./docs/callcopilot.zh-CN.md) |
 | **Cherry Studio** | 开源跨平台桌面 AI 客户端，内置 300+ 助手、MCP、知识库与多模型对话。 | [指南](./docs/cherry_studio.zh-CN.md) |
 | **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |
 | **Cline** | 运行在 VS Code 中的 AI 编程助手扩展，支持多种 API 供应商。 | [指南](./docs/cline.zh-CN.md) |

--- a/docs/callcopilot.md
+++ b/docs/callcopilot.md
@@ -1,0 +1,139 @@
+[English](./callcopilot.md) | [简体中文](./callcopilot.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with callCopilot
+
+[callCopilot](https://github.com/qoli/callCopilot) is a standalone launcher for GitHub Copilot CLI BYOK providers. It wraps Copilot CLI with DeepSeek V4 aliases, local proxy setup, token-limit metadata, and thinking-block preservation for the official DeepSeek Anthropic-compatible endpoint.
+
+Use it when you want to run GitHub Copilot CLI with DeepSeek without manually exporting every `COPILOT_PROVIDER_*` variable before each session.
+
+#### 1. Install Requirements
+
+Install GitHub Copilot CLI:
+
+```shell
+npm install -g @github/copilot
+```
+
+Clone callCopilot:
+
+```shell
+git clone https://github.com/qoli/callCopilot.git
+cd callCopilot
+```
+
+Runtime requirements:
+
+- macOS system Python at `/usr/bin/python3`.
+- `node` for local provider proxies.
+- `npm` for the first `ds` or `dsf` run, when callCopilot installs `opencode-deepseek-thinking-fix` locally.
+- `copilot` from GitHub Copilot CLI.
+
+#### 2. Get a DeepSeek API Key
+
+Go to the [DeepSeek Platform](https://platform.deepseek.com/api_keys), create an API key, and copy it.
+
+#### 3. Configure callCopilot
+
+Create `.env` from the example file:
+
+```shell
+cp examples/.env.example .env
+```
+
+Set your DeepSeek API key:
+
+```env
+DEEPSEEK_API_KEY=sk-your-deepseek-api-key
+CALLCOPILOT_DEEPSEEK_PROVIDER_BASE_URL=https://api.deepseek.com/anthropic
+```
+
+The official DeepSeek aliases are:
+
+| Alias | Provider | Model |
+| ----- | -------- | ----- |
+| `ds` | DeepSeek Anthropic-compatible API | `deepseek-v4-pro` |
+| `dsf` | DeepSeek Anthropic-compatible API | `deepseek-v4-flash` |
+
+For `ds` and `dsf`, callCopilot sets Copilot CLI's provider type to `anthropic`, starts a local proxy, and forwards requests to `https://api.deepseek.com/anthropic`.
+
+#### 4. Context and Thinking Settings
+
+DeepSeek V4 supports a 1M-token context window. For the official DeepSeek aliases, callCopilot passes these Copilot CLI limits by default:
+
+```env
+COPILOT_PROVIDER_MAX_PROMPT_TOKENS=1048576
+COPILOT_PROVIDER_MAX_OUTPUT_TOKENS=393216
+```
+
+You can override them if needed:
+
+```shell
+export CALLCOPILOT_DEEPSEEK_MAX_PROMPT_TOKENS=1048576
+export CALLCOPILOT_DEEPSEEK_MAX_OUTPUT_TOKENS=393216
+```
+
+DeepSeek V4 thinking mode is enabled through the local Anthropic-compatible proxy. The proxy preserves and re-injects thinking blocks across tool-call turns so DeepSeek can continue reasoning correctly in Copilot CLI agent sessions.
+
+The default thinking budget is `8000` tokens. For more complex coding tasks, increase it before launching callCopilot:
+
+```shell
+export DEEPSEEK_THINKING_BUDGET=65536
+```
+
+Do not disable thinking mode as the primary workaround for reasoning-content errors.
+
+#### 5. First Run
+
+Run Copilot CLI with DeepSeek V4 Pro:
+
+```shell
+bin/callCopilot ds -- -s -p "Reply OK only."
+```
+
+Run with DeepSeek V4 Flash:
+
+```shell
+bin/callCopilot dsf -- -s -p "Reply OK only."
+```
+
+To start an interactive Copilot CLI agent session with DeepSeek V4 Pro:
+
+```shell
+cd /path/to/my-project
+/path/to/callCopilot/bin/callCopilot ds
+```
+
+callCopilot adds `--autopilot` by default unless you pass your own Copilot CLI arguments.
+
+#### Optional: NVIDIA Hosted DeepSeek
+
+callCopilot also includes an NVIDIA-hosted DeepSeek alias:
+
+```env
+NVIDIA_DEEPSEEK_API_KEY=your-nvidia-api-key
+CALLCOPILOT_NVIDIA_DEEPSEEK_PROVIDER_BASE_URL=https://integrate.api.nvidia.com/v1
+```
+
+Run it with:
+
+```shell
+bin/callCopilot nds -- -s -p "Reply OK only."
+```
+
+This path uses `deepseek-ai/deepseek-v4-pro` through an OpenAI-compatible endpoint. Check the provider's current model limits and availability before relying on it for long-context work.
+
+#### Optional: Local OpenAI-Compatible Models
+
+Any other model ID is routed to the local oMLX OpenAI-compatible backend:
+
+```shell
+bin/callCopilot Qwen3.6-35B-A3B-bf16 -- -s -p "Reply OK only."
+```
+
+For local models, callCopilot reads `max_context_window` and `max_tokens` from the local `/v1/models/status` response and passes those values to Copilot CLI. The local path is therefore limited by the model server's reported capabilities, not by DeepSeek V4's 1M context.
+
+#### Resources
+
+- [callCopilot GitHub repository](https://github.com/qoli/callCopilot)
+- [GitHub Copilot CLI BYOK docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models)
+- [DeepSeek Thinking Mode docs](https://api-docs.deepseek.com/guides/thinking_mode)

--- a/docs/callcopilot.zh-CN.md
+++ b/docs/callcopilot.zh-CN.md
@@ -1,0 +1,139 @@
+[English](./callcopilot.md) | [简体中文](./callcopilot.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 callCopilot
+
+[callCopilot](https://github.com/qoli/callCopilot) 是一个 GitHub Copilot CLI BYOK provider 独立启动器。它为 Copilot CLI 封装了 DeepSeek V4 别名、本地代理启动、token 上限元数据，以及官方 DeepSeek Anthropic 兼容端点所需的 thinking block 保留逻辑。
+
+如果你希望用 DeepSeek 运行 GitHub Copilot CLI，但不想每次手动导出一组 `COPILOT_PROVIDER_*` 环境变量，可以使用 callCopilot。
+
+#### 1. 安装依赖
+
+安装 GitHub Copilot CLI：
+
+```shell
+npm install -g @github/copilot
+```
+
+克隆 callCopilot：
+
+```shell
+git clone https://github.com/qoli/callCopilot.git
+cd callCopilot
+```
+
+运行时依赖：
+
+- macOS 系统 Python：`/usr/bin/python3`。
+- `node`，用于本地 provider 代理。
+- `npm`，首次运行 `ds` 或 `dsf` 时，callCopilot 会在本地安装 `opencode-deepseek-thinking-fix`。
+- GitHub Copilot CLI 提供的 `copilot` 命令。
+
+#### 2. 获取 DeepSeek API Key
+
+前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 创建 API Key，并复制该 Key。
+
+#### 3. 配置 callCopilot
+
+从示例文件创建 `.env`：
+
+```shell
+cp examples/.env.example .env
+```
+
+填写 DeepSeek API Key：
+
+```env
+DEEPSEEK_API_KEY=sk-your-deepseek-api-key
+CALLCOPILOT_DEEPSEEK_PROVIDER_BASE_URL=https://api.deepseek.com/anthropic
+```
+
+官方 DeepSeek 别名如下：
+
+| 别名 | Provider | 模型 |
+| ---- | -------- | ---- |
+| `ds` | DeepSeek Anthropic 兼容 API | `deepseek-v4-pro` |
+| `dsf` | DeepSeek Anthropic 兼容 API | `deepseek-v4-flash` |
+
+对于 `ds` 和 `dsf`，callCopilot 会把 Copilot CLI 的 provider type 设置为 `anthropic`，启动本地代理，并把请求转发到 `https://api.deepseek.com/anthropic`。
+
+#### 4. 上下文与 Thinking 配置
+
+DeepSeek V4 支持 100 万 token 上下文窗口。对于官方 DeepSeek 别名，callCopilot 默认向 Copilot CLI 传入以下限制：
+
+```env
+COPILOT_PROVIDER_MAX_PROMPT_TOKENS=1048576
+COPILOT_PROVIDER_MAX_OUTPUT_TOKENS=393216
+```
+
+如有需要，可以覆盖这些值：
+
+```shell
+export CALLCOPILOT_DEEPSEEK_MAX_PROMPT_TOKENS=1048576
+export CALLCOPILOT_DEEPSEEK_MAX_OUTPUT_TOKENS=393216
+```
+
+DeepSeek V4 的 thinking mode 通过本地 Anthropic 兼容代理启用。该代理会在工具调用回合之间保留并重新注入 thinking blocks，使 DeepSeek 能在 Copilot CLI Agent 会话中正确延续推理。
+
+默认 thinking budget 是 `8000` tokens。复杂编程任务可以在启动 callCopilot 前调高该值：
+
+```shell
+export DEEPSEEK_THINKING_BUDGET=65536
+```
+
+不要把禁用 thinking mode 作为解决 reasoning-content 错误的主要方法。
+
+#### 5. 首次运行
+
+使用 DeepSeek V4 Pro 运行 Copilot CLI：
+
+```shell
+bin/callCopilot ds -- -s -p "Reply OK only."
+```
+
+使用 DeepSeek V4 Flash：
+
+```shell
+bin/callCopilot dsf -- -s -p "Reply OK only."
+```
+
+在项目中启动 DeepSeek V4 Pro 的交互式 Copilot CLI Agent 会话：
+
+```shell
+cd /path/to/my-project
+/path/to/callCopilot/bin/callCopilot ds
+```
+
+除非你传入自己的 Copilot CLI 参数，否则 callCopilot 会默认添加 `--autopilot`。
+
+#### 可选：NVIDIA 托管的 DeepSeek
+
+callCopilot 也提供 NVIDIA 托管 DeepSeek 的别名：
+
+```env
+NVIDIA_DEEPSEEK_API_KEY=your-nvidia-api-key
+CALLCOPILOT_NVIDIA_DEEPSEEK_PROVIDER_BASE_URL=https://integrate.api.nvidia.com/v1
+```
+
+运行：
+
+```shell
+bin/callCopilot nds -- -s -p "Reply OK only."
+```
+
+该路径通过 OpenAI 兼容端点使用 `deepseek-ai/deepseek-v4-pro`。如果需要长上下文，请先确认该 provider 当前的模型限制与可用性。
+
+#### 可选：本地 OpenAI 兼容模型
+
+其他任意模型 ID 会被路由到本地 oMLX OpenAI 兼容后端：
+
+```shell
+bin/callCopilot Qwen3.6-35B-A3B-bf16 -- -s -p "Reply OK only."
+```
+
+对于本地模型，callCopilot 会从本地 `/v1/models/status` 响应中读取 `max_context_window` 和 `max_tokens`，并把这些值传给 Copilot CLI。因此本地路径受模型服务实际回报的能力限制，而不是固定使用 DeepSeek V4 的 100 万 token 上下文。
+
+#### 相关资源
+
+- [callCopilot GitHub 仓库](https://github.com/qoli/callCopilot)
+- [GitHub Copilot CLI BYOK 文档](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models)
+- [DeepSeek Thinking Mode 文档](https://api-docs.deepseek.com/guides/thinking_mode)


### PR DESCRIPTION
## Summary

- Add a bilingual callCopilot integration guide for running GitHub Copilot CLI with DeepSeek V4 through BYOK.
- Document official `ds` / `dsf` aliases, 1M prompt-token defaults, thinking-block preservation, NVIDIA-hosted DeepSeek, and local oMLX behavior.
- Add callCopilot entries to both README tables.

## Validation

- `git diff --cached --check`
- `rg -n "deepseek-chat|deepseek-reasoner|deepseek-coder" README.md README.zh-CN.md docs/callcopilot.md docs/callcopilot.zh-CN.md || true`
- Verified both new guide files exist and both README entries point to them.
