### PR TITLE
Add AFK integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Each guide walks through installation, configuration, and first run — so you c
 
 | Tool            | Description                                                                                                 | Guide                          |
 | --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **AFK** | Browser-based coding agent platform with connected daemons, persistent sessions, sub-agents, skills, MCP tools, and DeepSeek connection support. | [Guide](./docs/afk.md) |
 | **AstrBot** | Open-source agent assistant for Feishu, Telegram and more, extensible with skills, plugins, and MCPs. | [Guide](./docs/astrbot.md) |
 | **Cherry Studio** | Open-source cross-platform desktop AI client with 300+ assistants, MCP support, knowledge bases, and multi-model chat. | [Guide](./docs/cherry_studio.md) |
 | **Claude Code** | AI coding assistant that runs in the terminal.                                                              | [Guide](./docs/claude_code.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,7 @@
 
 | 工具            | 简介                                                                  | 指南                                |
 | --------------- | --------------------------------------------------------------------- | ----------------------------------- |
+| **AFK** | 基于浏览器的编程 Agent 平台，支持连接 daemon、持久会话、子 Agent、Skills、MCP 工具以及 DeepSeek 连接。 | [指南](./docs/afk.zh-CN.md) |
 | **AstrBot** | 开源的 Agent 助手，支持接入 QQ、微信、飞书等消息平台，并可通过 Skill、插件和 MCP 扩展能力。 | [指南](./docs/astrbot.zh-CN.md) |
 | **Cherry Studio** | 开源跨平台桌面 AI 客户端，内置 300+ 助手、MCP、知识库与多模型对话。 | [指南](./docs/cherry_studio.zh-CN.md) |
 | **Claude Code** | 运行在终端内的 AI 编程助手。                                          | [指南](./docs/claude_code.zh-CN.md) |

--- a/docs/afk.md
+++ b/docs/afk.md
@@ -1,0 +1,72 @@
+[English](./afk.md) | [简体中文](./afk.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with AFK
+
+AFK is a browser-based coding agent platform. Install the daemon on your machine, connect it to your AFK account, and run coding sessions from the browser using DeepSeek models.
+
+#### 1. Create an AFK Account
+
+Open AFK in your browser:
+
+<https://afk.mooglest.com>
+
+Create an account or sign in.
+
+#### 2. Install and Connect the AFK Daemon
+
+In AFK, follow the daemon setup instructions for your operating system.
+
+The daemon runs on your machine and gives AFK access to the project directories you choose. After it connects, it will appear in the AFK browser UI.
+
+#### 3. Get a DeepSeek API Key
+
+Go to the [DeepSeek Platform](https://platform.deepseek.com/api_keys), create an API key, and copy it.
+
+#### 4. Configure DeepSeek in AFK
+
+In the AFK browser UI:
+
+1. Open **Account → LLM**
+2. Click **Add connection**
+3. Select **DeepSeek**
+4. Paste your DeepSeek API key
+5. Save the connection
+6. Optionally click **Test** to verify the connection
+
+AFK uses DeepSeek through an OpenAI-compatible API path.
+
+#### 5. Start a Coding Session
+
+Create a new AFK session:
+
+1. Click **New session**
+2. Select a connected daemon
+3. Choose your project directory
+4. Select the DeepSeek connection
+5. Select or manually enter a model:
+   - `deepseek-v4-pro`
+   - `deepseek-v4-flash`
+6. Enter a coding task and start the session
+
+Example task:
+
+```text
+Inspect this repository, find the failing tests, fix the underlying issue, and summarize what changed.
+```
+
+AFK will run the agent through your connected daemon, stream progress to the browser, and use the selected DeepSeek model for the session.
+
+#### Notes
+
+- DeepSeek V4 models support up to **1 million tokens** of context.
+- If the model list does not show the latest DeepSeek models, manually enter `deepseek-v4-pro` or `deepseek-v4-flash`.
+- AFK chooses the model per session, so you can switch between DeepSeek and other providers when starting new sessions.
+- AFK supports persistent sessions, browser-visible progress, project instructions through `AGENTS.md`, sub-agents, skills, MCP tools, and workspace isolation.
+
+#### Troubleshooting
+
+- `401` or authentication errors: check your DeepSeek API key in **Account → LLM**.
+- `402` or payment errors: check your DeepSeek Platform balance.
+- No daemon available: make sure the AFK daemon is installed, running, and connected to your account.
+- Project directory not visible: make sure the daemon was installed or configured with access to that directory.
+- Model not listed: manually enter `deepseek-v4-pro` or `deepseek-v4-flash`.

--- a/docs/afk.zh-CN.md
+++ b/docs/afk.zh-CN.md
@@ -1,0 +1,72 @@
+[English](./afk.md) | [简体中文](./afk.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 AFK
+
+AFK 是一个基于浏览器的编程 Agent 平台。你只需要在自己的机器上安装 daemon，将它连接到 AFK 账号，然后就可以在浏览器中使用 DeepSeek 模型运行编程会话。
+
+#### 1. 创建 AFK 账号
+
+在浏览器中打开 AFK：
+
+<https://afk.mooglest.com>
+
+创建账号或登录。
+
+#### 2. 安装并连接 AFK Daemon
+
+在 AFK 中，根据你的操作系统按照 daemon 设置说明进行安装。
+
+daemon 会运行在你的机器上，并让 AFK 访问你选择的项目目录。连接成功后，它会出现在 AFK 浏览器界面中。
+
+#### 3. 获取 DeepSeek API Key
+
+前往 [DeepSeek Platform](https://platform.deepseek.com/api_keys)，创建并复制 API Key。
+
+#### 4. 在 AFK 中配置 DeepSeek
+
+在 AFK 浏览器界面中：
+
+1. 打开 **Account → LLM**
+2. 点击 **Add connection**
+3. 选择 **DeepSeek**
+4. 粘贴你的 DeepSeek API Key
+5. 保存连接
+6. 可选：点击 **Test** 验证连接是否可用
+
+AFK 会通过 OpenAI 兼容的 API 路径使用 DeepSeek。
+
+#### 5. 启动编程会话
+
+创建一个新的 AFK 会话：
+
+1. 点击 **New session**
+2. 选择已连接的 daemon
+3. 选择你的项目目录
+4. 选择 DeepSeek 连接
+5. 选择或手动输入模型：
+   - `deepseek-v4-pro`
+   - `deepseek-v4-flash`
+6. 输入编程任务并启动会话
+
+示例任务：
+
+```text
+Inspect this repository, find the failing tests, fix the underlying issue, and summarize what changed.
+```
+
+AFK 会通过你已连接的 daemon 运行 Agent，将进度实时流式展示到浏览器，并在该会话中使用你选择的 DeepSeek 模型。
+
+#### 说明
+
+- DeepSeek V4 模型支持最高 **100 万 token** 上下文。
+- 如果模型列表中没有显示最新的 DeepSeek 模型，可以手动输入 `deepseek-v4-pro` 或 `deepseek-v4-flash`。
+- AFK 会在每个会话启动时选择模型，因此你可以在新会话中切换 DeepSeek 或其他提供商。
+- AFK 支持持久会话、浏览器可见的执行进度、通过 `AGENTS.md` 配置项目指令、子 Agent、Skills、MCP 工具以及工作区隔离。
+
+#### 故障排查
+
+- `401` 或认证错误：检查 **Account → LLM** 中的 DeepSeek API Key。
+- `402` 或支付错误：检查你的 DeepSeek Platform 余额。
+- 没有可用 daemon：确认 AFK daemon 已安装、正在运行，并已连接到你的账号。
+- 看不到项目目录：确认 daemon 安装或配置时允许访问该目录。
+- 模型未列出：手动输入 `deepseek-v4-pro` 或 `deepseek-v4-flash`。


### PR DESCRIPTION
## Summary\n- Add English and Simplified Chinese guides for using DeepSeek models with AFK\n- Add AFK to both README tool tables\n- Document AFK's account + daemon setup flow, DeepSeek connection setup, model selection, notes, and troubleshooting\n\n## Checks\n- Verified guide uses current DeepSeek V4 model names: `deepseek-v4-pro`, `deepseek-v4-flash`\n- Verified no deprecated DeepSeek model names are introduced\n- Mentioned DeepSeek V4 1M context support\n\nGenerated with AFK