### PR TITLE
Add Axiomate integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
+| **Axiomate**    | Multi-provider AI agent CLI with interactive TUI for DeepSeek setup, plus UIA/AX-based computer use with Set-of-Mark overlays for text-only models. | [Guide](./docs/axiomate.md)    |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,7 @@
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
+| **Axiomate** | 多 Provider AI Agent CLI，提供交互式 TUI 配置 DeepSeek，并通过 UIA/AX + Set-of-Mark 覆盖层为纯文本模型提供桌面自动化。 | [指南](./docs/axiomate.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |

--- a/docs/axiomate.md
+++ b/docs/axiomate.md
@@ -1,0 +1,88 @@
+[English](./axiomate.md) | [简体中文](./axiomate.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Axiomate
+
+Axiomate is a multi-provider AI agent CLI that lets you chat, code, and control your computer — all from the terminal. It connects to DeepSeek, OpenRouter, SiliconFlow, ollama, vLLM, Anthropic, and more via a single unified config. For DeepSeek V4, Axiomate provides an interactive TUI wizard for zero-friction setup, automatic `reasoning_content` round-trip across tool calls, and UIA/AX-based computer use with Set-of-Mark overlays designed for text-only models.
+
+## 1. Install
+
+**Prerequisites:** Node.js 20+, Git. Windows also needs Visual Studio 2022 Build Tools (auto-installed by bootstrap).
+
+Download the latest release from [GitHub Releases](https://github.com/axiomates/axiomate-agent/releases/tag/0.6.2), or build from source:
+
+```bash
+git clone https://github.com/axiomates/axiomate-agent.git
+cd axiomate-agent
+npm run bootstrap   # installs pnpm + Bun + Rust + deps, builds all workspaces
+pnpm run start      # launch Axiomate
+```
+
+## 2. Configure DeepSeek (Interactive TUI)
+
+### First Run — Onboarding Wizard
+
+The first time you launch Axiomate with no models configured, a multi-step TUI wizard guides you through setup:
+
+| Step | Field | What to enter for DeepSeek |
+|------|-------|---------------------------|
+| 1 | Protocol | **OpenAI Chat Completions** |
+| 2 | API base URL | `https://api.deepseek.com` |
+| 3 | API key | Your key from [platform.deepseek.com](https://platform.deepseek.com/api_keys) (masked input) |
+| 4 | Model ID | `deepseek-v4-pro` or `deepseek-v4-flash` |
+| 5 | Context window | `1000000` (1M tokens) |
+| 6 | Image input support | **No** — DeepSeek V4 is text-only |
+| 7 | Vendor template | `Auto-detect` (auto-selects `openai-chat-deepseek-official`) |
+| 8 | Reasoning depth | **High** or **Max** (DeepSeek V4 Pro only supports these two levels) |
+
+After verification succeeds, the config is saved to `~/.axiomate.json` and you're ready to go.
+
+### Add More Models Later — `/model add`
+
+Inside the TUI, type `/model add` to re-enter the same wizard and add another model (e.g., `deepseek-v4-flash` for cost-efficient iteration). The new model becomes active immediately. Switch between models anytime with `/model`.
+
+### Manual Config (Optional)
+
+You can also edit `~/.axiomate.json` directly:
+
+```jsonc
+{
+  "models": {
+    "deepseek-v4-pro": {
+      "model": "deepseek-v4-pro",
+      "protocol": "openai-chat",
+      "baseUrl": "https://api.deepseek.com",
+      "apiKey": "sk-...",
+      "contextWindow": 1000000,
+      "supportsImages": false,
+      "thinking": { "enabled": true, "effort": "max" }
+    }
+  },
+  "currentModel": "deepseek-v4-pro"
+}
+```
+
+## 3. First Run
+
+```bash
+cd /path/to/my-project
+axiomate
+```
+
+Axiomate enters the project directory, loads your DeepSeek model, and starts an agentic coding session with file editing, shell execution, grep, and more — all powered by DeepSeek V4's 1M context window and extended reasoning.
+
+## 4. Computer Use with UIA/AX (for Text-Only Models)
+
+DeepSeek V4 does not support vision input, but Axiomate's computer-use layer compensates with **UIAutomation / Accessibility (UIA/AX) bindings** and **Set-of-Mark (SOM) overlays**:
+
+- **`screenshot`** — captures the screen with coordinate rulers so the model can reason about spatial layout from text descriptions
+- **`zoom`** — captures a region and overlays numbered SOM markers on every detected UI element, letting the model reference elements by index instead of pixel coordinates
+- **UIA element detection** (Windows) — uses native UIAutomation to identify buttons, text fields, menus, and other controls with pixel-accurate bounding boxes
+- **Accessibility tree** (macOS) — uses the AX API for equivalent element discovery
+
+This means DeepSeek V4 Pro can drive desktop applications — clicking, typing, scrolling, reading UI state — without needing a vision model. The SOM overlays translate visual information into structured text that reasoning models handle well.
+
+## Resources
+
+- [Axiomate GitHub](https://github.com/axiomates/axiomate-agent)
+- [DeepSeek Platform](https://platform.deepseek.com/) — get an API key
+- [DeepSeek API Docs](https://api-docs.deepseek.com/) — model reference

--- a/docs/axiomate.zh-CN.md
+++ b/docs/axiomate.zh-CN.md
@@ -1,0 +1,88 @@
+[English](./axiomate.md) | [简体中文](./axiomate.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Axiomate
+
+Axiomate 是一个多 Provider AI Agent CLI，支持在终端中聊天、编程和控制桌面。它通过统一配置连接 DeepSeek、OpenRouter、SiliconFlow、ollama、vLLM、Anthropic 等多种后端。针对 DeepSeek V4，Axiomate 提供交互式 TUI 向导实现零摩擦配置，自动在工具调用间 round-trip `reasoning_content`，并通过 UIA/AX 原生绑定 + Set-of-Mark 覆盖层为纯文本模型提供桌面自动化能力。
+
+## 1. 安装
+
+**前置条件：** Node.js 20+、Git。Windows 还需要 Visual Studio 2022 Build Tools（bootstrap 脚本会自动安装）。
+
+从 [GitHub Releases](https://github.com/axiomates/axiomate-agent/releases/tag/0.6.2) 下载最新版本，或从源码构建：
+
+```bash
+git clone https://github.com/axiomates/axiomate-agent.git
+cd axiomate-agent
+npm run bootstrap   # 自动安装 pnpm + Bun + Rust + 依赖，构建所有工作区
+pnpm run start      # 启动 Axiomate
+```
+
+## 2. 配置 DeepSeek（交互式 TUI）
+
+### 首次启动 — Onboarding 向导
+
+首次启动 Axiomate 且未配置任何模型时，会进入多步骤 TUI 向导：
+
+| 步骤 | 字段 | DeepSeek 填写内容 |
+|------|------|-------------------|
+| 1 | 协议 | **OpenAI Chat Completions** |
+| 2 | API 基础 URL | `https://api.deepseek.com` |
+| 3 | API Key | 从 [platform.deepseek.com](https://platform.deepseek.com/api_keys) 获取（掩码输入） |
+| 4 | 模型 ID | `deepseek-v4-pro` 或 `deepseek-v4-flash` |
+| 5 | 上下文窗口 | `1000000`（100 万 token） |
+| 6 | 图像输入支持 | **否** — DeepSeek V4 为纯文本模型 |
+| 7 | 供应商模板 | `Auto-detect`（自动选择 `openai-chat-deepseek-official`） |
+| 8 | 推理深度 | **High** 或 **Max**（DeepSeek V4 Pro 仅支持这两个级别） |
+
+验证连接成功后，配置保存至 `~/.axiomate.json`，即可开始使用。
+
+### 后续添加模型 — `/model add`
+
+在 TUI 中输入 `/model add` 可重新进入相同向导，添加更多模型（例如 `deepseek-v4-flash` 用于低成本迭代）。新模型添加后立即激活。随时通过 `/model` 命令切换模型。
+
+### 手动配置（可选）
+
+也可以直接编辑 `~/.axiomate.json`：
+
+```jsonc
+{
+  "models": {
+    "deepseek-v4-pro": {
+      "model": "deepseek-v4-pro",
+      "protocol": "openai-chat",
+      "baseUrl": "https://api.deepseek.com",
+      "apiKey": "sk-...",
+      "contextWindow": 1000000,
+      "supportsImages": false,
+      "thinking": { "enabled": true, "effort": "max" }
+    }
+  },
+  "currentModel": "deepseek-v4-pro"
+}
+```
+
+## 3. 开始使用
+
+```bash
+cd /path/to/my-project
+axiomate
+```
+
+Axiomate 进入项目目录，加载 DeepSeek 模型，启动 Agent 编程会话 — 支持文件编辑、Shell 执行、代码搜索等，全部由 DeepSeek V4 的 100 万 token 上下文窗口和扩展推理驱动。
+
+## 4. 桌面自动化：UIA/AX Computer Use（适用于纯文本模型）
+
+DeepSeek V4 不支持视觉输入，但 Axiomate 的 Computer Use 层通过 **UIAutomation / 无障碍（UIA/AX）原生绑定** 和 **Set-of-Mark (SOM) 覆盖层** 进行补偿：
+
+- **`screenshot`** — 截取屏幕并附加坐标标尺，让模型通过文本描述推理空间布局
+- **`zoom`** — 截取区域并在每个检测到的 UI 元素上叠加编号 SOM 标记，模型可通过索引引用元素而非像素坐标
+- **UIA 元素检测**（Windows）— 使用原生 UIAutomation 识别按钮、文本框、菜单等控件，提供像素级精确边界框
+- **无障碍树**（macOS）— 使用 AX API 实现等效的元素发现
+
+这意味着 DeepSeek V4 Pro 可以驱动桌面应用 — 点击、输入、滚动、读取 UI 状态 — 无需视觉模型。SOM 覆盖层将视觉信息转换为结构化文本，推理模型可以很好地处理。
+
+## 相关资源
+
+- [Axiomate GitHub](https://github.com/axiomates/axiomate-agent)
+- [DeepSeek 开放平台](https://platform.deepseek.com/) — 获取 API Key
+- [DeepSeek API 文档](https://api-docs.deepseek.com/zh-cn/) — 模型参考


### PR DESCRIPTION
## Summary

- Add English + Chinese integration guide for [Axiomate](https://github.com/axiomates/axiomate-agent) — a multi-provider AI agent CLI with interactive TUI setup for DeepSeek V4 and UIA/AX-based computer use with Set-of-Mark overlays for text-only models.
- Insert table entry in both READMEs (alphabetical order, after AstrBot).

### Highlights

- **Interactive TUI onboarding**: step-by-step wizard configures DeepSeek V4 Pro/Flash with correct base URL, 1M context, and max reasoning effort — no manual JSON editing required. `/model add` re-enters the same wizard to add more models.
- **UIA/AX computer use for text-only models**: native UIAutomation (Windows) and Accessibility (macOS) bindings detect UI elements; Set-of-Mark overlays translate visual layout into numbered indices so DeepSeek V4 can drive desktop apps without vision input.
- **Automatic `reasoning_content` round-trip**: vendor template preserves reasoning context across multi-turn tool calls.

Release: https://github.com/axiomates/axiomate-agent/releases/tag/0.6.2

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing) — not included in guide (no pricing table)
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes — N/A (no images)
@