### PR TITLE
docs: add Happex configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
+| **Happex** | Cross-platform desktop AI engineering platform with task management, tool execution, and multi-model support. | [Guide](./docs/happex.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,7 @@
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
+| **Happex** | 跨平台桌面 AI 工程平台，支持任务管理、工具执行与多模型接入。 | [指南](./docs/happex.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **Langcli** | 100% 兼容 Claude Code、支持 DeepSeek V4 等主流 LLM 模型的开源 AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |

--- a/docs/happex.md
+++ b/docs/happex.md
@@ -1,0 +1,126 @@
+[English](./happex.md) | [简体中文](./happex.zh-CN.md) · [← 返回](../README.md)
+
+# Connecting to Happex
+
+> **Happex Desktop AI Engineering Platform** — A cross-platform desktop application for AI-assisted software engineering, supporting task management, tool execution, and multi-vendor models.
+
+
+
+## Download & Installation
+
+### System Requirements
+
+| Platform | Minimum Version |
+| -------- | --------------- |
+| macOS | 10.15+ (Catalina) |
+| Windows | Windows 10+ |
+
+### Download
+
+1. Visit the [GitHub Releases page](https://github.com/huangsongyuan/happex/releases/latest)
+2. Download the installer for your platform:
+   - **macOS (Apple Silicon)**: `happex_<version>_aarch64.dmg`
+   - **macOS (Intel)**: `happex_<version>_x86_64.dmg`
+   - **Windows**: `happex_<version>_x64-setup.exe` (NSIS installer)
+3. Open/run the installer and follow the prompts to complete installation
+
+
+## Updating
+
+### Auto-Update (Recommended)
+
+Happex has a built-in auto-update mechanism based on Tauri Updater.
+
+1. Open the app, go to **About** (gear icon → "About")
+2. Click **"Check for Updates"**
+3. If a new version is found:
+   - The version number and release notes are displayed
+   - Click **"Install Now"**
+4. A progress bar is shown during download
+5. After download completes, the app automatically restarts to apply the update
+
+### Manual Update
+
+Download the latest installer from [GitHub Releases](https://github.com/huangsongyuan/happex/releases/latest) and install over the existing version.
+
+
+## DeepSeek Provider Configuration
+
+Get your API Key from the [DeepSeek Open Platform](https://platform.deepseek.com/api_keys).
+Get the URL and configuration instructions from the [DeepSeek Open Platform Model Documentation](https://api-docs.deepseek.com/zh-cn/quick_start/pricing/).
+
+### Page Configuration (UI)
+
+#### Adding a Provider
+
+1. Go to **Settings** → **Provider & Model Settings**
+2. Click the **+** button in the top-right corner of the provider panel
+3. Fill in the form:
+   - **Provider Type**: Select OpenAI Compatible or Anthropic
+   - **Display Name**: A human-readable label (e.g., "My DeepSeek")
+   - **Base URL** (OpenAI protocol: `https://api.deepseek.com/v1`;
+   - Anthropic protocol: `https://api.deepseek.com/anthropic`)
+   - **API Key**: Your API key (stored in the system keychain)
+4. Click **"Add Provider"**
+
+#### Editing a Provider
+
+- Click the **edit (pencil)** icon next to a provider in the list
+- You can update the display name, Base URL, and API key
+- The API key field in edit mode is optional — leave it empty to keep the existing key
+
+
+#### Deleting a Provider
+
+Click the **trash** icon next to a provider. Deleting a provider also removes all model configurations under it.
+
+
+
+## Model Configuration
+
+Each provider account can have multiple model configurations. Models are managed per-provider and can be set as the global default model.
+
+### Page Configuration (UI)
+
+#### Adding a DeepSeek Model
+
+1. Select a provider from the left-hand list
+2. Click **"Add Model"** in the top-right of the model panel
+3. Fill in the form:
+   - **Model ID**: The exact model identifier sent to the API (e.g., `deepseek-v4-pro`, `deepseek-v4-flash`)
+   - **Display Name**: A human-readable label (e.g., "deepseek-v4-pro", "deepseek-v4-flash")
+   - **Context Window**: Maximum context length in tokens (refer to DeepSeek model documentation, recommended value: 1000000)
+   - **Max Output Tokens**: Maximum output length in tokens (refer to DeepSeek model documentation, recommended value: 384000)
+   - **Capabilities**: Toggle each capability on/off:
+     - `chat` — Conversational chat
+     - `tool_use` — Function/tool calling
+     - `streaming` — Streaming responses
+     - `vision` — Image input support
+     - `reasoning` — Extended reasoning/thinking
+     - `embedding` — Embedding generation
+4. Click **"Add Model"**
+
+#### Setting a Default Model
+
+- Click the **star** icon next to a model to set it as the default
+- The default model is used for newly created tasks
+- Only one model can be the default at a time
+
+#### Editing a Model
+
+Click the **edit (pencil)** icon next to a model in the table to update its parameters.
+
+#### Deleting a Model
+
+Click the **trash** icon next to a model to remove it.
+
+
+## Frequently Asked Questions
+
+### "No model selected" Error
+
+1. Go to **Settings** → **Provider & Model Settings**
+2. Ensure at least one provider is configured
+3. Add at least one model configuration under the provider
+4. Click the **star** icon to set a default model
+---

--- a/docs/happex.zh-CN.md
+++ b/docs/happex.zh-CN.md
@@ -1,0 +1,128 @@
+[English](./happex.md) | [简体中文](./happex.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入Happex
+
+> **Happex 桌面 AI 工程平台** — 一个跨平台桌面应用，用于 AI 辅助软件工程，支持任务管理、工具执行和多供应商模型。
+
+
+
+## 下载与安装
+
+### 系统要求
+
+| 平台    | 最低版本            |
+| ------- | ------------------- |
+| macOS   | 10.15+ (Catalina)   |
+| Windows | Windows 10+         |
+
+### 下载
+
+1. 访问 [GitHub Releases 页面](https://github.com/huangsongyuan/happex/releases/latest)
+2. 下载适合您平台的安装包：
+   - **macOS (Apple Silicon)**：`happex_<version>_aarch64.dmg`
+   - **macOS (Intel)**：`happex_<version>_x86_64.dmg`
+   - **Windows**：`happex_<version>_x64-setup.exe`（NSIS 安装包）
+3. 打开/运行安装包并按提示完成安装
+
+
+## 更新
+
+### 自动更新（推荐）
+
+Happex 内置基于 Tauri Updater 的自动更新机制。
+
+1. 打开应用，进入 **关于**（齿轮图标 → "关于"）
+2. 点击 **"检查更新"**
+3. 如果发现新版本：
+   - 显示版本号和发布说明
+   - 点击 **"立即安装"**
+4. 下载过程中显示进度条
+5. 下载完成后，应用自动重启以应用更新
+
+### 手动更新
+
+从 [GitHub Releases](https://github.com/huangsongyuan/happex/releases/latest) 下载最新安装包，覆盖安装即可。
+
+
+## DeepSeek供应商配置
+
+前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
+前往 [DeepSeek 开放平台模型说明](https://api-docs.deepseek.com/zh-cn/quick_start/pricing/)) 获取URL及配置说明。
+
+### 页面配置（UI）
+
+#### 添加供应商
+
+1. 进入 **设置** → **提供商与模型设置**
+2. 点击供应商面板右上角的 **+** 按钮
+3. 填写表单：
+   - **Provider 类型**：选择 OpenAI Compatible 或 Anthropic
+   - **显示名称**：可读的标签（例如："我的 DeepSeek"）
+   - **Base URL**（openAI协议:https://api.deepseek.com/v1;
+   - Anthropic协议:https://api.deepseek.com/anthropic）
+   - **API 密钥**：您的 API 密钥（存储在系统钥匙串中）
+4. 点击 **"添加 Provider"**
+
+#### 编辑供应商
+
+- 点击列表中供应商旁边的 **编辑（铅笔）** 图标
+- 可以更新显示名称、Base URL 和 API 密钥
+- 编辑模式下的 API 密钥字段为可选——留空则保持现有密钥不变
+
+
+#### 删除供应商
+
+点击供应商旁边的 **垃圾桶** 图标。删除供应商会同时移除其下的所有模型配置。
+
+
+
+## 模型配置
+
+每个供应商账户可以拥有多个模型配置。模型按供应商管理，并可以设置为全局默认模型。
+
+### 页面配置（UI）
+
+#### 添加DeepSeek模型
+
+1. 从左侧列表中选择一个供应商
+2. 点击模型面板右上角的 **"添加模型"**
+3. 填写表单：
+   - **模型 ID**：发送给 API 的精确模型标识符（例如：`deepseek-v4-pro`、`deepseek-v4-flash`）
+   - **显示名称**：可读的标签（例如："deepseek-v4-pro"、"deepseek-v4-flash"）
+   - **上下文窗口**：最大上下文长度，以 token 计（可参照deepseek模型说明，配置值：1000000）
+   - **最大输出 token**：最大输出长度，以 token 计（可参照deepseek模型说明，配置值：384000）
+   - **能力**：逐一开关各能力：
+     - `chat` — 对话聊天
+     - `tool_use` — 函数/工具调用
+     - `streaming` — 流式响应
+     - `vision` — 图像输入支持
+     - `reasoning` — 扩展推理/思考
+     - `embedding` — 嵌入向量生成
+4. 点击 **"添加模型"**
+
+#### 设置默认模型
+
+- 点击模型旁边的 **星形** 图标将其设为默认
+- 默认模型用于新创建的任务
+- 同时只能有一个模型为默认
+
+#### 编辑模型
+
+点击模型中表格旁边的 **编辑（铅笔）** 图标来更新其参数。
+
+#### 删除模型
+
+点击模型旁边的 **垃圾桶** 图标移除该模型。
+
+
+## 常见问题
+
+### "未选择模型"报错
+
+1. 进入 **设置** → **提供商与模型设置**
+2. 确保至少配置了一个供应商
+3. 在供应商下至少添加一个模型配置
+4. 点击 **星形** 图标设置默认模型
+---
+
+

--- a/docs/happex.zh-CN.md
+++ b/docs/happex.zh-CN.md
@@ -4,8 +4,6 @@
 
 > **Happex 桌面 AI 工程平台** — 一个跨平台桌面应用，用于 AI 辅助软件工程，支持任务管理、工具执行和多供应商模型。
 
-
-
 ## 下载与安装
 
 ### 系统要求
@@ -23,7 +21,6 @@
    - **macOS (Intel)**：`happex_<version>_x86_64.dmg`
    - **Windows**：`happex_<version>_x64-setup.exe`（NSIS 安装包）
 3. 打开/运行安装包并按提示完成安装
-
 
 ## 更新
 
@@ -43,11 +40,10 @@ Happex 内置基于 Tauri Updater 的自动更新机制。
 
 从 [GitHub Releases](https://github.com/huangsongyuan/happex/releases/latest) 下载最新安装包，覆盖安装即可。
 
-
 ## DeepSeek供应商配置
 
 前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
-前往 [DeepSeek 开放平台模型说明](https://api-docs.deepseek.com/zh-cn/quick_start/pricing/)) 获取URL及配置说明。
+前往 [DeepSeek 开放平台模型说明](https://api-docs.deepseek.com/zh-cn/quick_start/pricing/)获取URL及配置说明。
 
 ### 页面配置（UI）
 
@@ -69,12 +65,9 @@ Happex 内置基于 Tauri Updater 的自动更新机制。
 - 可以更新显示名称、Base URL 和 API 密钥
 - 编辑模式下的 API 密钥字段为可选——留空则保持现有密钥不变
 
-
 #### 删除供应商
 
 点击供应商旁边的 **垃圾桶** 图标。删除供应商会同时移除其下的所有模型配置。
-
-
 
 ## 模型配置
 
@@ -114,7 +107,6 @@ Happex 内置基于 Tauri Updater 的自动更新机制。
 
 点击模型旁边的 **垃圾桶** 图标移除该模型。
 
-
 ## 常见问题
 
 ### "未选择模型"报错
@@ -123,6 +115,6 @@ Happex 内置基于 Tauri Updater 的自动更新机制。
 2. 确保至少配置了一个供应商
 3. 在供应商下至少添加一个模型配置
 4. 点击 **星形** 图标设置默认模型
----
 
+---
 


### PR DESCRIPTION
 - Add documentation for Happex configuration guide
 - Follows the same format as other agent configuration guides
