### PR TITLE
docs: add Iris integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
+| **Iris**        | Open-source multi-platform AI agent for Console / Web / Discord / Telegram / WeChat / WeCom / Lark / QQ, with built-in DeepSeek provider, tools, sessions, MCP, and memory. | [Guide](./docs/iris.md)        |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **LobeHub** | LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. | [Guide](./docs/lobehub.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,7 @@
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
+| **Iris** | 开源多平台 AI 代理，支持 Console / Web / Discord / Telegram / 微信 / 企业微信 / 飞书 / QQ，内置 DeepSeek provider、工具系统、会话存储、MCP 和记忆能力。 | [指南](./docs/iris.zh-CN.md) |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **Langcli** | 100% 兼容 Claude Code、支持 DeepSeek V4 等主流 LLM 模型的开源 AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **LobeHub** | LobeHub 是你的 Chief Agent Operator，通过招聘、排班并报告整个 AI 团队，将你的 Agent 组织成 7×24 小时运作。 | [指南](./docs/lobehub.zh-CN.md) |

--- a/docs/iris.md
+++ b/docs/iris.md
@@ -1,0 +1,86 @@
+[English](./iris.md) | [简体中文](./iris.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Iris
+
+[Iris](https://github.com/Lianues/Iris) is an open-source multi-platform AI agent that runs on Console (TUI), Web, Discord, Telegram, WeChat, WeCom, Lark, and QQ, with built-in tool calling, session storage, image input, OCR fallback, MCP, memory, and multi-agent support. DeepSeek is one of its first-class LLM providers — Iris talks to `api.deepseek.com` directly, no proxy required.
+
+#### 1. Install Iris
+
+Recommended (cross-platform, requires Node.js):
+
+```bash
+npm install -g irises
+```
+
+The CLI is `iris`; the npm package is `irises`. Other install methods (GitHub Release binary, Linux one-line installer, Docker, source build) are listed in the [Iris install guide](https://github.com/Lianues/Iris/blob/main/docs/install.md).
+
+#### 2. Configure DeepSeek with the onboard wizard
+
+Get an API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys), then run:
+
+```bash
+iris onboard
+```
+
+In the interactive TUI wizard:
+
+- When prompted for **LLM provider**, select **DeepSeek**.
+- When prompted for **API Key**, paste your DeepSeek API Key.
+- When prompted for **Model**, choose `deepseek-v4-pro` (for coding and complex reasoning) or `deepseek-v4-flash` (for fast, lower-cost iteration).
+- For the remaining prompts (platforms, model alias, etc.), accept the defaults or configure as needed.
+
+The wizard writes to `~/.iris/configs/llm.yaml` (override the path via the `IRIS_DATA_DIR` environment variable).
+
+If you prefer YAML, the equivalent `~/.iris/configs/llm.yaml` is:
+
+```yaml
+defaultModel: deepseek_pro
+
+models:
+  deepseek_pro:
+    provider: deepseek
+    apiKey: sk-your-deepseek-api-key
+    model: deepseek-v4-pro
+    contextWindow: 1000000
+    requestBody:
+      thinking:
+        type: enabled
+      reasoning_effort: max
+      max_tokens: 384000
+
+  deepseek_flash:
+    provider: deepseek
+    apiKey: sk-your-deepseek-api-key
+    model: deepseek-v4-flash
+    contextWindow: 1000000
+    requestBody:
+      max_tokens: 384000
+```
+
+- `contextWindow: 1000000` enables DeepSeek V4's full **1M-token** context window in Iris's TUI usage gauge.
+- `requestBody.thinking.type: enabled` plus `reasoning_effort: max` turn on DeepSeek V4 thinking at the deepest reasoning level. Both are the official OpenAI-format control parameters documented in DeepSeek's [Thinking Mode guide](https://api-docs.deepseek.com/guides/thinking_mode) — recommended for coding and multi-step agent tasks.
+- `max_tokens: 384000` lifts the per-response output cap so V4 has enough budget for long chains of thought plus the final answer.
+
+#### 3. Start Iris
+
+```bash
+iris or iris start
+```
+
+Inside the Console TUI, use `/model` to switch between configured models, `/settings` to open the LLM / System / MCP settings center, and `/exit` to quit. The full Slash-command reference is in [docs/platforms.md](https://github.com/Lianues/Iris/blob/main/docs/platforms.md).
+
+#### Optional: run Iris on chat platforms
+
+Iris can also run as a Web GUI or as a bot on Discord, Telegram, Lark, QQ, WeChat, or WeCom. Update `platform.type` in `~/.iris/configs/platform.yaml`, and install the IM extension if needed:
+
+```bash
+iris ext install lark    # example: install the Lark extension
+```
+
+Per-platform tokens and bot setup are documented in [docs/platforms.md](https://github.com/Lianues/Iris/blob/main/docs/platforms.md).
+
+#### Troubleshooting
+
+- **`baseUrl` seems ignored.** By design. `provider: deepseek` always hits the official endpoint `https://api.deepseek.com/v1`. If you need to route through a custom proxy or gateway, use `provider: openai-compatible` with your gateway's `baseUrl` instead.
+- **`Invalid model` error.** When using `provider: deepseek`, the `model` field accepts only `deepseek-v4-pro` or `deepseek-v4-flash`. Older V3-era model ids are no longer supported.
+- **No thoughts visible in the TUI.** Make sure `requestBody.thinking.type: enabled` is nested under your DeepSeek model entry, not at the top level of `llm.yaml`.

--- a/docs/iris.zh-CN.md
+++ b/docs/iris.zh-CN.md
@@ -1,0 +1,86 @@
+[English](./iris.md) | [简体中文](./iris.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Iris
+
+[Iris](https://github.com/Lianues/Iris) 是一款开源的多平台 AI 代理 Agent，支持 Console（TUI）、Web、Discord、Telegram、微信、企业微信、飞书、QQ 等平台，内置工具调用、会话存储、图片输入、OCR 回退、MCP、记忆与多 Agent 能力。Iris 原生支持 DeepSeek 作为 LLM 提供商 —— 直接对接 `api.deepseek.com`，无需任何代理层。
+
+#### 1. 安装 Iris
+
+推荐方式（跨平台，需要 Node.js）：
+
+```bash
+npm install -g irises
+```
+
+命令行入口是 `iris`，npm 包名是 `irises`。其他安装方式（GitHub Release 二进制、Linux 一键脚本、Docker、源码编译）请参阅 [Iris 安装文档](https://github.com/Lianues/Iris/blob/main/docs/install.md)。
+
+#### 2. 通过交互式向导配置 DeepSeek
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key，然后执行：
+
+```bash
+iris onboard
+```
+
+在 TUI 向导中：
+
+- 当提示 **LLM 提供商** 时，选择 **DeepSeek**。
+- 当提示 **API Key** 时，粘贴你的 DeepSeek API Key。
+- 当提示 **模型** 时，在 `deepseek-v4-pro`（编程与复杂推理）和 `deepseek-v4-flash`（快速、低成本日常任务）之间二选一。
+- 剩余选项（平台、模型别名等）按需配置或保留默认值。
+
+向导会把配置写入 `~/.iris/configs/llm.yaml`（可通过 `IRIS_DATA_DIR` 环境变量覆盖路径）。
+
+如果你习惯直接编辑 YAML，对应的 `~/.iris/configs/llm.yaml` 是：
+
+```yaml
+defaultModel: deepseek_pro
+
+models:
+  deepseek_pro:
+    provider: deepseek
+    apiKey: sk-your-deepseek-api-key
+    model: deepseek-v4-pro
+    contextWindow: 1000000
+    requestBody:
+      thinking:
+        type: enabled
+      reasoning_effort: max
+      max_tokens: 384000
+
+  deepseek_flash:
+    provider: deepseek
+    apiKey: sk-your-deepseek-api-key
+    model: deepseek-v4-flash
+    contextWindow: 1000000
+    requestBody:
+      max_tokens: 384000
+```
+
+- `contextWindow: 1000000` 在 Iris TUI 的上下文用量条上启用 DeepSeek V4 完整的 **100 万 Token** 窗口。
+- `requestBody.thinking.type: enabled` 配合 `reasoning_effort: max` 启用 DeepSeek V4 思考模式并使用最深推理强度，这两个字段都来自 DeepSeek 官方 [Thinking Mode 文档](https://api-docs.deepseek.com/guides/thinking_mode) 中列出的 OpenAI 格式控制参数，推荐用于编程与多步骤 Agent 任务。
+- `max_tokens: 384000` 放开单次响应的输出上限，让 V4 有足够预算容纳长链思考加上最终回复。
+
+#### 3. 启动 Iris
+
+```bash
+iris 或 iris start
+```
+
+进入 Console TUI 后，常用命令：`/model` 切换模型、`/settings` 打开设置中心（LLM / System / MCP）、`/exit` 退出。完整 Slash 命令参考见 [docs/platforms.md](https://github.com/Lianues/Iris/blob/main/docs/platforms.md)。
+
+#### 可选：在聊天平台上运行 Iris
+
+Iris 还可以作为 Web GUI 或聊天机器人运行在 Discord、Telegram、飞书、QQ、微信、企业微信 上。修改 `~/.iris/configs/platform.yaml` 中的 `platform.type`，并在需要时安装对应的 IM extension：
+
+```bash
+iris ext install lark    # 示例：安装飞书 extension
+```
+
+各平台的 Token 与机器人配置详见 [docs/platforms.md](https://github.com/Lianues/Iris/blob/main/docs/platforms.md)。
+
+#### 常见问题
+
+- **`baseUrl` 似乎被忽略了。** 这是预期行为。`provider: deepseek` 固定请求官方接口 `https://api.deepseek.com/v1`。如果需要通过自定义代理或网关访问，请改用 `provider: openai-compatible` 并填入你网关的 `baseUrl`。
+- **报 `Invalid model` 错误。** 使用 `provider: deepseek` 时，`model` 字段只接受 `deepseek-v4-pro` 或 `deepseek-v4-flash`。V3 时代的旧模型 id 已不再支持。
+- **TUI 看不到思考内容。** 确认 `requestBody.thinking.type: enabled` 写在了 DeepSeek 模型条目下，而不是 `llm.yaml` 的顶层。


### PR DESCRIPTION
Adds a bilingual integration guide for **[Iris](https://github.com/Lianues/Iris)** — an open-source multi-platform AI agent (Console / Web / Discord / Telegram / WeChat / WeCom / Lark / QQ) with a built-in DeepSeek provider, tool calling, MCP, and memory.
The guide covers install → configure DeepSeek via the `iris onboard` wizard → first run, using `deepseek-v4-pro` / `deepseek-v4-flash` with a 1M context window and `reasoning_effort: max` thinking mode.
### Changes
- **New:** `docs/iris.md`, `docs/iris.zh-CN.md`
- **Updated:** `README.md`, `README.zh-CN.md` (table entry in alphabetical order)
See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing) — N/A, no pricing table
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes — N/A, no images
