### PR TITLE
Add Proma — open-source desktop AI agent with DeepSeek as a preset provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
+| **Proma**       | Open-source desktop AI agent (macOS / Windows) — DeepSeek preset with 1M context auto-enabled, aggressive SubAgent orchestration, GUI experience beyond terminal-only agents. | [Guide](./docs/proma.md)       |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,7 @@
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具，记忆，MCP等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
+| **Proma** | 开源 AI 桌面 Agent（macOS / Windows）—— DeepSeek 预设渠道并自动启用 1M 上下文，主动 SubAgent 编排，体验超越终端 Agent 的桌面 GUI。 | [指南](./docs/proma.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **Langcli** | 100%兼容Claude code、支持Deepseek v4等主流LLM模型的开源AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |

--- a/docs/proma.md
+++ b/docs/proma.md
@@ -1,0 +1,61 @@
+[English](./proma.md) | [简体中文](./proma.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Proma
+
+Proma is a local-first, open-source desktop AI agent for macOS and Windows. It bundles a multi-model **Chat** mode, a general-purpose **Agent** mode (built on the Claude Agent SDK), plus workspaces, Skills, MCP servers, memory, and chat-app bot bridges in a single client.
+
+DeepSeek is a **first-class provider** in Proma: a DeepSeek channel is auto-provisioned on first launch, the 1M context beta is enabled automatically for `deepseek-v4-pro` / `deepseek-v4-flash`, and a single key drives both Chat and Agent modes. Combined with Proma's aggressive SubAgent orchestration and a desktop UI that surfaces every step of the run, this is one of the smoothest open-source paths to put DeepSeek V4 to real work — no terminal setup required.
+
+- **GitHub:** <https://github.com/ErlichLiu/Proma>
+- **Website:** <https://proma.cool>
+
+#### 1. Install Proma
+
+Download the installer for your platform from the [Proma Releases page](https://github.com/ErlichLiu/Proma/releases).
+
+Available builds:
+
+- macOS Apple Silicon (`Proma-x.y.z-arm64.dmg`)
+- macOS Intel (`Proma-x.y.z.dmg`)
+- Windows (`Proma-Setup-x.y.z.exe`)
+
+After installing, launch Proma and finish the first-run environment check. Agent mode relies on a working local shell plus Git and Node.js / Bun, so make sure those are available on your `PATH`.
+
+#### 2. Configure the DeepSeek Channel
+
+Open **Settings → Channels** from the sidebar. Proma ships with a pre-created **DeepSeek** channel — you only need to fill in the API key.
+
+1. Locate the **DeepSeek** entry in the channel list (created automatically on first launch). If it is missing, click **Add Channel** and choose **DeepSeek** from the provider dropdown.
+2. Paste your [DeepSeek API Key](https://platform.deepseek.com/api_keys) into the **API Key** field. The **Base URL** is preset to `https://api.deepseek.com/anthropic` (DeepSeek's Anthropic-compatible endpoint) — leave it as is.
+3. Confirm the **Models** list includes `deepseek-v4-pro` and `deepseek-v4-flash`. Both are seeded by default.
+4. Toggle **Enabled** on, then click **Test Connection** to verify the key.
+
+That is all the wiring needed. Proma will route DeepSeek through its Anthropic-compatible adapter for both Chat and Agent modes.
+
+#### 3. Use DeepSeek in Chat Mode
+
+Open the **Chat** tab in the sidebar, start a new conversation, and pick **DeepSeek V4 Pro** (or **DeepSeek V4 Flash**) from the model selector at the top of the input box.
+
+Chat mode supports streaming responses, attachments (PDF, Office, images), Markdown / Mermaid / KaTeX / code highlighting, side-by-side comparison with other models, system prompts, and built-in web search — all working with DeepSeek out of the box.
+
+#### 4. Use DeepSeek in Agent Mode
+
+Open **Settings → Agent** and set the **Default Agent Channel** to your DeepSeek channel and **Default Model** to `deepseek-v4-pro`. Then switch to the **Agent** tab and start a new session.
+
+Proma's Agent mode is built on `@anthropic-ai/claude-agent-sdk` and gives DeepSeek V4 a full agentic loop — tool use, plan mode, permission gating, and SubAgent dispatch — inside a desktop GUI:
+
+- **1M context auto-enabled** for `deepseek-v4-pro` / `deepseek-v4-flash` (`context-1m-2025-08-07` beta).
+- **Built-in sub-agents** — `explorer`, `researcher`, `code-reviewer` — that the system prompt actively delegates to, with complexity-aware routing across DeepSeek V4 Pro and V4 Flash. DeepSeek runs as an *orchestrator*, not just an answerer; long tasks never pollute the main context.
+- **Workspace-scoped Skills, MCP, memory, files** — switch workspace to switch project context.
+- **Plan mode, permission approvals, and live SubAgent activity** — all surfaced inline in the message stream.
+- **Remote triggers** — kick off DeepSeek-powered Agent runs from Feishu / Lark, DingTalk, or WeChat groups.
+
+#### 5. Why Proma is the Smoothest Open-Source Path for DeepSeek V4
+
+- **Zero-config DeepSeek.** Preset channel, preset models, 1M context wired in code — paste the key and go.
+- **One key, both modes.** The same DeepSeek channel powers Chat and a full agentic Agent in a single client.
+- **Aggressive SubAgent orchestration.** Built-in `explorer` / `researcher` / `code-reviewer` plus a system prompt that actively delegates with complexity-aware routing across DeepSeek V4 Pro and V4 Flash — DeepSeek punches well above what a single context window can do alone.
+- **GUI beyond terminal agents.** Real-time SubAgent activity, side-by-side Diff preview, multi-session parallel streaming, attachment preview, plan / permission UI, voice input, and Feishu / DingTalk / WeChat bot bridges — all in a desktop app.
+- **Local-first.** Sessions, workspaces, and Skills live under `~/.proma/` as JSON / JSONL — easy to back up, easy to inspect.
+
+Proma is fully open source ([Apache-2.0](https://github.com/ErlichLiu/Proma)) and welcomes Skills, MCP configs, and Agent workflow contributions that showcase what DeepSeek V4 can do.

--- a/docs/proma.zh-CN.md
+++ b/docs/proma.zh-CN.md
@@ -1,0 +1,61 @@
+[English](./proma.md) | [简体中文](./proma.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Proma
+
+Proma 是一个本地优先的开源 AI 桌面 Agent，支持 macOS 和 Windows。它把多模型 **Chat 模式**、基于 Claude Agent SDK 的通用 **Agent 模式**，以及工作区、Skills、MCP、记忆、远程机器人等能力放在同一个客户端里。
+
+DeepSeek 是 Proma 的**一等公民渠道**：首次启动自动创建 DeepSeek 预设渠道，`deepseek-v4-pro` / `deepseek-v4-flash` 自动启用 1M 上下文 Beta，同一个 Key 同时驱动 Chat 与 Agent 模式。再叠加 Proma 主动的 SubAgent 编排和把每一步执行都可视化的桌面 UI，这是目前开源里把 DeepSeek V4 真正用起来最丝滑的路径 —— 无需任何终端配置。
+
+- **GitHub:** <https://github.com/ErlichLiu/Proma>
+- **官网:** <https://proma.cool>
+
+#### 1. 安装 Proma
+
+从 [Proma Releases 页面](https://github.com/ErlichLiu/Proma/releases) 下载对应平台的安装包。
+
+提供的安装包：
+
+- macOS Apple Silicon (`Proma-x.y.z-arm64.dmg`)
+- macOS Intel (`Proma-x.y.z.dmg`)
+- Windows (`Proma-Setup-x.y.z.exe`)
+
+安装后启动 Proma 并完成首次运行的环境检查。Agent 模式依赖本机的 Shell、Git 和 Node.js / Bun，请确保这些工具在 `PATH` 中可用。
+
+#### 2. 配置 DeepSeek 渠道
+
+从侧边栏打开 **设置 → 渠道**。Proma 内置了 **DeepSeek** 预设渠道 —— 你只需要填入 API Key。
+
+1. 在渠道列表中找到 **DeepSeek** 条目（首次启动自动创建）。如果不存在，点击 **新建渠道** 并从供应商下拉中选择 **DeepSeek**。
+2. 在 **API Key** 字段粘贴你的 [DeepSeek API Key](https://platform.deepseek.com/api_keys)。**Base URL** 已经预设为 `https://api.deepseek.com/anthropic`（DeepSeek 的 Anthropic 兼容端点），保持默认即可。
+3. 确认 **模型列表** 包含 `deepseek-v4-pro` 和 `deepseek-v4-flash`，这两个模型已经预置好。
+4. 打开 **启用** 开关，点击 **测试连接** 验证 Key。
+
+到这里渠道配置就完成了。Proma 会通过 Anthropic 兼容适配器，让 DeepSeek 同时驱动 Chat 模式和 Agent 模式。
+
+#### 3. 在 Chat 模式中使用 DeepSeek
+
+打开侧边栏的 **Chat** 标签页，开始一个新会话，在输入框顶部的模型选择器里选择 **DeepSeek V4 Pro**（或 **DeepSeek V4 Flash**）。
+
+Chat 模式支持流式响应、附件（PDF、Office、图片）、Markdown / Mermaid / KaTeX / 代码高亮、多模型并排对比、系统提示词以及内置联网搜索 —— 这些功能在 DeepSeek 上都是开箱即用的。
+
+#### 4. 在 Agent 模式中使用 DeepSeek
+
+打开 **设置 → Agent**，把 **默认 Agent 渠道** 设为你的 DeepSeek 渠道，**默认模型** 设为 `deepseek-v4-pro`。然后切换到 **Agent** 标签页，新建一个会话。
+
+Proma 的 Agent 模式基于 `@anthropic-ai/claude-agent-sdk` 构建，让 DeepSeek V4 在桌面 GUI 里跑完整的 Agent 循环 —— 工具调用、计划模式、权限控制、SubAgent 派发：
+
+- **1M 上下文自动启用**：识别到 `deepseek-v4-pro` / `deepseek-v4-flash` 自动附加 `context-1m-2025-08-07` Beta。
+- **内置 SubAgent 体系** —— `explorer` / `researcher` / `code-reviewer`，系统提示词主动派发，配合按复杂度在 DeepSeek V4 Pro 与 V4 Flash 之间路由。DeepSeek 作为**编排者**而非单点应答者，长任务不会污染主上下文。
+- **工作区级 Skills / MCP / 记忆 / 文件**，切换工作区即切换项目上下文。
+- **计划模式、权限审批、SubAgent 实时活动**全部内联呈现在消息流中。
+- **远程触发**：从飞书 / Lark、钉钉、企业微信群里触发 DeepSeek 驱动的 Agent 工作流，桌面端本机执行。
+
+#### 5. 为什么 Proma 是用 DeepSeek V4 最丝滑的开源路径
+
+- **零配置 DeepSeek**：预设渠道、预设模型、1M 上下文写在代码里 —— 粘贴 Key 即可开干。
+- **一个 Key，两种模式**：同一个 DeepSeek 渠道同时驱动 Chat 与完整 Agent 循环，一个客户端搞定。
+- **主动的 SubAgent 编排**：内置 `explorer` / `researcher` / `code-reviewer`，系统提示词主动派发，按复杂度在 DeepSeek V4 Pro 与 V4 Flash 之间路由 —— DeepSeek 能爆发出远超单一上下文窗口的能力。
+- **GUI 超越终端 Agent**：SubAgent 实时活动流、并排 Diff 预览、多会话并发流式、附件预览、计划/权限 UI、语音输入、飞书/钉钉/微信机器人桥接 —— 完整呈现在一个桌面应用里。
+- **本地优先**：会话、工作区、Skills 全部以 JSON / JSONL 存在 `~/.proma/`，易于备份、易于审查。
+
+Proma 完全开源（[Apache-2.0](https://github.com/ErlichLiu/Proma)），欢迎贡献能体现 DeepSeek V4 能力的 Skills、MCP 配置和 Agent 工作流。


### PR DESCRIPTION
## What

Adds **Proma** — a local-first, open-source desktop AI agent for macOS and Windows — to `awesome-deepseek-agent`.

- New guide: `docs/proma.md` (English) and `docs/proma.zh-CN.md` (简体中文)
- README entries inserted in alphabetical order (between **Pi** and **Reasonix**) in both `README.md` and `README.zh-CN.md`

Repo: <https://github.com/ErlichLiu/Proma>
Website: <https://proma.cool>

## Why Proma is a great fit for this list

DeepSeek is a **first-class, preset provider** in Proma:

- A DeepSeek channel is **auto-provisioned on first launch** — paste the key and go, no manual base URL or model wiring.
- The **1M context beta** (`context-1m-2025-08-07`) is **enabled in code** for `deepseek-v4-pro` / `deepseek-v4-flash` — users get the full window without touching a config flag.
- Base URL preset to DeepSeek's Anthropic-compatible endpoint `https://api.deepseek.com/anthropic`.
- A single DeepSeek key powers **both Chat mode and a full agentic Agent mode** in one client.

Differentiators relative to other tools already in the list:

- **Aggressive SubAgent orchestration.** Built-in `explorer` / `researcher` / `code-reviewer` sub-agents with system-prompt-level delegation and complexity-aware routing across DeepSeek V4 Pro / V4 Flash. DeepSeek runs as an *orchestrator*, not just an answerer; long tasks don't pollute the main context.
- **GUI beyond terminal agents.** Real-time SubAgent activity stream, side-by-side Diff preview, multi-session parallel streaming, attachment preview (PDF / Office / images), plan / permission UI, voice input, and Feishu / DingTalk / WeChat bot bridges — all in a desktop app.
- **Local-first.** Sessions, workspaces, Skills, and configs live as JSON / JSONL under `~/.proma/` — easy to back up and inspect, no local DB.

## Checklist (per CONTRIBUTING.md)

- [x] One tool = one PR
- [x] English + 简体中文 guides in the same PR
- [x] Model names use `deepseek-v4-pro` / `deepseek-v4-flash`
- [x] 1M context configured (auto-enabled in Proma's Agent SDK integration)
- [x] Base URL points to the official Anthropic-compatible endpoint
- [x] No pricing tables included (skipped to avoid going stale)
- [x] No workarounds for upstream-fixed bugs
- [x] README entries inserted in alphabetical order (between Pi and Reasonix), both English and Chinese
- [x] Configuration verified end-to-end in the agent

License: Apache-2.0.
