### PR TITLE
Add OpenClaude integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
+| **OpenClaude** | Open-source coding-agent CLI supporting OpenAI-compatible APIs, Gemini, GitHub Models, Ollama, and more — tools, agents, MCP, slash commands. | [Guide](./docs/openclaude.md) |
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,7 @@
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具、记忆、MCP 等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
+| **OpenClaude** | 开源编程 Agent 命令行工具，支持 OpenAI 兼容 API、Gemini、GitHub Models、Ollama 等多种后端 —— 内置工具、Agent、MCP、斜杠命令。 | [指南](./docs/openclaude.zh-CN.md) |
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |

--- a/docs/openclaude.md
+++ b/docs/openclaude.md
@@ -1,0 +1,62 @@
+[English](./openclaude.md) | [简体中文](./openclaude.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with OpenClaude
+
+OpenClaude is an open-source coding-agent CLI for cloud and local model providers. It supports OpenAI-compatible APIs, Gemini, GitHub Models, Ollama, and more, with a terminal-first workflow featuring tools, agents, MCP servers, slash commands, and streaming output.
+
+## Install OpenClaude
+
+OpenClaude requires **Node.js 18+**. Install globally via npm:
+
+```sh
+npm install -g @gitlawb/openclaude
+```
+
+After installation, ensure **ripgrep** (`rg`) is available on your system. Verify with `rg --version`.
+
+## Configure DeepSeek as the Provider
+
+### Option 1 — Environment Variables (Quick Start)
+
+Set the following environment variables before launching OpenClaude:
+
+```sh
+export CLAUDE_CODE_USE_OPENAI=1
+export OPENAI_BASE_URL=https://api.deepseek.com/v1
+export OPENAI_API_KEY=your-deepseek-api-key
+export OPENAI_MODEL=deepseek-v4-pro
+```
+
+**Windows (PowerShell):**
+
+```powershell
+$env:CLAUDE_CODE_USE_OPENAI=1
+$env:OPENAI_BASE_URL="https://api.deepseek.com/v1"
+$env:OPENAI_API_KEY="your-deepseek-api-key"
+$env:OPENAI_MODEL="deepseek-v4-pro"
+```
+
+You can switch to `deepseek-v4-flash` for a faster and more cost-effective experience. To set a different reasoning effort, also set `OPENAI_REASONING_EFFORT=max`.
+
+Get your API key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+### Option 2 — Interactive Setup (Recommended)
+
+1. Run `openclaude` in your terminal.
+2. Type `/provider` and follow the guided prompts.
+3. Select **OpenAI-compatible** as the provider type.
+4. Enter `https://api.deepseek.com/v1` as the base URL.
+5. Enter your DeepSeek API key.
+6. Enter `deepseek-v4-pro` or `deepseek-v4-flash` as the model name.
+
+The provider profile will be saved for future sessions.
+
+## Run OpenClaude
+
+Navigate to your project directory and run:
+
+```sh
+openclaude
+```
+
+OpenClaude will load the DeepSeek model and you can start coding with agentic tools, file operations, MCP servers, and more — all from the terminal.

--- a/docs/openclaude.zh-CN.md
+++ b/docs/openclaude.zh-CN.md
@@ -1,0 +1,62 @@
+[English](./openclaude.md) | [简体中文](./openclaude.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 OpenClaude
+
+OpenClaude 是一个开源的编程 Agent 命令行工具，支持云端和本地模型提供商。它兼容 OpenAI API、Gemini、GitHub Models、Ollama 等多种后端，提供终端优先的工作流，包含工具调用、Agent、MCP 服务器、斜杠命令和流式输出等功能。
+
+## 安装 OpenClaude
+
+OpenClaude 需要 **Node.js 18+**。通过 npm 全局安装：
+
+```sh
+npm install -g @gitlawb/openclaude
+```
+
+安装后，请确保系统中已安装 **ripgrep**（`rg` 命令），可通过 `rg --version` 验证。
+
+## 配置 DeepSeek 为模型提供商
+
+### 方式一 — 环境变量（快速启动）
+
+在启动 OpenClaude 前设置以下环境变量：
+
+```sh
+export CLAUDE_CODE_USE_OPENAI=1
+export OPENAI_BASE_URL=https://api.deepseek.com/v1
+export OPENAI_API_KEY=你的-DeepSeek-API-密钥
+export OPENAI_MODEL=deepseek-v4-pro
+```
+
+**Windows (PowerShell)：**
+
+```powershell
+$env:CLAUDE_CODE_USE_OPENAI=1
+$env:OPENAI_BASE_URL="https://api.deepseek.com/v1"
+$env:OPENAI_API_KEY="你的-DeepSeek-API-密钥"
+$env:OPENAI_MODEL="deepseek-v4-pro"
+```
+
+如需更快速且更具成本效益的体验，可将模型切换为 `deepseek-v4-flash`。如需设置不同的推理强度，可同时设置 `OPENAI_REASONING_EFFORT=max`。
+
+从 [DeepSeek 平台](https://platform.deepseek.com/api_keys) 获取 API 密钥。
+
+### 方式二 — 交互式配置（推荐）
+
+1. 在终端中运行 `openclaude`。
+2. 输入 `/provider` 并按引导提示操作。
+3. 选择 **OpenAI-compatible** 作为提供商类型。
+4. 输入 `https://api.deepseek.com/v1` 作为基础 URL。
+5. 输入你的 DeepSeek API 密钥。
+6. 输入 `deepseek-v4-pro` 或 `deepseek-v4-flash` 作为模型名称。
+
+配置完成后，供应商配置文件将保存，后续会话无需重复配置。
+
+## 运行 OpenClaude
+
+进入你的项目目录并运行：
+
+```sh
+openclaude
+```
+
+OpenClaude 将加载 DeepSeek 模型，你就可以开始在终端中使用 Agent 工具、文件操作、MCP 服务器等各项功能进行编码了。


### PR DESCRIPTION
## Summary

- Add OpenClaude integration guide for DeepSeek models
- OpenClaude is an open-source coding-agent CLI that supports OpenAI-compatible APIs — making it straightforward to connect with DeepSeek's OpenAI-compatible endpoint
- Both English and Chinese versions included
- Inserted in alphabetical order in both README tables

## Guide covers

1. **Installation** — `npm install -g @gitlawb/openclaude` with system requirements
2. **Configuration** — two approaches:
   - Environment variables (quick start)
   - Interactive `/provider` setup (recommended)
3. **First run** — launching OpenClaude in a project directory

## Checklist

- [x] Uses `deepseek-v4-pro` / `deepseek-v4-flash` model names
- [x] Supports 1M context window via model naming
- [x] Supports `max` reasoning effort
- [x] Bilingual (English + Simplified Chinese)
- [x] Alphabetical order in both README files
- [x] Single tool per PR

🤖 Generated with OpenClaude