### PR TITLE
Add OpenAgentd integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Codex** | OpenAI's coding agent. | [Guide](./docs/codex.md) |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
+| **OpenAgentd** | Open-source desktop cockpit for local AI agent teams with a built-in DeepSeek provider. | [Guide](./docs/openagentd.md) |
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@
 | **Codex** | OpenAI 的编程 Agent。 | [指南](./docs/codex.zh-CN.md) |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
+| **OpenAgentd** | 开源的本地 AI Agent 团队桌面控制台，内置 DeepSeek Provider。 | [指南](./docs/openagentd.zh-CN.md) |
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |

--- a/docs/openagentd.md
+++ b/docs/openagentd.md
@@ -1,0 +1,49 @@
+[English](./openagentd.md) | [简体中文](./openagentd.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with OpenAgentd
+
+[OpenAgentd](https://github.com/lthoangg/openagentd) is an open-source desktop cockpit for local AI agents. It runs a FastAPI sidecar and React UI locally, supports a lead-and-member agent team, and includes a built-in DeepSeek provider.
+
+#### 1. Install OpenAgentd
+
+For the desktop app, install with Homebrew on macOS:
+
+```bash
+brew install --cask lthoangg/tap/openagentd
+```
+
+Or download the latest macOS / Linux desktop build from the [OpenAgentd releases page](https://github.com/lthoangg/openagentd/releases/latest).
+
+For the CLI / local web server:
+
+```bash
+uv tool install openagentd
+openagentd init
+openagentd
+```
+
+OpenAgentd serves the local UI at `http://localhost:4082`.
+
+#### 2. Configure DeepSeek
+
+In the desktop or web UI, open **Settings → Providers**, select **DeepSeek**, paste your [DeepSeek API Key](https://platform.deepseek.com/api_keys), and choose `deepseek-v4-pro` or `deepseek-v4-flash`.
+
+You can also configure the lead agent directly in `~/.config/openagentd/agents/openagentd.md`:
+
+```yaml
+---
+name: openagentd
+role: lead
+model: deepseek:deepseek-v4-pro
+temperature: 0.2
+thinking_level: high
+---
+```
+
+For coding mode, apply the same model setting to `~/.config/openagentd/agents/coding/openagentd.md`.
+
+OpenAgentd maps `thinking_level` to DeepSeek's thinking mode fields. Use `deepseek-v4-pro` with `thinking_level: high` for stronger coding sessions, or `deepseek-v4-flash` for faster lower-cost runs. DeepSeek V4 supports a 1 million token context window; OpenAgentd does not require a separate context-window setting for the built-in DeepSeek provider.
+
+#### 3. Start Using It
+
+Launch OpenAgentd, start a new session, and send a message. In coding mode, OpenAgentd shows workspace files, tool calls, inline diffs, todos, and spawned team members in the same local UI while DeepSeek drives the agent loop.

--- a/docs/openagentd.zh-CN.md
+++ b/docs/openagentd.zh-CN.md
@@ -1,0 +1,49 @@
+[English](./openagentd.md) | [简体中文](./openagentd.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 OpenAgentd
+
+[OpenAgentd](https://github.com/lthoangg/openagentd) 是开源的本地 AI Agent 桌面控制台。它在本机运行 FastAPI sidecar 与 React UI，支持主 Agent + 成员 Agent 的团队模式，并内置 DeepSeek Provider。
+
+#### 1. 安装 OpenAgentd
+
+macOS 桌面版可以通过 Homebrew 安装：
+
+```bash
+brew install --cask lthoangg/tap/openagentd
+```
+
+也可以从 [OpenAgentd Releases 页面](https://github.com/lthoangg/openagentd/releases/latest) 下载最新的 macOS / Linux 桌面构建。
+
+如果使用 CLI / 本地 Web Server：
+
+```bash
+uv tool install openagentd
+openagentd init
+openagentd
+```
+
+OpenAgentd 会在 `http://localhost:4082` 启动本地 UI。
+
+#### 2. 配置 DeepSeek
+
+在桌面或 Web UI 中打开 **Settings → Providers**，选择 **DeepSeek**，填入你的 [DeepSeek API Key](https://platform.deepseek.com/api_keys)，并选择 `deepseek-v4-pro` 或 `deepseek-v4-flash`。
+
+你也可以直接编辑主 Agent 配置文件 `~/.config/openagentd/agents/openagentd.md`：
+
+```yaml
+---
+name: openagentd
+role: lead
+model: deepseek:deepseek-v4-pro
+temperature: 0.2
+thinking_level: high
+---
+```
+
+如果使用编码模式，请在 `~/.config/openagentd/agents/coding/openagentd.md` 中设置同样的模型。
+
+OpenAgentd 会将 `thinking_level` 映射为 DeepSeek 的 thinking mode 字段。编码任务推荐使用 `deepseek-v4-pro` 与 `thinking_level: high`，如果更看重速度和成本，可以选择 `deepseek-v4-flash`。DeepSeek V4 支持 100 万 token 上下文窗口；OpenAgentd 内置 DeepSeek Provider 不需要额外配置上下文窗口。
+
+#### 3. 开始使用
+
+启动 OpenAgentd，新建会话并发送消息即可。编码模式下，OpenAgentd 会在同一个本地 UI 中展示工作区文件、工具调用、内联 diff、todos 与团队成员运行状态，由 DeepSeek 驱动 Agent 循环。


### PR DESCRIPTION
## Summary
- Add English and Simplified Chinese OpenAgentd integration guides
- Add OpenAgentd to both README tool tables
- Document DeepSeek provider model IDs, API key setup, thinking level, and 1M context support

## Checklist

### Agent Configuration
- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against DeepSeek API Docs
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation
- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in docs/assets/ with descriptive filenames and reasonable sizes

No pricing or images are included in this guide.