### PR TITLE
docs: add Phantty DeepSeek agent guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
+| **Phantty** | Windows terminal emulator with built-in DeepSeek-first AI Agent sessions, local tools, WSL/SSH support, and skills. | [Guide](./docs/phantty.md) |
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,6 +30,7 @@
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
+| **Phantty** | 内置 DeepSeek 优先 AI Agent 会话的 Windows 终端模拟器，支持本地工具、WSL/SSH 与 Skills。 | [指南](./docs/phantty.zh-CN.md) |
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |

--- a/docs/phantty.md
+++ b/docs/phantty.md
@@ -1,0 +1,114 @@
+[English](./phantty.md) | [简体中文](./phantty.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Phantty
+
+Phantty is a Windows terminal emulator written in Zig, built on Ghostty's VT parser, with built-in DeepSeek-first AI Agent sessions. It can run local PowerShell/cmd commands, work with WSL and SSH terminals, load local skills, and keep the agent inside the terminal workflow.
+
+- **GitHub:** <https://github.com/xuzhougeng/phantty>
+
+#### 1. Install Phantty
+
+Phantty is Windows-only. Download a portable release from:
+
+```text
+https://github.com/xuzhougeng/phantty/releases
+```
+
+Choose one of the Windows portable zip assets:
+
+| Asset | Use case |
+|---|---|
+| `phantty-windows-portable-webview2-vX.Y.Z.zip` | Recommended if you want the embedded browser panel. |
+| `phantty-windows-portable-no-webview-vX.Y.Z.zip` | Use when WebView2 is not available or should be disabled. |
+| `phantty-windows-portable-vX.Y.Z.zip` | General portable build. |
+
+Extract the zip and run:
+
+```powershell
+.\phantty.exe
+```
+
+#### 2. Get a DeepSeek API Key
+
+Get your API key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+Phantty can store the key in its AI profile, or read it from the `DEEPSEEK_API_KEY` environment variable when the profile's base URL points to DeepSeek:
+
+```powershell
+$env:DEEPSEEK_API_KEY = "sk-your-deepseek-api-key"
+
+# Optional: persist for future PowerShell sessions
+[Environment]::SetEnvironmentVariable("DEEPSEEK_API_KEY", "sk-your-deepseek-api-key", "User")
+```
+
+#### 3. Open and Configure the AI Agent
+
+Start Phantty, then press `Ctrl+Shift+T` and choose `AI Agent`.
+
+If no AI profile exists yet, Phantty opens the AI settings form first. Use:
+
+| Field | Value |
+|---|---|
+| Profile name | `DeepSeek` |
+| Base URL | `https://api.deepseek.com` |
+| API key | Your DeepSeek API key, or leave empty when `DEEPSEEK_API_KEY` is set |
+| Model | `deepseek-v4-pro` |
+| Thinking | `enabled` |
+| Effort | `max` |
+| Stream | `false` |
+| Agent | `true` |
+
+You can also use `deepseek-v4-flash` for a faster, lighter agent profile.
+
+DeepSeek V4 models support up to 1 million tokens of context. Phantty does not require a separate `context_window` setting; it sends OpenAI-compatible Chat Completions requests directly to DeepSeek and relies on the selected DeepSeek V4 model's context window.
+
+#### 4. First Run
+
+After saving the profile, Phantty opens an Agent tab. Try:
+
+```text
+Inspect this repository and summarize the build and test commands.
+```
+
+When the agent requests a tool command, Phantty shows an approval prompt unless you have configured full agent permission. This keeps local PowerShell/cmd, WSL, and SSH tool execution explicit.
+
+#### Useful Shortcuts
+
+| Shortcut | Action |
+|---|---|
+| `Ctrl+Shift+T` | Open the session launcher |
+| `Ctrl+Shift+P` | Open the command center |
+| `Ctrl+Shift+Alt+E` | Toggle the left file explorer / agent history panel |
+| `Esc` | Dismiss overlays or interrupt relevant UI flows |
+
+#### Agent Skills and Local Commands
+
+Phantty discovers local skills from:
+
+- `%APPDATA%\phantty\skills\<skill-name>\SKILL.md`
+- `.\skills\<skill-name>\SKILL.md` in the current working directory
+- `skills\<skill-name>\SKILL.md` next to `phantty.exe`
+
+Use `$skill-name your request` to load a skill for the next agent request.
+
+Local slash commands inside the AI Agent tab:
+
+| Command | Action |
+|---|---|
+| `/skills` | List discovered local skills |
+| `/commands` | List local AI chat commands |
+| `/reload-skills` | Reload skills from disk for future skill calls |
+
+#### Troubleshooting
+
+- `Missing API key`: set `DEEPSEEK_API_KEY`, or save the key in the AI profile.
+- `401` or authentication errors: check the API key and base URL.
+- `402` or payment errors: check your DeepSeek Platform balance.
+- No tool execution: keep `Agent = true`, and approve tool prompts when permission mode is `confirm`.
+- Avoid legacy DeepSeek V3 model names; use `deepseek-v4-pro` or `deepseek-v4-flash`.
+
+#### Resources
+
+- [Phantty](https://github.com/xuzhougeng/phantty)
+- [DeepSeek API Docs](https://api-docs.deepseek.com/)
+- [DeepSeek Thinking Mode](https://api-docs.deepseek.com/guides/thinking_mode)

--- a/docs/phantty.zh-CN.md
+++ b/docs/phantty.zh-CN.md
@@ -1,0 +1,114 @@
+[English](./phantty.md) | [简体中文](./phantty.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Phantty
+
+Phantty 是一款用 Zig 编写的 Windows 终端模拟器，基于 Ghostty 的 VT 解析器，并内置 DeepSeek 优先的 AI Agent 会话。它可以在终端工作流中运行本地 PowerShell/cmd 命令，配合 WSL 和 SSH 终端，加载本地 Skills，并把 Agent 留在终端环境里使用。
+
+- **GitHub：** <https://github.com/xuzhougeng/phantty>
+
+#### 1. 安装 Phantty
+
+Phantty 仅支持 Windows。请从发布页下载便携版：
+
+```text
+https://github.com/xuzhougeng/phantty/releases
+```
+
+选择一个 Windows portable zip：
+
+| 文件 | 适用场景 |
+|---|---|
+| `phantty-windows-portable-webview2-vX.Y.Z.zip` | 推荐选择，适合需要内嵌浏览器面板的用户。 |
+| `phantty-windows-portable-no-webview-vX.Y.Z.zip` | 适合没有 WebView2 或希望禁用内嵌浏览器的环境。 |
+| `phantty-windows-portable-vX.Y.Z.zip` | 通用便携版。 |
+
+解压后运行：
+
+```powershell
+.\phantty.exe
+```
+
+#### 2. 获取 DeepSeek API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 创建并复制 API Key。
+
+Phantty 可以把 API Key 保存在 AI Profile 中；如果 Profile 的 Base URL 指向 DeepSeek，也可以从 `DEEPSEEK_API_KEY` 环境变量读取：
+
+```powershell
+$env:DEEPSEEK_API_KEY = "sk-your-deepseek-api-key"
+
+# 可选：持久保存到后续 PowerShell 会话
+[Environment]::SetEnvironmentVariable("DEEPSEEK_API_KEY", "sk-your-deepseek-api-key", "User")
+```
+
+#### 3. 打开并配置 AI Agent
+
+启动 Phantty 后，按 `Ctrl+Shift+T`，选择 `AI Agent`。
+
+如果还没有 AI Profile，Phantty 会先打开 AI 设置表单。填写：
+
+| 字段 | 值 |
+|---|---|
+| Profile name | `DeepSeek` |
+| Base URL | `https://api.deepseek.com` |
+| API key | 你的 DeepSeek API Key；如果已经设置 `DEEPSEEK_API_KEY`，可以留空 |
+| Model | `deepseek-v4-pro` |
+| Thinking | `enabled` |
+| Effort | `max` |
+| Stream | `false` |
+| Agent | `true` |
+
+也可以使用 `deepseek-v4-flash` 创建更快、更轻量的 Agent Profile。
+
+DeepSeek V4 模型支持最高 100 万 token 上下文。Phantty 不需要额外配置 `context_window`；它会直接向 DeepSeek 发送 OpenAI 兼容的 Chat Completions 请求，并使用所选 DeepSeek V4 模型的上下文能力。
+
+#### 4. 首次运行
+
+保存 Profile 后，Phantty 会打开一个 Agent 标签页。可以尝试：
+
+```text
+Inspect this repository and summarize the build and test commands.
+```
+
+当 Agent 请求运行工具命令时，如果权限模式不是 full，Phantty 会显示确认提示。这样本地 PowerShell/cmd、WSL 和 SSH 相关工具执行都需要显式确认。
+
+#### 常用快捷键
+
+| 快捷键 | 功能 |
+|---|---|
+| `Ctrl+Shift+T` | 打开会话启动器 |
+| `Ctrl+Shift+P` | 打开命令中心 |
+| `Ctrl+Shift+Alt+E` | 切换左侧文件浏览器 / Agent History 面板 |
+| `Esc` | 关闭浮层或中断相关 UI 流程 |
+
+#### Agent Skills 与本地命令
+
+Phantty 会从以下位置发现本地 Skills：
+
+- `%APPDATA%\phantty\skills\<skill-name>\SKILL.md`
+- 当前工作目录下的 `.\skills\<skill-name>\SKILL.md`
+- `phantty.exe` 同级目录下的 `skills\<skill-name>\SKILL.md`
+
+使用 `$skill-name your request` 可以为下一次 Agent 请求加载指定 Skill。
+
+AI Agent 标签页内置本地 slash commands：
+
+| 命令 | 功能 |
+|---|---|
+| `/skills` | 列出发现的本地 Skills |
+| `/commands` | 列出本地 AI Chat 命令 |
+| `/reload-skills` | 为后续 Skill 调用重新从磁盘读取 Skills |
+
+#### 故障排查
+
+- `Missing API key`：设置 `DEEPSEEK_API_KEY`，或把 API Key 保存到 AI Profile。
+- `401` 或认证错误：检查 API Key 和 Base URL。
+- `402` 或余额错误：检查 DeepSeek 开放平台余额。
+- 工具无法执行：保持 `Agent = true`，并在权限模式为 `confirm` 时确认工具请求。
+- 不要使用旧的 DeepSeek V3 模型名；请使用 `deepseek-v4-pro` 或 `deepseek-v4-flash`。
+
+#### 相关资源
+
+- [Phantty](https://github.com/xuzhougeng/phantty)
+- [DeepSeek API 文档](https://api-docs.deepseek.com/zh-cn/)
+- [DeepSeek 深度思考模式](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode)


### PR DESCRIPTION
## Summary

- Add an English Phantty integration guide.
- Add a Simplified Chinese Phantty integration guide.
- Add Phantty entries to both README guide tables.

## DeepSeek configuration covered

- Uses current DeepSeek V4 model names: `deepseek-v4-pro` and `deepseek-v4-flash`.
- Documents `reasoning_effort = max` for the Phantty AI Agent profile.
- Mentions DeepSeek V4 1 million token context support.
- Avoids pricing claims.

## Checks

- `rg -n "deepseek-chat|deepseek-reasoner|deepseek-coder" README.md README.zh-CN.md docs/phantty.md docs/phantty.zh-CN.md` returned no matches.
- `git diff --check HEAD~1..HEAD`
