### PR TITLE
docs: add VT Code integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Codex** | OpenAI's coding agent. | [Guide](./docs/codex.md) |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
+| **VT Code** | Rust terminal coding agent with native DeepSeek V4 support and 1M context. | [Guide](./docs/vtcode.md) |
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,6 +21,7 @@
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Codex** | OpenAI 的编程 Agent。 | [指南](./docs/codex.zh-CN.md) |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
+| **VT Code** | 基于 Rust 的终端编程 Agent，原生支持 DeepSeek V4 和 100 万上下文。 | [指南](./docs/vtcode.zh-CN.md) |
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |

--- a/docs/vtcode.md
+++ b/docs/vtcode.md
@@ -1,0 +1,61 @@
+[English](./vtcode.md) | [简体中文](./vtcode.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with VT Code
+
+VT Code is a Rust terminal coding agent with native DeepSeek support, so you can connect it directly to DeepSeek V4 without a proxy or custom endpoint.
+
+#### 1. Install VT Code
+
+Install VT Code using your preferred method, then make sure the `vtcode` binary is on your `PATH`.
+
+```shell
+cargo install vtcode
+```
+
+If you want a fresh project config, run:
+
+```shell
+vtcode init
+```
+
+#### 2. Get a DeepSeek API Key
+
+- Go to [DeepSeek Platform](https://platform.deepseek.com/api_keys) and create an API key.
+- Save it in your shell as `DEEPSEEK_API_KEY`.
+
+#### 3. Configure VT Code
+
+Create or edit `vtcode.toml` in your project root:
+
+```toml
+[agent]
+provider = "deepseek"
+api_key_env = "DEEPSEEK_API_KEY"
+default_model = "deepseek-v4-pro"
+reasoning_effort = "max"
+
+[agent.model_settings]
+context_window = 1000000
+max_output_tokens = 384000
+```
+
+Notes:
+
+- `deepseek-v4-pro` is the best default for coding tasks.
+- `reasoning_effort = "max"` matches DeepSeek V4 Pro’s highest reasoning setting.
+- `context_window = 1000000` and `max_output_tokens = 384000` reflect DeepSeek V4’s 1M context support.
+- If you want a faster and cheaper default, switch `default_model` to `deepseek-v4-flash`.
+
+#### 4. Start VT Code
+
+```shell
+cd /path/to/your-project
+vtcode ask "Summarize this repository"
+```
+
+If you prefer the full interactive session, run `vtcode` instead.
+
+#### Resources
+
+- [VT Code](https://github.com/vinhnx/vtcode)
+- [DeepSeek API Docs](https://api-docs.deepseek.com/)

--- a/docs/vtcode.zh-CN.md
+++ b/docs/vtcode.zh-CN.md
@@ -1,0 +1,61 @@
+[English](./vtcode.md) | [简体中文](./vtcode.zh-CN.md) · [← Back](../README.md)
+
+# 接入 VT Code
+
+VT Code 是一款 Rust 终端编程 Agent，内置 DeepSeek 支持，因此你可以直接连接 DeepSeek V4，无需代理或自定义接口。
+
+#### 1. 安装 VT Code
+
+使用你习惯的方式安装 VT Code，并确保 `vtcode` 命令已加入 `PATH`。
+
+```shell
+cargo install vtcode
+```
+
+如果你想生成一份新的项目配置，可以执行：
+
+```shell
+vtcode init
+```
+
+#### 2. 获取 DeepSeek API Key
+
+- 前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 创建 API Key。
+- 将其保存为环境变量 `DEEPSEEK_API_KEY`。
+
+#### 3. 配置 VT Code
+
+在项目根目录创建或编辑 `vtcode.toml`：
+
+```toml
+[agent]
+provider = "deepseek"
+api_key_env = "DEEPSEEK_API_KEY"
+default_model = "deepseek-v4-pro"
+reasoning_effort = "max"
+
+[agent.model_settings]
+context_window = 1000000
+max_output_tokens = 384000
+```
+
+说明：
+
+- `deepseek-v4-pro` 是编程任务最合适的默认模型。
+- `reasoning_effort = "max"` 对应 DeepSeek V4 Pro 的最高推理强度。
+- `context_window = 1000000` 和 `max_output_tokens = 384000` 体现了 DeepSeek V4 的 100 万上下文支持。
+- 如果你更重视速度和成本，可以把 `default_model` 改成 `deepseek-v4-flash`。
+
+#### 4. 启动 VT Code
+
+```shell
+cd /path/to/your-project
+vtcode ask "总结一下这个仓库"
+```
+
+如果你想进入完整交互式会话，也可以直接运行 `vtcode`。
+
+#### 相关资源
+
+- [VT Code](https://github.com/vinhnx/vtcode)
+- [DeepSeek API 文档](https://api-docs.deepseek.com/zh-cn/)


### PR DESCRIPTION
### Summary
- Added a bilingual VT Code guide
- Linked it from both READMEs

### Checklist
- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- Pricing not included in this guide
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation
- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in docs/assets/ with descriptive filenames and reasonable sizes (none added)
