### PR TITLE
docs: add CodeCraft integration guide (EN + zh-CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Cherry Studio** | Open-source cross-platform desktop AI client with 300+ assistants, MCP support, knowledge bases, and multi-model chat. | [Guide](./docs/cherry_studio.md) |
 | **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |
 | **Cline** | AI coding assistant extension for VS Code supporting multiple API providers. | [Guide](./docs/cline.md) |
+| **CodeCraft** | Desktop AI coding assistant powered by AI Agent with 19 tools and sub-agent parallel collaboration. Cross-platform Electron app with bundled JRE — zero setup. | [Guide](./docs/codecraft.md) |
 | **Codex** | OpenAI's coding agent. | [Guide](./docs/codex.md) |
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,7 @@
 | **Cherry Studio** | 开源跨平台桌面 AI 客户端，内置 300+ 助手、MCP、知识库与多模型对话。 | [指南](./docs/cherry_studio.zh-CN.md) |
 | **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |
 | **Cline** | 运行在 VS Code 中的 AI 编程助手扩展，支持多种 API 供应商。 | [指南](./docs/cline.zh-CN.md) |
+| **CodeCraft** | 基于 AI Agent 的桌面端智能编程助手，支持 19 个工具和子 Agent 并行协作，Electron 跨平台桌面应用内置 JRE 开箱即用。 | [指南](./docs/codecraft.zh-CN.md) |
 | **Codex** | OpenAI 的编程 Agent。 | [指南](./docs/codex.zh-CN.md) |
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |

--- a/docs/codecraft.md
+++ b/docs/codecraft.md
@@ -1,0 +1,82 @@
+[English](./codecraft.md) | [简体中文](./codecraft.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with CodeCraft
+
+CodeCraft is an AI Agent-based desktop intelligent programming assistant with **19 tools** (file read/write, command execution, Git operations, web search, etc.) and sub-agent parallel collaboration. Packaged as a cross-platform Electron desktop app with a bundled JRE — no Java installation required.
+
+### Install CodeCraft
+
+#### Option 1: Download Installer (Recommended)
+
+Go to [CodeCraft Releases](https://github.com/zb614433612/CodeCraft/releases) and download the latest installer for your platform:
+
+| Platform | Installer |
+|----------|-----------|
+| Windows | `CodeCraft-Setup-{version}.exe` |
+| macOS | `CodeCraft-{version}.dmg` |
+| Linux | `CodeCraft-{version}.AppImage` / `.deb` |
+
+Double-click to install — **no Java or Node.js setup needed**. All dependencies are bundled.
+
+#### Option 2: Build from Source
+
+```bash
+# Prerequisites: JDK 17+, Maven 3.6+, Node.js 18+
+git clone https://github.com/zb614433612/CodeCraft.git
+cd CodeCraft
+mvn clean package -DskipTests && mvn spring-boot:run
+```
+
+After startup, visit **http://localhost:8084**.
+
+### Configure CodeCraft
+
+CodeCraft uses DeepSeek's **OpenAI-compatible endpoint**. All configuration is done through the GUI — no manual config file editing needed.
+
+#### Step 1: Get Your API Key
+
+Create and copy your API Key from [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+#### Step 2: Configure in CodeCraft
+
+1. Launch CodeCraft, log in with default account `admin` / `123456`
+2. Click **Settings → System Config** in the left menu
+3. Find the **DeepSeek API Key** field, paste your API Key
+4. Click Save
+
+#### Step 3: Choose Model & Reasoning Effort
+
+At the top of the chat page, you can switch model and thinking mode:
+
+| Setting | Recommended | Notes |
+|---------|-------------|-------|
+| **Model** | `deepseek-v4-pro` | V4 Pro for complex coding tasks; V4 Flash for faster, lower-cost responses |
+| **Thinking Mode** | `thinking_max` | Enables deep reasoning before execution for the best coding experience |
+| **Execution Mode** | `auto` or `manual` | `auto` lets AI execute tools automatically; `manual` prompts for confirmation before each operation |
+
+> 💡 **1M Context Window**: DeepSeek V4 models support up to **1 million tokens** of context. CodeCraft includes a built-in intelligent context compaction system (three-tier progressive: WARN → COMPACT → DROP) that automatically manages token consumption, so you can focus on the conversation without manually clearing history.
+
+### Use CodeCraft
+
+1. Set a **working directory** for the current session in the left menu (your project's root directory)
+2. Type a programming task in the chat input, e.g., "Create a Spring Boot REST API with CRUD endpoints"
+3. AI automatically invokes tools — reading/writing files, executing commands, searching code, etc.
+4. Complex tasks are automatically decomposed into sub-agents that execute in parallel, with results summarized upon completion
+
+```
+Working directory: /path/to/my-project
+
+Input: Write a user registration endpoint with validation and database persistence
+AI operations:
+  ├─ Read project structure to understand existing code
+  ├─ Create UserController, UserService, UserMapper
+  ├─ Write parameter validation logic
+  ├─ Auto compile to verify
+  └─ Report completion status
+```
+
+### More Resources
+
+- [CodeCraft Source Code](https://github.com/zb614433612/CodeCraft)
+- [Architecture Documentation](https://github.com/zb614433612/CodeCraft/blob/master/docs/ARCHITECTURE.md) (Chinese) / [ARCHITECTURE_EN.md](https://github.com/zb614433612/CodeCraft/blob/master/docs/ARCHITECTURE_EN.md) (English)
+- [Development Quick Reference](https://github.com/zb614433612/CodeCraft/blob/master/docs/DEV_QUICKREF.md)

--- a/docs/codecraft.zh-CN.md
+++ b/docs/codecraft.zh-CN.md
@@ -1,0 +1,82 @@
+[English](./codecraft.md) | [简体中文](./codecraft.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 CodeCraft
+
+CodeCraft 是一个基于 AI Agent 的桌面端智能编程助手，支持 **19 个工具**（文件读写、命令执行、Git 操作、网络搜索等），并支持子 Agent 并行协作，通过 Electron 打包为跨平台桌面应用，内置 JRE 开箱即用。
+
+### 从零安装 CodeCraft
+
+#### 方式一：下载安装包（推荐）
+
+前往 [CodeCraft Releases](https://github.com/zb614433612/CodeCraft/releases) 页面，下载对应平台的最新安装包：
+
+| 平台 | 安装包 |
+|------|--------|
+| Windows | `CodeCraft-Setup-{version}.exe` |
+| macOS | `CodeCraft-{version}.dmg` |
+| Linux | `CodeCraft-{version}.AppImage` / `.deb` |
+
+下载后双击安装即可，**无需安装 Java 或 Node.js**，所有依赖均已内置。
+
+#### 方式二：从源码构建
+
+```bash
+# 环境要求：JDK 17+、Maven 3.6+、Node.js 18+
+git clone https://github.com/zb614433612/CodeCraft.git
+cd CodeCraft
+mvn clean package -DskipTests && mvn spring-boot:run
+```
+
+启动后访问 **http://localhost:8084**。
+
+### 配置 CodeCraft
+
+CodeCraft 使用 DeepSeek 的 **OpenAI 兼容端点**，在图形界面中即可完成全部配置，无需手动编辑配置文件。
+
+#### 第一步：获取 API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 创建并复制你的 API Key。
+
+#### 第二步：在 CodeCraft 中配置
+
+1. 启动 CodeCraft，默认账号 `admin` / `123456` 登录
+2. 点击左侧菜单 **设置 → 系统配置**
+3. 找到 **DeepSeek API Key** 配置项，粘贴你的 API Key
+4. 点击保存
+
+#### 第三步：选择模型与推理强度
+
+在聊天页面顶部，你可以切换模型和思考模式：
+
+| 配置项 | 推荐值 | 说明 |
+|--------|--------|------|
+| **模型** | `deepseek-v4-pro` | V4 Pro 适合复杂编程任务；V4 Flash 响应更快、成本更低 |
+| **思考模式** | `深度思考 (thinking_max)` | 开启后 AI 会先深度推理再执行，获得最佳编程体验 |
+| **执行模式** | `auto` 或 `manual` | auto 模式 AI 自动执行工具；manual 模式操作前需确认 |
+
+> 💡 **1M 上下文**：DeepSeek V4 系列支持高达 **100 万 token** 的上下文窗口。CodeCraft 内置了智能上下文压缩系统（三级渐进：预警 → 压缩 → 丢弃），自动管理 Token 消耗，让你专注对话而无需手动清理历史。
+
+### 使用 CodeCraft
+
+1. 在左侧菜单中，为当前会话设置 **工作目录**（即你的项目根目录）
+2. 在聊天框中输入编程任务，例如：「帮我创建一个 Spring Boot REST API 项目」
+3. AI 会自动调用工具完成任务——读写文件、执行命令、搜索代码等
+4. 复杂任务会被自动拆解，子 Agent 并行执行，完成后汇总结果
+
+```
+工作目录示例：/path/to/my-project
+
+输入：帮我写一个用户注册接口，包含参数校验和数据库存储
+AI 操作：
+  ├─ 读取项目结构，了解现有代码
+  ├─ 创建 UserController、UserService、UserMapper
+  ├─ 编写参数校验逻辑
+  ├─ 自动编译验证
+  └─ 报告完成情况
+```
+
+### 更多资源
+
+- [CodeCraft 源码](https://github.com/zb614433612/CodeCraft)
+- [架构文档](https://github.com/zb614433612/CodeCraft/blob/master/docs/ARCHITECTURE.md)（英文版：[ARCHITECTURE_EN.md](https://github.com/zb614433612/CodeCraft/blob/master/docs/ARCHITECTURE_EN.md)）
+- [开发速查表](https://github.com/zb614433612/CodeCraft/blob/master/docs/DEV_QUICKREF.md)


### PR DESCRIPTION
Add CodeCraft — desktop AI coding assistant with 19 tools, sub-agent parallel collaboration, and DeepSeek V4 support (1M context, thinking_max).

https://github.com/zb614433612/CodeCraft