### PR TITLE
docs: add Open Multi-Agent integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **LobeHub** | LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. | [Guide](./docs/lobehub.md) |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
+| **Open Multi-Agent** | TypeScript-native multi-agent orchestration framework that decomposes a goal into a parallel task DAG. | [Guide](./docs/open_multi_agent.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,6 +30,7 @@
 | **LobeHub** | LobeHub 是你的 Chief Agent Operator，通过招聘、排班并报告整个 AI 团队，将你的 Agent 组织成 7×24 小时运作。 | [指南](./docs/lobehub.zh-CN.md) |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具、记忆、MCP 等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
+| **Open Multi-Agent** | 原生 TypeScript 多智能体编排框架，自动把目标拆解为并行任务 DAG。 | [指南](./docs/open_multi_agent.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |

--- a/docs/open_multi_agent.md
+++ b/docs/open_multi_agent.md
@@ -1,0 +1,115 @@
+[English](./open_multi_agent.md) | [简体中文](./open_multi_agent.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Open Multi-Agent
+
+[Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) (OMA) is a TypeScript-native multi-agent orchestration framework. Give it a goal and a coordinator agent decomposes it into a task DAG, parallelizes independents, and synthesizes the result. Three runtime dependencies, drops into any Node.js backend. DeepSeek V4 is a first-class provider, including reasoning-mode tool calls.
+
+#### 1. Installation
+
+Requires Node.js 20+.
+
+```bash
+npm install @open-multi-agent/core
+```
+
+#### 2. API Key
+
+Get a DeepSeek API key from the [DeepSeek Platform](https://platform.deepseek.com/), then export it:
+
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+```
+
+#### 3. First Run (single agent)
+
+Create `hello.ts`:
+
+```typescript
+import { OpenMultiAgent } from '@open-multi-agent/core'
+
+const oma = new OpenMultiAgent({
+  defaultProvider: 'deepseek',
+  defaultModel: 'deepseek-v4-pro',
+})
+
+const result = await oma.runAgent(
+  {
+    name: 'assistant',
+    systemPrompt: 'You are a helpful assistant. Be concise.',
+  },
+  'Explain what a B-tree is in 3 sentences.',
+)
+
+console.log(result.output)
+console.log(`Tokens: ${result.tokenUsage.input_tokens} in / ${result.tokenUsage.output_tokens} out`)
+```
+
+Run it:
+
+```bash
+npx tsx hello.ts
+```
+
+#### 4. Run a Team
+
+The coordinator decomposes the goal into a task DAG; independents run in parallel.
+
+```typescript
+import { OpenMultiAgent } from '@open-multi-agent/core'
+
+const oma = new OpenMultiAgent({
+  defaultProvider: 'deepseek',
+  defaultModel: 'deepseek-v4-flash',
+})
+
+const team = oma.createTeam('research-team', {
+  name: 'research-team',
+  agents: [
+    {
+      name: 'researcher',
+      model: 'deepseek-v4-pro',
+      provider: 'deepseek',
+      systemPrompt: 'You research a topic and produce structured findings.',
+    },
+    {
+      name: 'writer',
+      systemPrompt: 'You turn research notes into a clear short article.',
+    },
+  ],
+  sharedMemory: true,
+})
+
+const result = await oma.runTeam(
+  team,
+  'Write a 200-word intro to vector databases for backend engineers.',
+)
+
+for (const [name, agentResult] of result.agentResults) {
+  console.log(`\n--- ${name} ---`)
+  console.log(agentResult.output)
+}
+console.log(`\nTotal tokens: ${result.totalTokenUsage.input_tokens} in / ${result.totalTokenUsage.output_tokens} out`)
+```
+
+For a fuller end-to-end example (3 agents collaborating to build an Express.js REST API), see [`examples/providers/deepseek.ts`](https://github.com/open-multi-agent/open-multi-agent/blob/main/examples/providers/deepseek.ts).
+
+#### 5. Notes
+
+- **Models**: `deepseek-v4-pro` (flagship, best for coding) and `deepseek-v4-flash` (economical). Both support **1M token context**. OMA does not cap the context window, so the full 1M is available.
+- **Reasoning effort**: DeepSeek V4 Pro supports `max` and `high` levels. Because `'max'` is DeepSeek-specific and outside the standard OpenAI SDK type union, pass it via `extraBody` on the agent config:
+  ```typescript
+  {
+    name: 'architect',
+    model: 'deepseek-v4-pro',
+    provider: 'deepseek',
+    extraBody: { reasoning_effort: 'max' },
+  }
+  ```
+  For `'high'`, you can also use the typed form: `thinking: { enabled: true, effort: 'high' }`.
+- **Reasoning content on tool calls**: OMA echoes `reasoning_content` on tool-using V4 conversations per the [DeepSeek thinking-mode spec](https://api-docs.deepseek.com/guides/thinking_mode).
+
+#### Resources
+
+- [Open Multi-Agent on GitHub](https://github.com/open-multi-agent/open-multi-agent)
+- [npm: @open-multi-agent/core](https://www.npmjs.com/package/@open-multi-agent/core)
+- [Provider documentation](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md)

--- a/docs/open_multi_agent.zh-CN.md
+++ b/docs/open_multi_agent.zh-CN.md
@@ -1,0 +1,115 @@
+[English](./open_multi_agent.md) | [简体中文](./open_multi_agent.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Open Multi-Agent
+
+[Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent)（简称 OMA）是面向 TypeScript 后端的多智能体编排框架。给定一个目标，coordinator agent 会将其拆解为任务 DAG，并行执行独立任务，合成最终结果。仅 3 个运行时依赖，可直接嵌入任意现有 Node.js 后端。DeepSeek V4 是其原生支持的 provider，包含思考模式下的工具调用。
+
+#### 1. 安装
+
+要求 Node.js 20+。
+
+```bash
+npm install @open-multi-agent/core
+```
+
+#### 2. 准备 API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/) 申请 API key，然后导出环境变量：
+
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+```
+
+#### 3. 单 Agent 运行
+
+新建 `hello.ts`：
+
+```typescript
+import { OpenMultiAgent } from '@open-multi-agent/core'
+
+const oma = new OpenMultiAgent({
+  defaultProvider: 'deepseek',
+  defaultModel: 'deepseek-v4-pro',
+})
+
+const result = await oma.runAgent(
+  {
+    name: 'assistant',
+    systemPrompt: '你是一个乐于助人的助手，回答简洁。',
+  },
+  '用 3 句话解释什么是 B 树。',
+)
+
+console.log(result.output)
+console.log(`Token 用量：输入 ${result.tokenUsage.input_tokens}，输出 ${result.tokenUsage.output_tokens}`)
+```
+
+运行：
+
+```bash
+npx tsx hello.ts
+```
+
+#### 4. 运行一个团队
+
+Coordinator 把目标拆解为任务 DAG，独立任务并行执行。
+
+```typescript
+import { OpenMultiAgent } from '@open-multi-agent/core'
+
+const oma = new OpenMultiAgent({
+  defaultProvider: 'deepseek',
+  defaultModel: 'deepseek-v4-flash',
+})
+
+const team = oma.createTeam('research-team', {
+  name: 'research-team',
+  agents: [
+    {
+      name: 'researcher',
+      model: 'deepseek-v4-pro',
+      provider: 'deepseek',
+      systemPrompt: '你负责调研一个主题，产出结构化的发现。',
+    },
+    {
+      name: 'writer',
+      systemPrompt: '你把调研笔记整理成一篇清晰的短文。',
+    },
+  ],
+  sharedMemory: true,
+})
+
+const result = await oma.runTeam(
+  team,
+  '面向后端工程师，写一段 200 字的向量数据库入门介绍。',
+)
+
+for (const [name, agentResult] of result.agentResults) {
+  console.log(`\n--- ${name} ---`)
+  console.log(agentResult.output)
+}
+console.log(`\n总 Token：输入 ${result.totalTokenUsage.input_tokens}，输出 ${result.totalTokenUsage.output_tokens}`)
+```
+
+更完整的端到端示例（3 个 agent 协作构建一个 Express.js REST API）见 [`examples/providers/deepseek.ts`](https://github.com/open-multi-agent/open-multi-agent/blob/main/examples/providers/deepseek.ts)。
+
+#### 5. 说明
+
+- **模型**：`deepseek-v4-pro`（旗舰，最适合编码）和 `deepseek-v4-flash`（经济款），两者都支持 **1M token 上下文**。OMA 不对 context window 设上限，可使用完整 1M 容量。
+- **Reasoning effort**：DeepSeek V4 Pro 支持 `max` 与 `high` 两档。由于 `'max'` 是 DeepSeek 特有取值（不在标准 OpenAI SDK 的类型联合中），需通过 agent config 的 `extraBody` 传入：
+  ```typescript
+  {
+    name: 'architect',
+    model: 'deepseek-v4-pro',
+    provider: 'deepseek',
+    extraBody: { reasoning_effort: 'max' },
+  }
+  ```
+  `'high'` 也可用标准形式：`thinking: { enabled: true, effort: 'high' }`。
+- **工具调用中的 reasoning content**：OMA 在 V4 工具调用对话中回传 `reasoning_content`，符合 [DeepSeek 思考模式规范](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode)。
+
+#### 资源
+
+- [Open Multi-Agent GitHub 仓库](https://github.com/open-multi-agent/open-multi-agent)
+- [npm: @open-multi-agent/core](https://www.npmjs.com/package/@open-multi-agent/core)
+- [Provider 文档](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md)


### PR DESCRIPTION
## Summary

Integration guide for [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) (OMA), a TypeScript-native multi-agent orchestration framework. DeepSeek V4 is supported, including reasoning-mode tool calls.

## Critical checks

- **Model naming**: `deepseek-v4-pro` / `deepseek-v4-flash` throughout, no V3 names
- **1M context**: noted in Notes; OMA does not cap the context window
- **Max reasoning effort**: documented via `extraBody: { reasoning_effort: 'max' }` (DeepSeek-specific value, outside the standard OpenAI SDK type union)
- **Reasoning content echo on tool calls**: OMA echoes `reasoning_content` on tool-using V4 conversations per the [DeepSeek thinking-mode spec](https://api-docs.deepseek.com/guides/thinking_mode)

README table rows inserted between **Oh My Pi** and **OpenClaw** in both `README.md` and `README.zh-CN.md`, per the alphabetical-order guidance in CONTRIBUTING.md.