### PR TITLE
docs: add Mangopi CLI integration guide (EN + zh-CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **LobeHub** | LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. | [Guide](./docs/lobehub.md) |
+| **Mangopi CLI** | Single-file, zero-dependency AI coding assistant for the terminal with 13 built-in tools. | [Guide](./docs/mangopi_cli.md) |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,6 +29,7 @@
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **Langcli** | 100% 兼容 Claude Code、支持 DeepSeek V4 等主流 LLM 模型的开源 AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **LobeHub** | LobeHub 是你的 Chief Agent Operator，通过招聘、排班并报告整个 AI 团队，将你的 Agent 组织成 7×24 小时运作。 | [指南](./docs/lobehub.zh-CN.md) |
+| **Mangopi CLI** | 单文件、零依赖的终端 AI 编程助手，内置 13 个工具，默认使用 DeepSeek。 | [指南](./docs/mangopi_cli.zh-CN.md) |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具、记忆、MCP 等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |

--- a/docs/mangopi_cli.md
+++ b/docs/mangopi_cli.md
@@ -1,0 +1,77 @@
+# Integrate with Mangopi CLI
+
+Mangopi CLI is a single-file (1732 lines), zero-dependency AI coding assistant for the terminal. Built with only the Python standard library, it runs on Python 3.8+ — no Node.js, no Docker, no framework. Just one hackable `.py` file you can read in an afternoon.
+
+**Key highlights:**
+- **Single-file architecture** — 1732 lines, 23 classes, 13 built-in tools, all in one `mangopi_cli.py`
+- **Zero runtime dependencies** — Python standard library only; `pip install mangopi-cli` pulls nothing
+- **Three-tier context compression** — micro (truncate stale tool output) → session (compact old turns, keep last 10) → full (LLM-driven summary), keeping long autonomous sessions within the 1M token budget
+- **Multi-provider support** — DeepSeek, OpenAI, MiniMax, and any OpenAI-compatible endpoint
+- **Multimodal support** — can view images (PNG/JPG/WebP) directly in the terminal via `view_image` tool
+- **13 built-in tools** — file I/O (read/write/edit with diff preview), regex grep, glob search, bash execution (with 7-category dangerous command detection + y/n confirmation), web search, image viewer, skill system, long-term memory, and more
+- **Safety sandbox** — dangerous command patterns require explicit confirmation; file writes are restricted to project root via `realpath` validation
+- **Goal Mode** — `/g` triggers autonomous plan → execute → verify → iterate loop with persistent checkpointing
+- **13 test files** — comprehensive unit tests covering safety detection, all three compaction tiers, path sandbox (including prefix collision attacks), web search, system prompt assembly, and more
+- **Python 3.8–3.12** — tested across all supported versions via GitHub Actions CI
+- **PyPI published** — trusted publishing via OIDC, `pip install mangopi-cli`
+
+### Installing Mangopi CLI from Scratch
+
+Mangopi CLI requires Python 3.8+ and nothing else — no Node.js, no Docker, no frameworks. The entire runtime is a single `mangopi_cli.py` file (1732 lines).
+
+#### Install via pip (recommended)
+
+```bash
+pip install mangopi-cli
+```
+
+#### Install from source
+
+```bash
+git clone git@github.com:w4n9H/mangopi-cli.git
+cd mangopi-cli
+python mangopi_cli.py
+```
+
+### Configuring Mangopi CLI
+
+Mangopi CLI supports all OpenAI-compatible API endpoints. Set the following environment variables:
+
+```bash
+export MANGO_KEY="<your DeepSeek API Key>"
+export MANGO_API_URL="https://api.deepseek.com"
+export MANGO_MODEL="deepseek-v4-flash"
+export MANGO_LANG="en"                          # en (default) | zh — UI language
+```
+
+> **Note**: Mangopi CLI supports up to **1,000,000 tokens** of context (configurable via `MANGO_MAX_CONTEXT`). DeepSeek V4 models with their 1M context window are a perfect match — combined with the three-tier compaction strategy, you can run long autonomous coding sessions without exhausting the context budget.
+
+For DeepSeek V4 Pro with reasoning/thinking mode:
+
+```bash
+export MANGO_API_URL="https://api.deepseek.com"
+export MANGO_MODEL="deepseek-v4-pro"
+```
+
+Mangopi CLI automatically enables thinking mode when the model supports it. DeepSeek V4 Pro supports `max` reasoning effort level out of the box.
+
+### Using Mangopi CLI
+
+Start Mangopi CLI in your project directory:
+
+```bash
+cd /path/to/my-project
+mangopi-cli
+```
+
+Enter interactive mode and start coding. Mangopi CLI has 13 built-in tools including file read/write/edit (with unified-diff preview), regex grep, glob search, bash execution, web search, image viewing, and more.
+
+#### Goal Mode
+
+Use `/g` to let Mangopi CLI autonomously plan, execute, verify, and iterate until a goal is completed:
+
+```
+/g build a FastAPI todo app with tests
+```
+
+The agent will keep working until the task is complete or you stop it. Press `Ctrl+C` to pause; resume with `/g continue`.

--- a/docs/mangopi_cli.zh-CN.md
+++ b/docs/mangopi_cli.zh-CN.md
@@ -1,0 +1,79 @@
+[English](./mangopi_cli.md) | [简体中文](./mangopi_cli.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Mangopi CLI
+
+Mangopi CLI 是一个单文件 (1732 行)、零依赖的终端 AI 编程助手，仅使用 Python 标准库构建。支持 Python 3.8+，不需要 Node.js、Docker 或任何第三方框架——就是一个 `.py` 文件，一个下午就能读完。
+
+**核心亮点：**
+- **单文件架构** — 1732 行，23 个类，13 个内置工具，全在一个 `mangopi_cli.py` 中
+- **零运行时依赖** — 纯 Python 标准库；`pip install mangopi-cli` 不拉任何第三方包
+- **三层上下文压缩** — micro（截断旧工具输出）→ session（压缩历史轮次，保留最近 10 轮）→ full（LLM 驱动摘要），确保长时间自主会话不超出 1M token 预算
+- **多 Provider 支持** — DeepSeek、OpenAI、MiniMax，以及任意 OpenAI 兼容接口
+- **多模态支持** — 终端内直接查看图片（PNG/JPG/WebP），通过 `view_image` 工具
+- **13 个内置工具** — 文件读写编辑（含 diff 预览）、正则 grep、glob 搜索、bash 执行（含 7 类危险命令检测 + y/n 确认）、网络搜索、图片查看、Skill 系统、长期记忆等
+- **安全沙箱** — 危险命令模式需显式确认；文件写入通过 `realpath` 校验限制在项目根目录内
+- **Goal Mode** — `/g` 启动自主规划 → 执行 → 验证 → 迭代循环，带持久化检查点
+- **13 个测试文件** — 全面覆盖安全检测、三层压缩、路径沙箱（含前缀碰撞攻击测试）、网络搜索、系统提示词组装等
+- **Python 3.8–3.12** — 通过 GitHub Actions CI 全版本矩阵测试
+- **PyPI 发布** — OIDC 可信发布，`pip install mangopi-cli` 即可安装
+
+### 从零安装 Mangopi CLI
+
+Mangopi CLI 只需要 Python 3.8+，不需要 Node.js、Docker 或任何第三方框架。整个运行时就是一个 `mangopi_cli.py` 文件 (1732 行)。
+
+#### 通过 pip 安装（推荐）
+
+```bash
+pip install mangopi-cli
+```
+
+#### 从源码安装
+
+```bash
+git clone git@github.com:w4n9H/mangopi-cli.git
+cd mangopi-cli
+python mangopi_cli.py
+```
+
+### 配置 Mangopi CLI
+
+Mangopi CLI 支持所有 OpenAI 兼容的 API 端点。设置以下环境变量：
+
+```bash
+export MANGO_KEY="<你的 DeepSeek API Key>"
+export MANGO_API_URL="https://api.deepseek.com"
+export MANGO_MODEL="deepseek-v4-flash"
+export MANGO_LANG="zh"                          # 中文界面
+```
+
+> **提示**：Mangopi CLI 支持最高 **1,000,000 token** 的上下文窗口（通过 `MANGO_MAX_CONTEXT` 配置）。DeepSeek V4 模型的 1M 上下文窗口与之完美匹配——配合三层压缩策略，你可以运行长时间的自主编程会话而不会耗尽上下文预算。
+
+使用 DeepSeek V4 Pro 并开启推理/思考模式：
+
+```bash
+export MANGO_API_URL="https://api.deepseek.com"
+export MANGO_MODEL="deepseek-v4-pro"
+```
+
+Mangopi CLI 会在模型支持时自动启用思考模式。DeepSeek V4 Pro 开箱即支持 `max` 推理强度级别。
+
+### 使用 Mangopi CLI
+
+进入项目目录，启动 Mangopi CLI：
+
+```bash
+cd /path/to/my-project
+mangopi-cli
+```
+
+进入交互模式后即可开始编程。Mangopi CLI 内置 13 个工具，包括文件读写编辑（含 diff 预览）、正则搜索、glob 文件匹配、bash 命令执行、网络搜索、图片查看等。
+
+#### 目标模式
+
+使用 `/g` 命令让 Mangopi CLI 自主完成规划、执行、验证、迭代的全流程：
+
+```
+/g 用 FastAPI 写一个带测试的 Todo API
+```
+
+Agent 会持续工作直到任务完成或你手动停止。按 `Ctrl+C` 可暂停；使用 `/g 继续` 恢复执行。


### PR DESCRIPTION
See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing)
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes
