### PR TITLE
docs: add EchoBird integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **EchoBird** | Desktop control center for AI coding tools — add DeepSeek once and apply it to Claude Code, Codex, or Claude Desktop in one click, with a built-in Install & Repair assistant and a quant-analysis workspace. | [Guide](./docs/echobird.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **EchoBird** | 面向 AI 编程工具的桌面端控制中心——添加一次 DeepSeek，即可一键应用到 Claude Code、Codex 或 Claude Desktop，并内置「安装与修复」助手与量化分析工作台。 | [指南](./docs/echobird.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |

--- a/docs/echobird.md
+++ b/docs/echobird.md
@@ -1,0 +1,39 @@
+[English](./echobird.md) | [简体中文](./echobird.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with EchoBird
+
+EchoBird is a desktop control center for AI coding tools on Windows, macOS, and Linux. Instead of editing config files by hand, you add a model provider once and apply it to Claude Code, Codex, or Claude Desktop in one click. EchoBird also ships with a built-in **Install & Repair** assistant and a quant-analysis workspace that can run on the same model.
+
+DeepSeek is a built-in provider: both its OpenAI-compatible endpoint (`https://api.deepseek.com`) and its Anthropic-compatible endpoint (`https://api.deepseek.com/anthropic`) are pre-filled, so EchoBird can point Anthropic-protocol tools like Claude Code and Claude Desktop straight at DeepSeek V4.
+
+- **GitHub:** <https://github.com/edison7009/EchoBird>
+- **Website:** <https://echobird.ai>
+
+#### 1. Install EchoBird
+
+Download the installer for your platform from the [official website](https://echobird.ai) or the [GitHub releases page](https://github.com/edison7009/EchoBird/releases).
+
+#### 2. Add DeepSeek as a model
+
+Open **App Manager**, go to the **Model Providers** panel, and select **DeepSeek** from the built-in provider list. Its **OpenAI URL** (`https://api.deepseek.com`) and **Anthropic URL** (`https://api.deepseek.com/anthropic`) are filled in for you.
+
+1. Paste your [DeepSeek API Key](https://platform.deepseek.com/api_keys).
+2. Set **Model ID** to **`deepseek-v4-pro`** for the strongest coding and reasoning, or **`deepseek-v4-flash`** for a faster, cheaper option.
+3. For Claude Code / Claude Desktop, append `[1m]` to the model name to use the full **1-million-token** context window, e.g. **`deepseek-v4-pro[1m]`**.
+4. Save.
+
+#### 3. Apply DeepSeek to a tool
+
+In **App Manager**, select the tool you want — **Claude Code**, **Codex**, or **Claude Desktop** — open its **MODELS** tab, pick your DeepSeek model, and click **Update model config** (or **Launch app directly**). EchoBird writes the right config for that tool: Anthropic-protocol tools use the `/anthropic` endpoint, OpenAI-compatible tools use `https://api.deepseek.com`.
+
+Keep EchoBird running after switching the Codex / Claude Desktop model.
+
+#### 4. Chat in Install & Repair
+
+Open the **Install & Repair** page and pick your DeepSeek model from the right-hand panel. The built-in assistant runs on DeepSeek V4 — use it to install tools, fix broken configs, and get onboarded.
+
+#### Notes
+
+- **Don't enable API Router for DeepSeek.** When you point a tool directly at DeepSeek, leave the **API Router** toggle off. It is only for relay/router endpoints and will break a direct DeepSeek connection.
+- **Reasoning effort.** DeepSeek V4 Pro runs with deep thinking enabled. For the strongest coding results, keep it at the `max` reasoning level.
+- **1M context.** DeepSeek V4 supports up to 1 million tokens; use the `[1m]` model-name suffix for Anthropic-protocol tools as shown above.

--- a/docs/echobird.zh-CN.md
+++ b/docs/echobird.zh-CN.md
@@ -1,0 +1,39 @@
+[English](./echobird.md) | [简体中文](./echobird.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 EchoBird
+
+EchoBird 是一款面向 AI 编程工具的桌面端控制中心，支持 Windows、macOS 和 Linux。无需手动修改配置文件——添加一次模型供应商，即可一键应用到 Claude Code、Codex 或 Claude Desktop。EchoBird 还内置「安装与修复」助手和量化分析工作台，都能运行在同一个模型上。
+
+DeepSeek 是内置供应商：其 OpenAI 兼容端点（`https://api.deepseek.com`）与 Anthropic 兼容端点（`https://api.deepseek.com/anthropic`）均已预填，因此 EchoBird 能把 Claude Code、Claude Desktop 这类 Anthropic 协议工具直接指向 DeepSeek V4。
+
+- **GitHub：** <https://github.com/edison7009/EchoBird>
+- **官网：** <https://echobird.ai>
+
+#### 1. 安装 EchoBird
+
+从[官网](https://echobird.ai)或 [GitHub Releases](https://github.com/edison7009/EchoBird/releases) 下载对应平台的安装包。
+
+#### 2. 添加 DeepSeek 模型
+
+打开 **应用管理（App Manager）**，进入 **模型供应商（Model Providers）** 面板，从内置供应商列表中选择 **DeepSeek**。它的 **OpenAI URL**（`https://api.deepseek.com`）与 **Anthropic URL**（`https://api.deepseek.com/anthropic`）已为你预填。
+
+1. 填入你的 [DeepSeek API Key](https://platform.deepseek.com/api_keys)。
+2. **Model ID** 填 **`deepseek-v4-pro`**（编程与推理最强），或 **`deepseek-v4-flash`**（更快、更省）。
+3. 用于 Claude Code / Claude Desktop 时，在模型名后追加 `[1m]` 即可启用完整的 **100 万 token** 上下文，例如 **`deepseek-v4-pro[1m]`**。
+4. 保存。
+
+#### 3. 把 DeepSeek 应用到工具
+
+在 **应用管理** 中选择目标工具——**Claude Code**、**Codex** 或 **Claude Desktop**——打开它的 **MODELS** 标签页，选中你的 DeepSeek 模型，点击 **更新模型配置（Update model config）**（或 **直接启动应用**）。EchoBird 会为该工具写入正确的配置：Anthropic 协议工具走 `/anthropic` 端点，OpenAI 兼容工具走 `https://api.deepseek.com`。
+
+切换 Codex / Claude Desktop 的模型后，请保持 EchoBird 运行。
+
+#### 4. 在「安装与修复」中对话
+
+打开 **安装与修复** 页面，在右侧面板选中你的 DeepSeek 模型，内置助手即运行在 DeepSeek V4 上——用它来安装工具、修复损坏的配置、完成上手引导。
+
+#### 注意事项
+
+- **DeepSeek 请勿开启 API Router。** 直接指向 DeepSeek 时，请关闭 **API Router** 开关。它仅用于中转 / 路由端点，开启会破坏与 DeepSeek 的直连。
+- **推理强度。** DeepSeek V4 Pro 默认开启深度思考。追求最佳编程效果时，请保持 `max` 推理档。
+- **100 万上下文。** DeepSeek V4 支持最高 100 万 token；Anthropic 协议工具请按上文使用 `[1m]` 模型名后缀。


### PR DESCRIPTION
## Summary

Adds an integration guide for **EchoBird**, a desktop control center for AI coding tools (Windows / macOS / Linux). DeepSeek is a built-in provider — both the OpenAI-compatible endpoint (`https://api.deepseek.com`) and the Anthropic-compatible endpoint (`https://api.deepseek.com/anthropic`) are pre-filled — so users can point **Claude Code**, **Codex**, or **Claude Desktop** at DeepSeek V4 in one click, and run the built-in Install & Repair assistant on the same model.

## Changes

- `docs/echobird.md` + `docs/echobird.zh-CN.md` — install → configure → first run
- README table entries in both `README.md` and `README.zh-CN.md`, inserted alphabetically (between DeepSeek-TUI and GitHub Copilot)

## Checklist

- [x] Model names current: `deepseek-v4-pro` / `deepseek-v4-flash`
- [x] 1M context documented (`[1m]` suffix for Anthropic-protocol tools)
- [x] Max reasoning effort (`max`) supported; no "disable thinking" workaround
- [x] Both EN and zh-CN versions in a single PR
- [x] README entries inserted in alphabetical order
- [x] One tool per PR