### PR TITLE
fix(pi): migrate to pi's current model config format

### DIFF
--- a/docs/pi_mono.md
+++ b/docs/pi_mono.md
@@ -38,6 +38,10 @@ Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compat
       "baseUrl": "https://api.deepseek.com",
       "api": "openai-completions",
       "apiKey": "$DEEPSEEK_API_KEY",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "thinkingFormat": "deepseek"
+      },
       "models": [
         {
           "id": "deepseek-v4-pro",
@@ -52,16 +56,15 @@ Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compat
             "cacheRead": 0.145,
             "cacheWrite": 0
           },
+          "thinkingLevelMap": {
+            "minimal": "high",
+            "low": "high",
+            "medium": "high",
+            "high": "high",
+            "xhigh": "max"
+          },
           "compat": {
-            "requiresReasoningContentOnAssistantMessages": true,
-            "thinkingFormat": "deepseek",
-            "reasoningEffortMap": {
-              "minimal": "high",
-              "low": "high",
-              "medium": "high",
-              "high": "high",
-              "xhigh": "max"
-            }
+            "requiresReasoningContentOnAssistantMessages": true
           }
         },
         {
@@ -77,16 +80,15 @@ Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compat
             "cacheRead": 0.028,
             "cacheWrite": 0
           },
+          "thinkingLevelMap": {
+            "minimal": "high",
+            "low": "high",
+            "medium": "high",
+            "high": "high",
+            "xhigh": "max"
+          },
           "compat": {
-            "requiresReasoningContentOnAssistantMessages": true,
-            "thinkingFormat": "deepseek",
-            "reasoningEffortMap": {
-              "minimal": "high",
-              "low": "high",
-              "medium": "high",
-              "high": "high",
-              "xhigh": "max"
-            }
+            "requiresReasoningContentOnAssistantMessages": true
           }
         }
       ]

--- a/docs/pi_mono.zh-CN.md
+++ b/docs/pi_mono.zh-CN.md
@@ -38,6 +38,10 @@ Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI
       "baseUrl": "https://api.deepseek.com",
       "api": "openai-completions",
       "apiKey": "$DEEPSEEK_API_KEY",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "thinkingFormat": "deepseek"
+      },
       "models": [
         {
           "id": "deepseek-v4-pro",
@@ -52,16 +56,15 @@ Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI
             "cacheRead": 0.145,
             "cacheWrite": 0
           },
+          "thinkingLevelMap": {
+            "minimal": "high",
+            "low": "high",
+            "medium": "high",
+            "high": "high",
+            "xhigh": "max"
+          },
           "compat": {
-            "requiresReasoningContentOnAssistantMessages": true,
-            "thinkingFormat": "deepseek",
-            "reasoningEffortMap": {
-              "minimal": "high",
-              "low": "high",
-              "medium": "high",
-              "high": "high",
-              "xhigh": "max"
-            }
+            "requiresReasoningContentOnAssistantMessages": true
           }
         },
         {
@@ -77,16 +80,15 @@ Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI
             "cacheRead": 0.028,
             "cacheWrite": 0
           },
+          "thinkingLevelMap": {
+            "minimal": "high",
+            "low": "high",
+            "medium": "high",
+            "high": "high",
+            "xhigh": "max"
+          },
           "compat": {
-            "requiresReasoningContentOnAssistantMessages": true,
-            "thinkingFormat": "deepseek",
-            "reasoningEffortMap": {
-              "minimal": "high",
-              "low": "high",
-              "medium": "high",
-              "high": "high",
-              "xhigh": "max"
-            }
+            "requiresReasoningContentOnAssistantMessages": true
           }
         }
       ]


### PR DESCRIPTION
## Summary

Pi deprecated `compat.reasoningEffortMap` in favor of model-level `thinkingLevelMap`. This PR updates the Pi integration guides (EN + zh-CN) to use the current format.

## Changes

- Replace deprecated `compat.reasoningEffortMap` with `thinkingLevelMap`
- Add `supportsDeveloperRole: false` at provider level (DeepSeek rejects the `developer` role)
- Move `thinkingFormat` from model-level compat to provider-level compat (reduces duplication)

## Verification

Per pi's [models documentation](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent/docs/models.md):

> Migration: older configs that used `compat.reasoningEffortMap` should move that mapping to model-level `thinkingLevelMap`.

The `supportsDeveloperRole` field is documented under [OpenAI Compatibility](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent/docs/models.md#openai-compatibility) — DeepSeek requires this to be `false` to avoid 400 errors from the `developer` role.