### PR TITLE
add LeAgent integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **LeAgent** | Open-source office AI agent with conversational chat, visual workflows, and 100+ built-in tools. | [Guide](./docs/leagent.md) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,6 +34,7 @@
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **LeAgent** | 开源办公 AI Agent，支持对话式交互、可视化工作流与 100+ 内置工具。 | [指南](./docs/leagent.zh-CN.md) |
 
 ## 相关资源
 

--- a/docs/leagent.md
+++ b/docs/leagent.md
@@ -39,7 +39,9 @@ curl -fsSL https://vixues.com.cn/install.sh | bash
 3. Select **DeepSeek** from the provider list.
 4. Enter your [DeepSeek API Key](https://platform.deepseek.com/api_keys).
 5. Choose a model — `deepseek-v4-pro` for best quality or `deepseek-v4-flash` for faster responses.
-6. Save the configuration.
+6. Set **context window** to `1000000` (DeepSeek V4 supports up to 1M tokens).
+7. Enable **Thinking Mode** and set reasoning effort to `max` for best results with `deepseek-v4-pro`.
+8. Save the configuration.
 
 #### 3. Get Started
 

--- a/docs/leagent.md
+++ b/docs/leagent.md
@@ -1,0 +1,50 @@
+[English](./leagent.md) | [简体中文](./leagent.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with LeAgent
+
+LeAgent is a self-hostable, local-first platform for building LLM-powered office automation — conversational AI, visual workflows, and 100+ tools in one deployable stack. DeepSeek is the most thoroughly validated provider and is recommended for first use.
+
+#### 1. Install LeAgent
+
+**Prerequisites:** git, uv, Node.js 20+
+
+Clone the repository and start with the launch script:
+
+```
+git clone https://github.com/vixues/LeAgent.git
+cd LeAgent
+./start.sh
+```
+
+This starts the backend on port 7860 and the frontend on port 5173.
+
+Alternatively, use Docker:
+
+```
+cd LeAgent/deploy
+cp .env.example .env
+docker compose up -d --build
+```
+
+Or use the one-line installer:
+
+```
+curl -fsSL https://vixues.com.cn/install.sh | bash
+```
+
+#### 2. Configure DeepSeek as the LLM Provider
+
+1. Open the LeAgent Web UI at `http://localhost:5173`.
+2. Navigate to **Settings → Model Provider**.
+3. Select **DeepSeek** from the provider list.
+4. Enter your [DeepSeek API Key](https://platform.deepseek.com/api_keys).
+5. Choose a model — `deepseek-v4-pro` for best quality or `deepseek-v4-flash` for faster responses.
+6. Save the configuration.
+
+#### 3. Get Started
+
+- **Chat:** Open the Chat page to start a multi-turn conversation powered by DeepSeek.
+- **Workflows:** Use the visual ReactFlow editor to build drag-and-drop automation workflows with DeepSeek as the reasoning engine.
+- **Tools:** Explore the 100+ built-in tools (documents, web, data, code execution, databases, and more) that the agent can invoke during conversations.
+
+For more information, see the [LeAgent documentation](https://github.com/vixues/LeAgent).

--- a/docs/leagent.zh-CN.md
+++ b/docs/leagent.zh-CN.md
@@ -39,7 +39,9 @@ curl -fsSL https://vixues.com.cn/install.sh | bash
 3. 在供应商列表中选择 **DeepSeek**。
 4. 输入你的 [DeepSeek API Key](https://platform.deepseek.com/api_keys)。
 5. 选择模型 —— `deepseek-v4-pro` 质量最佳，`deepseek-v4-flash` 响应更快。
-6. 保存配置。
+6. 将**上下文窗口**设置为 `1000000`（DeepSeek V4 支持最高 100 万 token 上下文）。
+7. 开启**思考模式**，并将推理强度设为 `max` 以获得 `deepseek-v4-pro` 的最佳效果。
+8. 保存配置。
 
 #### 3. 开始使用
 

--- a/docs/leagent.zh-CN.md
+++ b/docs/leagent.zh-CN.md
@@ -1,0 +1,50 @@
+[English](./leagent.md) | [简体中文](./leagent.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 LeAgent
+
+LeAgent 是一个可自部署的本地优先平台，用于构建由大语言模型驱动的办公自动化 —— 对话式 AI、可视化工作流以及 100+ 工具集于一身。DeepSeek 是目前验证最充分的供应商，推荐首次使用时选用。
+
+#### 1. 安装 LeAgent
+
+**前置条件：** git、uv、Node.js 20+
+
+克隆仓库并通过启动脚本运行：
+
+```
+git clone https://github.com/vixues/LeAgent.git
+cd LeAgent
+./start.sh
+```
+
+后端将在 7860 端口启动，前端将在 5173 端口启动。
+
+也可以使用 Docker 部署：
+
+```
+cd LeAgent/deploy
+cp .env.example .env
+docker compose up -d --build
+```
+
+或者使用一键安装脚本：
+
+```
+curl -fsSL https://vixues.com.cn/install.sh | bash
+```
+
+#### 2. 配置 DeepSeek 作为模型供应商
+
+1. 打开 LeAgent Web UI，地址为 `http://localhost:5173`。
+2. 进入 **设置 → 模型供应商**。
+3. 在供应商列表中选择 **DeepSeek**。
+4. 输入你的 [DeepSeek API Key](https://platform.deepseek.com/api_keys)。
+5. 选择模型 —— `deepseek-v4-pro` 质量最佳，`deepseek-v4-flash` 响应更快。
+6. 保存配置。
+
+#### 3. 开始使用
+
+- **对话：** 打开 Chat 页面，开始由 DeepSeek 驱动的多轮对话。
+- **工作流：** 使用可视化 ReactFlow 编辑器，构建拖拽式自动化工作流，以 DeepSeek 作为推理引擎。
+- **工具：** 探索 100+ 内置工具（文档、网页、数据、代码执行、数据库等），Agent 可在对话过程中调用这些工具。
+
+更多信息请参阅 [LeAgent 文档](https://github.com/vixues/LeAgent)。


### PR DESCRIPTION

[**LeAgent**](https://github.com/vixues/LeAgent) is an open-source desktop AI agent that combines multi-turn chat, a visual workflow builder, 100+ built-in tools, a declarative rule engine, Agent Skills, and MCP — all in a single self-hostable stack.

- **Agent runtime** — multi-turn sessions with streaming, tool execution, tiered model routing, layered prompts, and episodic / semantic / procedural cognitive memory
- **Skills** — [Agent Skills v1.0](https://agentskills.my/specification) `SKILL.md` bundles with progressive disclosure and on-demand loading; built-in skills, install from links/archives, and a pluggable HTTP skill registry
- **100+ offline tools** — documents, web, data, code execution, databases, generative UI, coding projects, and more
- **Sidebar desk pet** — customizable avatar and background, walk/jump animations, and personality bubbles; upload PNG / SVG / GIF or sprite sheets, synced with chat streaming and session state
- **Visual workflows** — ReactFlow editor with YAML export, templates, and every tool as a typed node
- **Multi-provider LLM** — DeepSeek, DashScope (Qwen), OpenAI, Ollama, vLLM, and more (DeepSeek is currently the most thoroughly validated; recommended for first use)
- **Zero-config default** — SQLite out of the box, single Docker container, optional PostgreSQL / Milvus
![screen shot](https://i.imgur.com/rcNFnFd.png)
---
## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit) — N/A, not included
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes — N/A, no images
