### PR TITLE
Add Raidho guide (plan/execute split agent with VSA memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Qwen Code** | Coding agent CLI by the Alibaba Qwen team — now with built-in DeepSeek provider support. | [Guide](./docs/qwen_code.md) |
+| **Raidho** | Coding agent that plans with one model and executes with another, with durable VSA memory across runs — DeepSeek-native, bring your own key. | [Guide](./docs/raidho.md) |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,6 +35,7 @@
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Qwen Code** | 阿里巴巴通义千问团队推出的 Coding Agent CLI，现已全面支持 DeepSeek 提供商。 | [指南](./docs/qwen_code.zh-CN.md) |
+| **Raidho** | 用一个模型规划、用另一个模型执行的编码智能体，带跨运行的持久化 VSA 记忆——原生支持 DeepSeek，自带密钥。 | [指南](./docs/raidho.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
 

--- a/docs/raidho.md
+++ b/docs/raidho.md
@@ -1,0 +1,85 @@
+# Raidho
+
+[Raidho](https://github.com/vitaliyfedotovpro-art/raidho) is a coding agent that
+**plans with one model and executes with another**, with a durable memory that
+carries facts across runs. It is provider-agnostic and runs on your own key —
+a natural fit for DeepSeek: put `deepseek-v4-pro` in the reasoning seat and the
+cheaper `deepseek-v4-flash` in the execution seat, so the token-heavy tool loop
+runs on the fast model while planning uses the strong one.
+
+## Install
+
+Requires Python ≥ 3.11.
+
+```bash
+git clone https://github.com/vitaliyfedotovpro-art/raidho
+cd raidho
+pip install -e '.[openai-compat]'   # DeepSeek / OpenAI-compatible backend
+pip install -e '.[embed]'           # optional: semantic memory recall
+```
+
+Or use the guided installer, which verifies your key live and runs a smoke test:
+
+```bash
+bash install.sh
+```
+
+## Configure for DeepSeek
+
+Single provider — everything on DeepSeek:
+
+```bash
+export CODER_PROVIDER=deepseek
+export CODER_MODEL=deepseek-v4-flash      # execution model
+export DEEPSEEK_API_KEY=sk-...
+```
+
+Split mode (the point of Raidho) — reason on `deepseek-v4-pro`, execute on
+`deepseek-v4-flash`:
+
+```bash
+export CODER_PROVIDER=deepseek            # execution (code mode, tool loop)
+export CODER_MODEL=deepseek-v4-flash
+export CODER_REASON_PROVIDER=deepseek     # reasoning (text mode)
+export CODER_REASON_MODEL=deepseek-v4-pro
+export DEEPSEEK_API_KEY=sk-...
+```
+
+DeepSeek V4 models support a 1M-token context window, so long files and multi-step
+tool loops fit without manual truncation. The endpoint
+(`https://api.deepseek.com/chat/completions`) is used automatically; no base-URL
+override is needed for DeepSeek.
+
+## First run
+
+Headless — run one task and exit:
+
+```bash
+coder "create a FastAPI hello-world app and run it"
+```
+
+Interactive REPL:
+
+```bash
+coder
+```
+
+In the REPL:
+
+- `/code` — agentic coding (tool loop, executes on `CODER_MODEL`)
+- `/text` — reasoning chat (runs on `CODER_REASON_MODEL` if set)
+- `/council <question>` — two providers debate, a neutral pass distills the
+  consensus (points of agreement, residual disagreements, recommendation)
+- `/ctx` — toggle context-first mode
+- `/learn` — toggle auto-distillation of repeated read-only tool loops
+- `/quit` — exit
+
+## Memory
+
+Raidho remembers `(subject, relation, object)` facts and recalls the relevant ones
+into its prompt each turn. New facts are saved via a `remember` tool, and council
+verdicts are distilled into facts automatically. Memory is written per project to
+`<workdir>/.raidho/memory` and reloaded on the next run — a decision reached today
+resurfaces tomorrow, recalled only when relevant and across languages. It is a
+Vector Symbolic Architecture (not RAG); you don't need to know the internals to use
+it. The REPL prints how many facts it loaded on start.

--- a/docs/raidho.zh-CN.md
+++ b/docs/raidho.zh-CN.md
@@ -1,0 +1,79 @@
+# Raidho
+
+[Raidho](https://github.com/vitaliyfedotovpro-art/raidho) 是一个**用一个模型规划、
+用另一个模型执行**的编码智能体，并带有可在多次运行之间保留事实的持久化记忆。它不绑定
+特定服务商，使用你自己的 API 密钥运行——非常适合 DeepSeek：把 `deepseek-v4-pro`
+放在推理端，把更便宜的 `deepseek-v4-flash` 放在执行端，这样高 token 消耗的工具循环
+在快速模型上运行，而规划则使用强模型。
+
+## 安装
+
+需要 Python ≥ 3.11。
+
+```bash
+git clone https://github.com/vitaliyfedotovpro-art/raidho
+cd raidho
+pip install -e '.[openai-compat]'   # DeepSeek / 兼容 OpenAI 的后端
+pip install -e '.[embed]'           # 可选：语义记忆召回
+```
+
+或使用引导式安装脚本，它会实时校验你的密钥并运行一次冒烟测试：
+
+```bash
+bash install.sh
+```
+
+## 为 DeepSeek 配置
+
+单一服务商——全部在 DeepSeek 上运行：
+
+```bash
+export CODER_PROVIDER=deepseek
+export CODER_MODEL=deepseek-v4-flash      # 执行模型
+export DEEPSEEK_API_KEY=sk-...
+```
+
+分离模式（Raidho 的核心）——用 `deepseek-v4-pro` 推理，用 `deepseek-v4-flash` 执行：
+
+```bash
+export CODER_PROVIDER=deepseek            # 执行（code 模式，工具循环）
+export CODER_MODEL=deepseek-v4-flash
+export CODER_REASON_PROVIDER=deepseek     # 推理（text 模式）
+export CODER_REASON_MODEL=deepseek-v4-pro
+export DEEPSEEK_API_KEY=sk-...
+```
+
+DeepSeek V4 模型支持 100 万 token 的上下文窗口，因此长文件和多步工具循环无需手动截断
+即可容纳。端点（`https://api.deepseek.com/chat/completions`）会自动使用；DeepSeek
+无需覆盖 base-URL。
+
+## 首次运行
+
+无界面模式——运行单个任务后退出：
+
+```bash
+coder "create a FastAPI hello-world app and run it"
+```
+
+交互式 REPL：
+
+```bash
+coder
+```
+
+在 REPL 中：
+
+- `/code` — 智能体编码（工具循环，在 `CODER_MODEL` 上执行）
+- `/text` — 推理对话（若设置了 `CODER_REASON_MODEL` 则在其上运行）
+- `/council <question>` — 两个服务商辩论，由中立环节提炼共识（一致点、遗留分歧、建议）
+- `/ctx` — 切换 context-first 模式
+- `/learn` — 切换对重复只读工具循环的自动蒸馏
+- `/quit` — 退出
+
+## 记忆
+
+Raidho 记住 `(主语, 关系, 宾语)` 形式的事实，并在每一轮把相关事实召回到提示词中。
+新事实通过 `remember` 工具保存，议会结论会自动蒸馏为事实。记忆按项目写入
+`<workdir>/.raidho/memory`，下次运行时自动重新加载——今天得出的决定明天会重新浮现，
+仅在相关时召回，且支持跨语言。它采用向量符号架构（VSA），而非 RAG；使用它无需了解
+其内部实现。REPL 在启动时会打印加载了多少条事实。


### PR DESCRIPTION
Adds a guide for **Raidho** — a provider-agnostic coding agent that plans with one model and executes with another (e.g. `deepseek-v4-pro` reasoning + `deepseek-v4-flash` execution), with durable VSA memory that persists across runs.

- `docs/raidho.md` + `docs/raidho.zh-CN.md` (bilingual, single PR per CONTRIBUTING)
- Entry added to both `README.md` and `README.zh-CN.md` in alphabetical order
- Models use current names (`deepseek-v4-pro` / `deepseek-v4-flash`), 1M context noted
- Config verified live: the tool loop runs end-to-end on `deepseek-v4-flash`
- No pricing claims; only verified configuration options

Repo: https://github.com/vitaliyfedotovpro-art/raidho