### PR TITLE
docs: add BitFun integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | Tool            | Description                                                                                                 | Guide                          |
 | --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | **AstrBot** | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs. | [Guide](./docs/astrbot.md) |
+| **BitFun** | Desktop-grade Agent runtime and ready-to-use Agent suite with Code, Cowork, Computer Use, Personal Assistant, MCP, LSP, memory, and remote control. | [Guide](./docs/bitfun.md) |
 | **Cherry Studio** | Open-source cross-platform desktop AI client with 300+ assistants, MCP support, knowledge bases, and multi-model chat. | [Guide](./docs/cherry_studio.md) |
 | **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
 | **Cline** | AI coding assistant extension for VS Code supporting multiple API providers. | [Guide](./docs/cline.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,6 +16,7 @@
 | 工具            | 简介                                                                  | 指南                                |
 | --------------- | --------------------------------------------------------------------- | ----------------------------------- |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
+| **BitFun** | 桌面级 Agent Runtime 与开箱即用的 Agent 套件，内置 Code、Cowork、Computer Use、Personal Assistant、MCP、LSP、记忆与远程控制。 | [指南](./docs/bitfun.zh-CN.md) |
 | **Cherry Studio** | 开源跨平台桌面 AI 客户端，内置 300+ 助手、MCP、知识库与多模型对话。 | [指南](./docs/cherry_studio.zh-CN.md) |
 | **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |
 | **Cline** | 运行在 VS Code 中的 AI 编程助手扩展，支持多种 API 供应商。 | [指南](./docs/cline.zh-CN.md) |

--- a/docs/bitfun.md
+++ b/docs/bitfun.md
@@ -1,0 +1,67 @@
+[English](./bitfun.md) | [简体中文](./bitfun.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with BitFun
+
+[BitFun](https://github.com/GCWing/BitFun) is a desktop-grade Agent runtime and a ready-to-use suite of desktop Agent applications. It includes Code, Cowork, Computer Use, and Personal Assistant agents, with MCP, LSP, memory, Skills, context compression, and remote control built in.
+
+BitFun is a good fit for DeepSeek V4 because its runtime is designed for long-running local sessions and cache-friendly agent loops. In a 731-trial SWE-Bench-Pro run, BitFun recorded a weighted KV cache hit rate of **98.67%** across **1.56B cached input tokens**; **83.1%** of trials reached at least **98%** cache hit rate, and **51.8%** reached at least **99%**.
+
+#### 1. Install BitFun
+
+Download the latest desktop installer from the [BitFun Releases](https://github.com/GCWing/BitFun/releases) page.
+
+If you prefer to build from source:
+
+```sh
+git clone https://github.com/GCWing/BitFun.git
+cd BitFun
+pnpm install
+pnpm run desktop:dev
+```
+
+#### 2. Get a DeepSeek API Key
+
+Create an API key in the [DeepSeek Platform](https://platform.deepseek.com/api_keys), then keep it ready for the BitFun model configuration.
+
+#### 3. Add a DeepSeek V4 model
+
+Open BitFun and go to **Settings → Model Configuration**. The quickest path is:
+
+1. Click the **DeepSeek** template.
+2. Paste your DeepSeek API key.
+3. Click the one-click validation button next to the configuration.
+4. Save the configuration after validation passes.
+
+The DeepSeek template fills the official API URL and OpenAI-compatible request format for you. BitFun supports DeepSeek V4's **1M context window**, **384K max output**, and **max** reasoning effort; these values can be reviewed or adjusted in the model's advanced settings.
+
+For lower-cost iteration, add `deepseek-v4-flash` as a **fast model**. It is useful for exploration, quick repository scanning, and lightweight agent turns, while `deepseek-v4-pro` remains the best default for complex coding and reasoning tasks.
+
+#### 4. Select the model for an Agent
+
+Choose the DeepSeek model in BitFun's model selector, then start with the Agent that matches your workflow:
+
+| Agent | Best for |
+|-------|----------|
+| Code Agent | Repository exploration, code edits, terminal commands, Git work, debugging, and review |
+| Cowork Agent | PDF, DOCX, XLSX, PPTX, and knowledge-work tasks |
+| Computer Use | Browser and desktop-app operation through screen, mouse, and keyboard control |
+| Personal Assistant | Long-running assistance, memory-backed tasks, scheduling, and remote entry points |
+
+#### 5. Verify the setup
+
+Use the one-click validation button beside the model configuration. If it passes, start a Code Agent session in a project directory and ask it to inspect the repository or run a small test command.
+
+BitFun should stream the answer and preserve the session locally. You can type `/usage` during a session to inspect recorded runtime and token usage details.
+
+#### Troubleshooting
+
+- Authentication errors: check that the API key is copied from the DeepSeek Platform and has not expired or been revoked.
+- Model not found: use `deepseek-v4-pro` or `deepseek-v4-flash`.
+- Context looks too small: review the model's advanced settings and confirm that Context Window Size is set to `1000000`.
+- Thinking is missing: review the advanced settings and confirm that reasoning mode is enabled with Reasoning Effort set to `max`.
+
+#### Resources
+
+- [BitFun GitHub](https://github.com/GCWing/BitFun)
+- [BitFun Website](https://openbitfun.com/)
+- [DeepSeek API Docs](https://api-docs.deepseek.com/)

--- a/docs/bitfun.zh-CN.md
+++ b/docs/bitfun.zh-CN.md
@@ -1,0 +1,67 @@
+[English](./bitfun.md) | [简体中文](./bitfun.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 集成 BitFun
+
+[BitFun](https://github.com/GCWing/BitFun) 是桌面级 Agent Runtime，也是一套开箱即用的桌面 Agent 应用。它内置 Code、Cowork、Computer Use、Personal Assistant 等 Agent，并提供 MCP、LSP、记忆、Skills、上下文压缩和远程控制能力。
+
+BitFun 很适合接入 DeepSeek V4：它的运行时面向长时间本地会话和 cache-friendly 的 Agent 循环设计。在一次 731 条 trial 的 SWE-Bench-Pro 评测中，BitFun 记录了 **98.67%** 的加权 KV cache 命中率，覆盖 **15.6 亿 cached input tokens**；其中 **83.1%** 的 trial 命中率不低于 **98%**，**51.8%** 不低于 **99%**。
+
+#### 1. 安装 BitFun
+
+从 [BitFun Releases](https://github.com/GCWing/BitFun/releases) 页面下载最新版桌面安装包。
+
+如果你希望从源码运行：
+
+```sh
+git clone https://github.com/GCWing/BitFun.git
+cd BitFun
+pnpm install
+pnpm run desktop:dev
+```
+
+#### 2. 获取 DeepSeek API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 创建 API Key，稍后填入 BitFun 的模型配置。
+
+#### 3. 添加 DeepSeek V4 模型
+
+打开 BitFun，进入 **设置 → 模型配置**。最简单的路径是：
+
+1. 点击 **DeepSeek** 模板。
+2. 粘贴你的 DeepSeek API Key。
+3. 点击配置项旁边的一键校验按钮。
+4. 校验通过后保存配置。
+
+DeepSeek 模板会自动填好官方 API 地址和 OpenAI 兼容请求格式。BitFun 支持 DeepSeek V4 的 **100 万 token 上下文窗口**、**384K 最大输出**和 **max** 推理强度；这些值可以在模型的高级设置中查看或调整。
+
+如果想降低日常迭代成本，可以把 `deepseek-v4-flash` 配置为**快速模型**。它适合 explore、快速扫仓库、轻量 Agent 回合等任务；复杂编码与深度推理任务仍建议默认使用 `deepseek-v4-pro`。
+
+#### 4. 为 Agent 选择模型
+
+在 BitFun 的模型选择器中选择 DeepSeek 模型，然后根据任务选择对应 Agent：
+
+| Agent | 适合场景 |
+|-------|----------|
+| Code Agent | 仓库探索、代码修改、终端命令、Git、调试和代码审查 |
+| Cowork Agent | PDF、DOCX、XLSX、PPTX 与知识工作流 |
+| Computer Use | 通过屏幕、鼠标和键盘操作浏览器或桌面应用 |
+| Personal Assistant | 长时间助理任务、记忆、日程调度和远程入口 |
+
+#### 5. 验证配置
+
+点击模型配置项旁边的一键校验按钮即可验证配置。校验通过后，在项目目录中启动一个 Code Agent 会话，让它检查仓库或运行一条简单测试命令。
+
+如果模型配置正确，BitFun 会流式返回回答，并将会话保存在本地。会话中也可以输入 `/usage` 查看已记录的运行时与 token 使用情况。
+
+#### 常见问题
+
+- 认证失败：确认 API Key 来自 DeepSeek 开放平台，且没有过期或被撤销。
+- 找不到模型：请使用 `deepseek-v4-pro` 或 `deepseek-v4-flash`。
+- 上下文窗口过小：检查模型高级设置，确认 Context Window Size 已设置为 `1000000`。
+- 没有思考过程：检查高级设置，确认已开启 Reasoning Mode，并将 Reasoning Effort 设置为 `max`。
+
+#### 相关资源
+
+- [BitFun GitHub](https://github.com/GCWing/BitFun)
+- [BitFun 官网](https://openbitfun.com/)
+- [DeepSeek API 文档](https://api-docs.deepseek.com/zh-cn/)


### PR DESCRIPTION
## Summary

- Add a bilingual BitFun DeepSeek integration guide.
- Add BitFun to the English and Simplified Chinese README tables in alphabetical order.
- Document recommended DeepSeek V4 Pro / Flash settings: 1M context, 384K max output, thinking enabled, and reasoning effort `max`.
- Include BitFun SWE-Bench-Pro KV cache evidence: 731 trials, 98.67% weighted cache hit rate, 1.56B cached input tokens, 83.1% of trials >=98%, and 51.8% >=99%.
<img width="1672" height="941" alt="ig_0d8276d45ad7c24a016a20cda0f08c8191ade8e291cc682036" src="https://github.com/user-attachments/assets/4aace22c-5f07-42cc-9f44-b09b40a15a38" />


----

<img width="3119" height="1953" alt="image" src="https://github.com/user-attachments/assets/1b91cf96-c886-4f87-a430-294f57977ace" />

----

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against DeepSeek API Docs (N/A: this guide does not include a pricing table)
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes (N/A: no images added)

## Validation

- `git diff --cached --check`
- Searched the staged diff for deprecated model names: `deepseek-chat`, `deepseek-reasoner`, `deepseek-coder`
- Checked open PRs for duplicate BitFun submissions
