### PR TITLE
docs: add JYY-Code integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
+| **JYY-Code** | Open-source terminal coding agent with multi-agent orchestration, persistent memory, Agent Skills, MCP, and communication tools. | [Guide](./docs/jyycode.md) |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **LobeHub** | LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. | [Guide](./docs/lobehub.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,6 +26,7 @@
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
+| **JYY-Code** | 开源终端编程 Agent，支持多 Agent 编排、持久记忆、Agent Skills、MCP 和通信工具。 | [指南](./docs/jyycode.zh-CN.md) |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **Langcli** | 100% 兼容 Claude Code、支持 DeepSeek V4 等主流 LLM 模型的开源 AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **LobeHub** | LobeHub 是你的 Chief Agent Operator，通过招聘、排班并报告整个 AI 团队，将你的 Agent 组织成 7×24 小时运作。 | [指南](./docs/lobehub.zh-CN.md) |

--- a/docs/jyycode.md
+++ b/docs/jyycode.md
@@ -1,0 +1,103 @@
+[English](./jyycode.md) | [简体中文](./jyycode.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with JYY-Code
+
+JYY-Code is an open-source terminal coding agent built on OpenCode, with multi-agent orchestration, persistent memory, Agent Skills, MCP, and communication tools.
+
+- **GitHub:** <https://github.com/Reon-Jin/JYY-Code>
+- **npm:** <https://www.npmjs.com/package/jyycode-ai>
+
+#### 1. Install JYY-Code
+
+- Install [Node.js](https://nodejs.org/en/download/) 20+.
+- Install the published CLI package:
+
+```sh
+npm install -g jyycode-ai
+```
+
+- Verify the installation:
+
+```sh
+jyycode --version
+```
+
+`jyy` and `jyycode` start the same CLI.
+
+#### 2. Configure DeepSeek
+
+The simplest setup is to store your DeepSeek API key with the built-in provider login command:
+
+```sh
+jyycode auth login --provider deepseek
+jyycode models deepseek --refresh
+```
+
+Get your API key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+You can also write the global config file at `~/.config/jyycode/jyycode.jsonc`:
+
+```jsonc
+{
+  "$schema": "https://jyycode.ai/config.json",
+  "model": "deepseek/deepseek-v4-pro",
+  "small_model": "deepseek/deepseek-v4-flash",
+  "provider": {
+    "deepseek": {
+      "options": {
+        "apiKey": "sk-..."
+      },
+      "models": {
+        "deepseek-v4-pro": {
+          "reasoning": true,
+          "limit": {
+            "context": 1000000,
+            "output": 384000
+          }
+        },
+        "deepseek-v4-flash": {
+          "limit": {
+            "context": 1000000,
+            "output": 384000
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Configuration notes:
+
+| Option | Description |
+|--------|-------------|
+| `model` | Default model in `provider/model` format. Use `deepseek/deepseek-v4-pro` for the strongest coding model. |
+| `small_model` | Lightweight model for smaller tasks such as titles and summaries, e.g. `deepseek/deepseek-v4-flash`. |
+| `provider.deepseek.options.apiKey` | DeepSeek API key. You can omit this when using `jyycode auth login --provider deepseek`. |
+| `limit.context` | DeepSeek V4 supports a 1 million token context window. |
+| `limit.output` | Maximum output token limit used by JYY-Code's model metadata. |
+
+JYY-Code recognizes reasoning variants for OpenAI-compatible reasoning models. For `deepseek-v4-pro`, use the `max` variant when you want maximum reasoning effort.
+
+#### 3. Launch JYY-Code in a project
+
+```sh
+cd /path/to/my-project
+jyy
+```
+
+Inside the TUI:
+
+- Run `/connect` if you prefer configuring the DeepSeek API key interactively.
+- Run `/models` to select `deepseek/deepseek-v4-pro`.
+- Run `/variants` and select `max` for maximum DeepSeek V4 Pro reasoning effort.
+
+#### 4. First run
+
+Ask JYY-Code to inspect the current repository:
+
+```text
+Read this project and summarize its architecture, then suggest one safe first improvement.
+```
+
+JYY-Code will run in the current terminal directory and can use its filesystem, shell, MCP, memory, skill, and multi-agent tools according to your configured permissions.

--- a/docs/jyycode.zh-CN.md
+++ b/docs/jyycode.zh-CN.md
@@ -1,0 +1,103 @@
+[English](./jyycode.md) | [简体中文](./jyycode.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 集成 JYY-Code
+
+JYY-Code 是一款开源终端编程 Agent，基于 OpenCode 深度扩展，支持多 Agent 编排、持久记忆、Agent Skills、MCP 和通信工具。
+
+- **GitHub：** <https://github.com/Reon-Jin/JYY-Code>
+- **npm：** <https://www.npmjs.com/package/jyycode-ai>
+
+#### 1. 安装 JYY-Code
+
+- 安装 [Node.js](https://nodejs.org/en/download/) 20+ 版本。
+- 安装已发布的 CLI 包：
+
+```sh
+npm install -g jyycode-ai
+```
+
+- 验证安装是否成功：
+
+```sh
+jyycode --version
+```
+
+`jyy` 和 `jyycode` 会启动同一个 CLI。
+
+#### 2. 配置 DeepSeek
+
+最简单的方式是使用内置 provider 登录命令保存 DeepSeek API Key：
+
+```sh
+jyycode auth login --provider deepseek
+jyycode models deepseek --refresh
+```
+
+从 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取你的 API Key。
+
+你也可以直接写入全局配置文件 `~/.config/jyycode/jyycode.jsonc`：
+
+```jsonc
+{
+  "$schema": "https://jyycode.ai/config.json",
+  "model": "deepseek/deepseek-v4-pro",
+  "small_model": "deepseek/deepseek-v4-flash",
+  "provider": {
+    "deepseek": {
+      "options": {
+        "apiKey": "sk-..."
+      },
+      "models": {
+        "deepseek-v4-pro": {
+          "reasoning": true,
+          "limit": {
+            "context": 1000000,
+            "output": 384000
+          }
+        },
+        "deepseek-v4-flash": {
+          "limit": {
+            "context": 1000000,
+            "output": 384000
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+配置说明：
+
+| 选项 | 说明 |
+|------|------|
+| `model` | 默认模型，格式为 `provider/model`。推荐使用 `deepseek/deepseek-v4-pro` 作为主力编程模型。 |
+| `small_model` | 轻量任务模型，例如标题、摘要等，可使用 `deepseek/deepseek-v4-flash`。 |
+| `provider.deepseek.options.apiKey` | DeepSeek API Key。如果使用 `jyycode auth login --provider deepseek` 保存凭证，可以省略此项。 |
+| `limit.context` | DeepSeek V4 支持 100 万 token 上下文窗口。 |
+| `limit.output` | JYY-Code 模型元数据中的最大输出 token 限制。 |
+
+JYY-Code 会为 OpenAI-compatible reasoning 模型识别推理强度变体。使用 `deepseek-v4-pro` 时，如需最大推理强度，请选择 `max` 变体。
+
+#### 3. 在项目中启动 JYY-Code
+
+```sh
+cd /path/to/my-project
+jyy
+```
+
+在 TUI 中：
+
+- 如果想交互式配置 DeepSeek API Key，运行 `/connect`。
+- 运行 `/models` 选择 `deepseek/deepseek-v4-pro`。
+- 运行 `/variants` 并选择 `max`，启用 DeepSeek V4 Pro 的最大推理强度。
+
+#### 4. 首次运行
+
+可以先让 JYY-Code 检查当前仓库：
+
+```text
+阅读这个项目并总结它的架构，然后建议一个安全的首个改进点。
+```
+
+JYY-Code 会在当前终端目录中运行，并按照你的权限配置使用文件系统、Shell、MCP、记忆、技能和多 Agent 工具。


### PR DESCRIPTION
## Summary
- add English and Simplified Chinese JYY-Code DeepSeek integration guides
- add JYY-Code to both README tables in alphabetical order
- document DeepSeek V4 Pro/Flash, 1M context metadata, and max reasoning variant usage

## Checks
- verified no JYY-Code duplicate in currently open upstream PR titles
- verified local markdown links resolve
- ran git diff --check
- confirmed DeepSeek V4 model names, 1M context, and high/max reasoning effort against official DeepSeek docs