### PR TITLE
Add Zagens integration guide (EN + zh-CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
+| **Zagens** | Desktop DeepSeek V4 harness — hallucination guard, completion gates, session replay, Code+Office runtime, `zagens` CLI. | [Guide](./docs/zagens.md) |
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,6 +36,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
+| **Zagens** | 桌面 DeepSeek V4 Harness — 抗幻觉、长程完成门禁、会话回放、Code+Office runtime、`zagens` CLI。 | [指南](./docs/zagens.zh-CN.md) |
 
 ## 相关资源
 

--- a/docs/zagens.md
+++ b/docs/zagens.md
@@ -1,0 +1,53 @@
+[English](./zagens.md) | [简体中文](./zagens.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Zagens
+
+Zagens is a **desktop agent harness** built around DeepSeek — a Tauri 2 UI with a local **runtime sidecar** that talks to `api.deepseek.com` directly. It supports **DeepSeek-V4-Pro** and **DeepSeek-V4-Flash** with the full **1M token** context window, plus tool use, MCP, skills, and session replay. A headless **`zagens`** CLI is available for scripting and automation; a **full-screen terminal TUI (`zagens-tui`) is in development and coming soon.**
+
+- **GitHub:** https://github.com/didclawapp-ai/zagens
+
+**Highlights:**
+
+- **Long-horizon harness** — layered completion gates for multi-step coding tasks, so agents are less likely to stall or claim “done” too early.
+- **Hallucination guard & verifiable output** — prompts require evidence-backed claims and explicit “not verified” labels when unsure; “done” means **tests and builds actually run**, and expected files are checked — not the model saying so on its own.
+- **Desktop-native control plane** — per-turn **session replay**, diff preview, tool approval UI, embedded terminal, and tray notifications.
+- **Code + Office in one runtime** — coding and spreadsheet/document workflows (`write_office`) share the same sidecar — no separate toolchain.
+
+#### 1. Install Zagens
+
+Pick one:
+
+```sh
+# Windows desktop (recommended): download from GitHub Releases
+#   https://github.com/didclawapp-ai/zagens/releases
+
+# CLI (Windows / macOS / Linux — requires Rust stable)
+cargo install zagens-cli --locked --bin zagens
+```
+
+Verify the CLI:
+
+```sh
+zagens --version
+```
+
+#### 2. Get a DeepSeek API Key
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys). On first desktop launch, enter it in **Settings** — it is saved to `~/.zagens/config.toml`. For the CLI, run `zagens login` or set `DEEPSEEK_API_KEY`.
+
+#### 3. Open your project and start
+
+**Desktop:** Launch Zagens, pick a workspace folder, and send your first prompt.
+
+**CLI:**
+
+```sh
+cd /path/to/my-project
+zagens exec "Summarize this repo's README.md in three bullet points"
+```
+
+Zagens defaults to **DeepSeek-V4-Pro** with `reasoning_effort = max` for deep V4 reasoning. Switch to **Flash** in Settings for lower cost, or adjust reasoning effort (`max` / `high`). Check connectivity with `zagens doctor`; expose a local HTTP API with `zagens serve --http`.
+
+<div align="center">
+<img src="https://raw.githubusercontent.com/didclawapp-ai/zagens/master/assets/screenshot.png" width="800" />
+</div>

--- a/docs/zagens.zh-CN.md
+++ b/docs/zagens.zh-CN.md
@@ -1,0 +1,53 @@
+[English](./zagens.md) | [简体中文](./zagens.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Zagens
+
+Zagens 是一款以 DeepSeek 为原生后端的**桌面 Agent 控制台**：Tauri 2 界面 + 本机 **runtime sidecar**，原生对接 `api.deepseek.com`，支持 **DeepSeek-V4-Pro** 与 **DeepSeek-V4-Flash** 全 **100 万 token** 上下文，并提供工具调用、MCP、技能与会话回放。亦可通过 headless **`zagens`** CLI 做脚本化与自动化；**全屏 TUI 终端（`zagens-tui`）正在开发中，近期推出。**
+
+- **GitHub：** https://github.com/didclawapp-ai/zagens
+
+**特色概览：**
+
+- **长程任务 Harness** — 针对多步编码任务的分层完成门禁，减少半途停手或过早「声称完成」。
+- **抗幻觉与可验证输出** — 系统提示要求结论有据可查，没核实就标明「未验证」；任务是否完成，会**自动跑测试、编译验证**并核对**该交付的文件是否真存在**，而不是只听模型说「做完了」。
+- **桌面原生控制面** — 按轮**会话回放**、diff 预览、工具执行审批、嵌入式终端与系统托盘通知。
+- **Code + Office 一体** — 编码与表格/文档（`write_office`）共用同一 sidecar runtime，无需另开一套工具链。
+
+#### 1. 安装 Zagens
+
+任选其一：
+
+```sh
+# Windows 桌面（推荐）：从 GitHub Releases 下载安装包
+#   https://github.com/didclawapp-ai/zagens/releases
+
+# CLI（Windows / macOS / Linux，需要 Rust stable）
+cargo install zagens-cli --locked --bin zagens
+```
+
+验证 CLI 安装：
+
+```sh
+zagens --version
+```
+
+#### 2. 获取 DeepSeek API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。桌面版首次启动可在 **设置** 中填写并保存到 `~/.zagens/config.toml`；CLI 可执行 `zagens login`，或设置环境变量 `DEEPSEEK_API_KEY`。
+
+#### 3. 进入项目目录并开始使用
+
+**桌面：** 启动 Zagens，选择工作区文件夹，发送第一条 prompt 即可。
+
+**CLI：**
+
+```sh
+cd /path/to/my-project
+zagens exec "用三条要点总结本仓库 README.md"
+```
+
+Zagens 默认使用 **DeepSeek-V4-Pro**，`reasoning_effort = max` 以发挥 V4 深度推理。可在设置中切换 **Flash** 以降低成本，或调整推理强度（`max` / `high`）。诊断连通性：`zagens doctor`；本地 HTTP API：`zagens serve --http`。
+
+<div align="center">
+<img src="https://raw.githubusercontent.com/didclawapp-ai/zagens/master/assets/screenshot.png" width="800" />
+</div>


### PR DESCRIPTION
See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.

## Checklist

### Agent Configuration

- [ ] Model names are current (v4-pro / v4-flash, not v3 names)
- [ ] 1M context is configured or mentioned
- [ ] Max thinking effort level is supported
- [ ] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing)
- [ ] Config fields are verified to work in the agent
- [ ] No workarounds for already-fixed upstream bugs

### Documentation

- [ ] Both English and Chinese versions included in a single PR
- [ ] README table entry inserted in alphabetical order
- [ ] One tool per PR; unrelated tools not combined
- [ ] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes
