### PR TITLE
Add OpenClacky integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
+| **OpenClacky** | Most token-efficient open-source AI agent (MIT) — native DeepSeek support, ~100% cache hit, Web UI + Terminal + IM (Feishu/WeCom/WeChat/Discord/Telegram). | [Guide](./docs/openclacky.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **AstrBot**     | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs.       | [Guide](./docs/astrbot.md)     |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,6 +24,7 @@
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
+| **OpenClacky** | 开源最省 Token 的 AI Agent（MIT）—— 原生支持 DeepSeek，缓存命中接近 100%，提供 Web UI、终端及飞书 / 企业微信 / 微信 / Discord / Telegram 接入。 | [指南](./docs/openclacky.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |

--- a/docs/openclacky.md
+++ b/docs/openclacky.md
@@ -1,0 +1,81 @@
+[English](./openclacky.md) | [简体中文](./openclacky.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with OpenClacky
+
+[OpenClacky](https://github.com/clacky-ai/openclacky) is the most token-efficient open-source AI agent (MIT). It ships with native DeepSeek support — proper handling of `reasoning_content`, ~100% prompt-cache hit rate, and a Web UI / Terminal / IM (Feishu, WeCom, WeChat, Discord, Telegram) experience all from one binary.
+
+#### 1. Install OpenClacky
+
+**macOS / Linux**
+
+```bash
+/bin/bash -c "$(curl -sSL https://raw.githubusercontent.com/clacky-ai/openclacky/main/scripts/install.sh)"
+```
+
+**Windows**
+
+```powershell
+powershell -c "& ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/clacky-ai/openclacky/main/scripts/install.ps1')))"
+```
+
+**Or via RubyGems** (Ruby >= 3.1.0):
+
+```bash
+gem install openclacky
+```
+
+Desktop installers (`.dmg` / `.exe`) are available at [openclacky.com](https://www.openclacky.com/).
+
+#### 2. Configure DeepSeek as the Default Model
+
+Start OpenClacky and open the configuration menu:
+
+```bash
+openclacky
+> /config
+```
+
+Set the following fields:
+
+| Field | Value |
+| --- | --- |
+| Provider | **DeepSeek** (built-in) |
+| Base URL | `https://api.deepseek.com` |
+| API Key | Your [DeepSeek API key](https://platform.deepseek.com/api_keys) |
+| Model | `deepseek-v4-pro` (recommended) or `deepseek-v4-flash` |
+| Context window | `1000000` (DeepSeek V4 supports 1M tokens) |
+| Reasoning effort | `max` (best coding quality) — `high` also supported |
+
+OpenClacky has first-class DeepSeek V4 support and correctly passes back `reasoning_content`, so you do **not** need to disable thinking mode. Keeping `reasoning_effort=max` gives the best result on coding tasks.
+
+#### 3. Get Started
+
+**Web UI** (recommended — multi-session, parallel coding/research/copywriting):
+
+```bash
+openclacky server          # http://localhost:7070
+openclacky server --port 8080
+openclacky server --host 0.0.0.0   # remote access
+```
+
+**Terminal**:
+
+```bash
+openclacky                 # interactive agent in current directory
+```
+
+**Scaffold a new project**:
+
+```bash
+$ openclacky
+> /new my-app
+> Add user auth with email and password
+```
+
+#### 4. Why This Combo Works
+
+- **~100% prompt cache hit** — sessions never restart, the system prompt is never mutated, and idle-time auto-compression pre-warms the cache. Combined with DeepSeek's $0.003625 / M tokens cache-hit price, real spend on long sessions drops dramatically.
+- **16 core tools + `invoke_skill`** — small tool schema means a small request payload, which means more of every prompt fits inside the 1M context window without paging.
+- **BYOK routing** — keep `deepseek-v4-pro` as the default and let subagents fan out to `deepseek-v4-flash` for cheaper subtasks.
+
+More docs: [openclacky.com/docs](https://www.openclacky.com/docs/installation) · [GitHub](https://github.com/clacky-ai/openclacky)

--- a/docs/openclacky.zh-CN.md
+++ b/docs/openclacky.zh-CN.md
@@ -1,0 +1,81 @@
+[English](./openclacky.md) | [简体中文](./openclacky.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 OpenClacky
+
+[OpenClacky](https://github.com/clacky-ai/openclacky) 是目前最省 Token 的开源 AI Agent（MIT 协议）。原生支持 DeepSeek，对 `reasoning_content` 处理良好，缓存命中率接近 100%，一个二进制即可使用 Web UI / 终端 / 飞书 / 企业微信 / 微信 / Discord / Telegram。
+
+#### 1. 安装 OpenClacky
+
+**macOS / Linux**
+
+```bash
+/bin/bash -c "$(curl -sSL https://raw.githubusercontent.com/clacky-ai/openclacky/main/scripts/install.sh)"
+```
+
+**Windows**
+
+```powershell
+powershell -c "& ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/clacky-ai/openclacky/main/scripts/install.ps1')))"
+```
+
+**或通过 RubyGems 安装**（需 Ruby >= 3.1.0）：
+
+```bash
+gem install openclacky
+```
+
+桌面端安装包（`.dmg` / `.exe`）可在 [openclacky.com](https://www.openclacky.com/) 下载。
+
+#### 2. 配置 DeepSeek 作为默认模型
+
+启动 OpenClacky，打开配置菜单：
+
+```bash
+openclacky
+> /config
+```
+
+按下表填写：
+
+| 字段 | 值 |
+| --- | --- |
+| Provider | **DeepSeek**（内置） |
+| Base URL | `https://api.deepseek.com` |
+| API Key | 你的 [DeepSeek API Key](https://platform.deepseek.com/api_keys) |
+| Model | `deepseek-v4-pro`（推荐）或 `deepseek-v4-flash` |
+| 上下文窗口 | `1000000`（DeepSeek V4 支持 1M tokens） |
+| Reasoning effort | `max`（编码体验最佳），也支持 `high` |
+
+OpenClacky 对 DeepSeek V4 有原生一等支持，正确回传 `reasoning_content`，**无需关闭** Thinking Mode。保持 `reasoning_effort=max` 可以获得最佳编码效果。
+
+#### 3. 开始使用
+
+**Web UI**（推荐，多会话并行 —— 编码 / 研究 / 文案同时跑）：
+
+```bash
+openclacky server          # http://localhost:7070
+openclacky server --port 8080
+openclacky server --host 0.0.0.0   # 允许远程访问
+```
+
+**终端模式**：
+
+```bash
+openclacky                 # 在当前目录启动交互式 Agent
+```
+
+**新建项目脚手架**：
+
+```bash
+$ openclacky
+> /new my-app
+> 帮我加一个邮箱密码登录
+```
+
+#### 4. 这套组合为什么省钱
+
+- **~100% Prompt 缓存命中** —— 会话不重启、System Prompt 不被修改、空闲时自动压缩并预热缓存。配合 DeepSeek $0.003625 / M tokens 的缓存命中价，长会话实际花费大幅下降。
+- **16 个核心工具 + `invoke_skill`** —— 工具 schema 小，请求体小，1M 上下文窗口能装下更多有效内容。
+- **BYOK 多模型路由** —— 主 Agent 用 `deepseek-v4-pro`，子任务路由到 `deepseek-v4-flash`，再省一档。
+
+更多文档：[openclacky.com/docs](https://www.openclacky.com/docs/installation) · [GitHub](https://github.com/clacky-ai/openclacky)


### PR DESCRIPTION
## Summary

Adds an integration guide for [OpenClacky](https://github.com/clacky-ai/openclacky) — an MIT-licensed open-source AI agent with native DeepSeek support,
~100% prompt-cache hit rate, and a Web UI / Terminal / IM (Feishu, WeCom, WeChat, Discord, Telegram) experience from one binary.

## Changes

- `docs/openclacky.md` — English guide
- `docs/openclacky.zh-CN.md` — Simplified Chinese guide
- `README.md` / `README.zh-CN.md` — table entry inserted in alphabetical order (before `OpenClaw`)

## Checklist

### Agent Configuration
- [x] Model names use the current `deepseek-v4-pro` / `deepseek-v4-flash` (no `deepseek-chat` / `deepseek-reasoner` / `deepseek-coder`)
- [x] 1M context window documented (`context_window: 1000000`)
- [x] `reasoning_effort=max` recommended; guide explicitly notes OpenClacky handles `reasoning_content` correctly so users do **not** need to disable
thinking mode
- [x] No workaround for already-fixed upstream bugs — DeepSeek V4 thinking-mode support is native
- [x] No pricing table included (so no stale numbers to maintain)
- [x] Configuration fields shown (`/config` → Provider / Base URL / API Key / Model / Context window / Reasoning effort) are verified to work in the agent

### Documentation
- [x] Both English and Chinese versions in a single PR
- [x] README table entry added in alphabetical order in both `README.md` and `README.zh-CN.md`
- [x] Single tool per PR
- [x] No images added (no `docs/assets/` changes)

## Notes for reviewers

OpenClacky's value prop for DeepSeek users is specifically token efficiency:
- session never restarts and the system prompt is never mutated → near-100% prompt cache hit, which compounds with DeepSeek's $0.003625 / M tokens
cache-hit price
- 16 core tools + a single `invoke_skill` meta-tool → small request payload leaves more room in the 1M context
- BYOK routing → main agent on `deepseek-v4-pro`, subagents fan out to `deepseek-v4-flash`