### PR TITLE
docs: add LangDriver integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
+| **LangDriver** | Minimal ReAct agent (~500 lines of Ruby) with macOS Seatbelt sandbox, MCP, declarative Skills, and persistent memory. | [Guide](./docs/langdriver.md) |
 | **LobeHub** | LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. | [Guide](./docs/lobehub.md) |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,6 +28,7 @@
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **Langcli** | 100% 兼容 Claude Code、支持 DeepSeek V4 等主流 LLM 模型的开源 AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
+| **LangDriver** | 极简 ReAct Agent（~500 行 Ruby），macOS Seatbelt 沙箱 + MCP + 声明式 Skill + 持久记忆。 | [指南](./docs/langdriver.zh-CN.md) |
 | **LobeHub** | LobeHub 是你的 Chief Agent Operator，通过招聘、排班并报告整个 AI 团队，将你的 Agent 组织成 7×24 小时运作。 | [指南](./docs/lobehub.zh-CN.md) |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具、记忆、MCP 等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |

--- a/docs/langdriver.md
+++ b/docs/langdriver.md
@@ -1,0 +1,84 @@
+[English](./langdriver.md) | [简体中文](./langdriver.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with LangDriver
+
+LangDriver is a minimal ReAct agent — ~500 lines of Ruby. It combines a ReAct loop with a macOS Seatbelt hard sandbox, MCP protocol support, declarative Skill installation, and persistent memory with async compaction. Tuned for DeepSeek out of the box.
+
+- **GitHub:** <https://github.com/kevin0x5/langdriver>
+
+#### 1. Install LangDriver
+
+Requires **macOS** and **Ruby 3.0+** (uses Reline shipped with Ruby 3).
+
+```sh
+git clone https://github.com/kevin0x5/langdriver && cd langdriver
+```
+
+#### 2. Configure LangDriver
+
+Set your DeepSeek API key:
+
+```sh
+export DEEPSEEK_API_KEY=sk-xxx
+```
+
+The default `langdriver.yaml` is already tuned for DeepSeek:
+
+```yaml
+runtime:
+  model: deepseek-v4-pro                # or deepseek-v4-flash (cheaper / faster)
+  compact_model: deepseek-v4-flash      # used for async chat compaction
+  api_base: https://api.deepseek.com
+  api_key_env: DEEPSEEK_API_KEY
+  max_steps: 50
+  extra:
+    max_tokens: 384000                  # DeepSeek v4 single-call max output
+    reasoning_effort: max               # recommended for complex agent tasks
+    thinking: { type: enabled }         # chain-of-thought (DeepSeek-V3.2+ supports tool calls in thinking mode)
+```
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+> **Note:** 1M context is native on DeepSeek v4 — no extra flags needed. The `runtime.extra` block is forwarded verbatim into the chat/completions request body.
+
+**Key configuration files:**
+
+| File | Purpose |
+|---|---|
+| `profile.md` | Assistant persona / tone (system prompt) |
+| `tools.yaml` | Global safety ceiling — what may be read, written, networked |
+| `skills.yaml` | Per-skill enable / trust / priority |
+| `mcp.yaml` | MCP server connections |
+| `hooks.yaml` | `after_user_prompt` / `after_tool_use` reminder text |
+
+#### 3. Run LangDriver
+
+```sh
+ruby langdriver.rb
+```
+
+In the REPL:
+
+```
+> read sample.txt and summarize it in one sentence
+```
+
+The model picks `read`, gets the content, then calls `final_answer`. **No hard-coded flow, no prompt templates — the model decides every step.**
+
+#### Key REPL commands
+
+| Command | Action |
+|---|---|
+| `/exit` | Exit |
+| `/clear` | Clear in-session chat (memory preserved) |
+| `/memory` | Show persistent memory |
+| `/remember <fact>` | Append a fact to long-term memory |
+| `/todos` | Show session todo list |
+| `/skill list` | List installed Skills |
+| `/skill install <url> <name>` | Install a community Skill (cloned into Seatbelt sandbox) |
+| `/mcp` | List MCP-provided tools |
+
+#### Security model
+
+Community Skills downloaded via `skill install` run inside a **macOS Seatbelt sandbox** with a dynamically generated deny-by-default profile. A three-layer permission intersection (Skill frontmatter × local override × global ceiling) and core/external trust levels ensure untrusted scripts cannot access unauthorized files or network.
+

--- a/docs/langdriver.zh-CN.md
+++ b/docs/langdriver.zh-CN.md
@@ -1,0 +1,84 @@
+[English](./langdriver.md) | [简体中文](./langdriver.zh-CN.md) · [← Back](../README.md)
+
+# 集成 LangDriver
+
+LangDriver 是一个极简的 ReAct Agent——约 500 行 Ruby。它将 ReAct 循环与 macOS Seatbelt 硬沙箱结合，支持 MCP 协议、声明式 Skill 安装、持久记忆与异步压缩。开箱即用，针对 DeepSeek 调优。
+
+- **GitHub:** <https://github.com/kevin0x5/langdriver>
+
+#### 1. 安装 LangDriver
+
+需要 **macOS** 和 **Ruby 3.0+**（使用 Ruby 3 自带的 Reline）。
+
+```sh
+git clone https://github.com/kevin0x5/langdriver && cd langdriver
+```
+
+#### 2. 配置 LangDriver
+
+设置 DeepSeek API key：
+
+```sh
+export DEEPSEEK_API_KEY=sk-xxx
+```
+
+默认 `langdriver.yaml` 已针对 DeepSeek 调优：
+
+```yaml
+runtime:
+  model: deepseek-v4-pro                # 或 deepseek-v4-flash（更便宜更快）
+  compact_model: deepseek-v4-flash      # 异步压缩用
+  api_base: https://api.deepseek.com
+  api_key_env: DEEPSEEK_API_KEY
+  max_steps: 50
+  extra:
+    max_tokens: 384000                  # DeepSeek v4 单次最大输出
+    reasoning_effort: max               # 复杂 Agent 任务建议 max
+    thinking: { type: enabled }         # 开启思维链（DeepSeek-V3.2+ 支持思考模式下的工具调用）
+```
+
+从 [DeepSeek 平台](https://platform.deepseek.com/api_keys) 获取 API Key。
+
+> **注意：** DeepSeek v4 原生支持 1M 上下文，无需额外开关。`runtime.extra` 配置块会原样透传到 chat/completions 请求体。
+
+**主要配置文件：**
+
+| 文件 | 作用 |
+|---|---|
+| `profile.md` | 助手的人格 / 语气（system prompt） |
+| `tools.yaml` | 全局安全天花板——能读写什么、能否联网 |
+| `skills.yaml` | 每个 Skill 的开关 / 信任级别 / 优先级 |
+| `mcp.yaml` | MCP server 连接信息 |
+| `hooks.yaml` | `after_user_prompt` / `after_tool_use` 提醒文本 |
+
+#### 3. 运行 LangDriver
+
+```sh
+ruby langdriver.rb
+```
+
+进入 REPL 后：
+
+```
+> 读 sample.txt 用一句话总结
+```
+
+模型自己调 `read` 拿到文件内容，再调 `final_answer`。**没有写死流程，没有提示词模板，每一步都是模型自己决定的。**
+
+#### REPL 常用命令
+
+| 命令 | 功能 |
+|---|---|
+| `/exit` | 退出 |
+| `/clear` | 清空当前会话（记忆保留） |
+| `/memory` | 查看持久记忆 |
+| `/remember <fact>` | 追加一条事实到长期记忆 |
+| `/todos` | 查看任务清单 |
+| `/skill list` | 列出已安装的 Skill |
+| `/skill install <url> <name>` | 安装社区 Skill（克隆后入 Seatbelt 沙箱） |
+| `/mcp` | 列出 MCP 提供的工具 |
+
+#### 安全模型
+
+通过 `skill install` 安装的社区 Skill 运行在 **macOS Seatbelt 沙箱** 内，含动态生成的 deny-by-default 安全策略。三层权限求交（Skill 声明 × 本地覆盖 × 全局天花板）和 core/external 信任分级，确保不可信脚本无法越权读写或联网。
+


### PR DESCRIPTION
LangDriver is a minimal ReAct agent (~500 lines of Ruby) with macOS Seatbelt sandbox, MCP protocol, declarative Skills, and persistent memory. Tuned for DeepSeek out of the box.

Repo: https://github.com/kevin0x5/langdriver