### PR TITLE
docs: add Kun integration guide (en/zh-CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
+| **Kun** | Open-source AI agent workspace with Code and Write modes; uses DeepSeek as the default reasoning model. | [Guide](./docs/kun.md) |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **LobeHub** | LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. | [Guide](./docs/lobehub.md) |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,6 +27,7 @@
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
+| **Kun** | 开源 AI Agent 工作空间，内置 Code 与 Write 模式，默认以 DeepSeek 作为推理主模型。 | [指南](./docs/kun.zh-CN.md) |
 | **Langcli** | 100% 兼容 Claude Code、支持 DeepSeek V4 等主流 LLM 模型的开源 AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **LobeHub** | LobeHub 是你的 Chief Agent Operator，通过招聘、排班并报告整个 AI 团队，将你的 Agent 组织成 7×24 小时运作。 | [指南](./docs/lobehub.zh-CN.md) |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具、记忆、MCP 等。 | [指南](./docs/nanobot.zh-CN.md) |

--- a/docs/kun.md
+++ b/docs/kun.md
@@ -1,0 +1,107 @@
+[English](./kun.md) | [简体中文](./kun.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Kun
+
+[Kun](https://github.com/KunAgent/Kun) is an open-source AI agent workspace that combines requirement clarification, design drafts, implementation plans, and agent coding into one GUI workflow. It ships with a local runtime (`kun serve`) that uses DeepSeek as the default text and reasoning model.
+
+- **GitHub:** <https://github.com/KunAgent/Kun>
+
+#### 1. Install Kun
+
+Download the latest release for your platform from the [GitHub Releases](https://github.com/KunAgent/Kun/releases) page, or build from source:
+
+```sh
+git clone https://github.com/KunAgent/Kun.git
+cd Kun
+npm install
+npm run dev
+```
+
+Requirements:
+
+- [Node.js](https://nodejs.org/en/download/) 20+
+- A DeepSeek API Key
+
+> **Note:** The first time you launch Kun, select **DeepSeek** as the model provider and paste your API key in the setup wizard.
+
+#### 2. Configure the Kun runtime for DeepSeek
+
+Kun's local runtime connects to the DeepSeek API directly. The simplest way to start it is with `kun serve`:
+
+```sh
+mkdir -p ~/.deepseekgui/kun
+kun serve \
+  --data-dir ~/.deepseekgui/kun \
+  --api-key "$DEEPSEEK_API_KEY" \
+  --base-url https://api.deepseek.com/beta \
+  --model deepseek-v4-pro
+```
+
+You can also set the API key via the environment variable:
+
+```sh
+export DEEPSEEK_API_KEY="sk-..."
+export KUN_MODEL="deepseek-v4-pro"
+kun serve --data-dir ~/.deepseekgui/kun
+```
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+**Key CLI flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--api-key` | DeepSeek-compatible API key | empty |
+| `--base-url` | DeepSeek-compatible API base URL | `https://api.deepseek.com/beta` |
+| `--model` | Default model id | `deepseek-v4-pro` |
+| `--data-dir` | Runtime data directory | required |
+| `--approval-policy` | Tool approval mode: `auto`, `on-request`, `never`, etc. | `auto` |
+| `--sandbox-mode` | Filesystem sandbox: `read-only`, `workspace-write`, `danger-full-access` | `workspace-write` |
+
+#### 3. Using DeepSeek V4 models
+
+Kun has built-in model profiles for DeepSeek V4. Both models are pre-configured with a **1 million token** context window and compaction thresholds around 980k input tokens:
+
+| Model | Use case |
+|-------|----------|
+| `deepseek-v4-pro` | Complex reasoning, planning, code review (default) |
+| `deepseek-v4-flash` | Faster, cheaper tasks and quick clarifications |
+
+To switch the default model, either:
+
+- Pass `--model deepseek-v4-flash` to `kun serve`, or
+- Set the `KUN_MODEL` environment variable, or
+- Edit `~/.deepseekgui/kun/config.json`:
+
+```json
+{
+  "serve": {
+    "model": "deepseek-v4-pro",
+    "baseUrl": "https://api.deepseek.com/beta",
+    "apiKey": "sk-..."
+  }
+}
+```
+
+#### 4. Run Kun from the terminal
+
+Besides the GUI, you can use Kun as a standalone agent CLI:
+
+```sh
+# One-shot task
+kun run --data-dir ~/.deepseekgui/kun --workspace "$PWD" "summarize this repo"
+
+# Interactive REPL
+kun chat --data-dir ~/.deepseekgui/kun --workspace "$PWD"
+
+# List available tools
+kun exec --data-dir ~/.deepseekgui/kun --workspace "$PWD" --list-tools
+```
+
+#### 5. Start coding in the GUI
+
+1. Launch Kun and bind a local project folder in **Code** mode.
+2. Start a thread and ask a question or give an instruction.
+3. Kun reads project context, executes tools, and shows inline diffs for file changes.
+
+> **Tip:** Kun forwards requests to the DeepSeek API, so reasoning/thinking content works out of the box with `deepseek-v4-pro`. No extra reasoning-effort flag is required at the Kun CLI level.

--- a/docs/kun.zh-CN.md
+++ b/docs/kun.zh-CN.md
@@ -1,0 +1,107 @@
+[English](./kun.md) | [简体中文](./kun.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Kun
+
+[Kun](https://github.com/KunAgent/Kun) 是一款开源 AI Agent 工作空间，它将需求澄清、设计稿、实施计划和 Agent 编码整合到同一条 GUI 工作流中。Kun 内置同名本地运行时（`kun serve`），并默认使用 DeepSeek 作为文本与推理主模型。
+
+- **GitHub：** <https://github.com/KunAgent/Kun>
+
+#### 1. 安装 Kun
+
+从 [GitHub Releases](https://github.com/KunAgent/Kun/releases) 下载对应平台的安装包，或从源码运行：
+
+```sh
+git clone https://github.com/KunAgent/Kun.git
+cd Kun
+npm install
+npm run dev
+```
+
+环境要求：
+
+- [Node.js](https://nodejs.org/en/download/) 20+
+- DeepSeek API Key
+
+> **注意：** 首次启动 Kun 时，在设置向导中选择 **DeepSeek** 作为模型供应商并填入 API Key。
+
+#### 2. 为 DeepSeek 配置 Kun 运行时
+
+Kun 的本地运行时会直接请求 DeepSeek API。最简单的启动方式是使用 `kun serve`：
+
+```sh
+mkdir -p ~/.deepseekgui/kun
+kun serve \
+  --data-dir ~/.deepseekgui/kun \
+  --api-key "$DEEPSEEK_API_KEY" \
+  --base-url https://api.deepseek.com/beta \
+  --model deepseek-v4-pro
+```
+
+也可以通过环境变量设置 API Key：
+
+```sh
+export DEEPSEEK_API_KEY="sk-..."
+export KUN_MODEL="deepseek-v4-pro"
+kun serve --data-dir ~/.deepseekgui/kun
+```
+
+从 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取你的 API Key。
+
+**常用 CLI 参数：**
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--api-key` | DeepSeek 兼容 API Key | 空 |
+| `--base-url` | DeepSeek 兼容 API 地址 | `https://api.deepseek.com/beta` |
+| `--model` | 默认模型 id | `deepseek-v4-pro` |
+| `--data-dir` | 运行时数据目录 | 必填 |
+| `--approval-policy` | 工具审批模式：`auto`、`on-request`、`never` 等 | `auto` |
+| `--sandbox-mode` | 文件沙箱：`read-only`、`workspace-write`、`danger-full-access` | `workspace-write` |
+
+#### 3. 使用 DeepSeek V4 模型
+
+Kun 内置了 DeepSeek V4 的模型画像。两个模型都默认配置 **100 万 token** 上下文窗口，并在输入 token 接近 98 万时触发上下文压缩：
+
+| 模型 | 适用场景 |
+|------|----------|
+| `deepseek-v4-pro` | 复杂推理、规划、代码审查（默认） |
+| `deepseek-v4-flash` | 速度更快、成本更低的任务与快速澄清 |
+
+切换默认模型的方式：
+
+- 给 `kun serve` 传入 `--model deepseek-v4-flash`，或
+- 设置环境变量 `KUN_MODEL`，或
+- 编辑 `~/.deepseekgui/kun/config.json`：
+
+```json
+{
+  "serve": {
+    "model": "deepseek-v4-pro",
+    "baseUrl": "https://api.deepseek.com/beta",
+    "apiKey": "sk-..."
+  }
+}
+```
+
+#### 4. 在终端中使用 Kun
+
+除了 GUI，Kun 也可以作为独立的 Agent CLI 使用：
+
+```sh
+# 单次任务
+kun run --data-dir ~/.deepseekgui/kun --workspace "$PWD" "summarize this repo"
+
+# 交互式 REPL
+kun chat --data-dir ~/.deepseekgui/kun --workspace "$PWD"
+
+# 列出可用工具
+kun exec --data-dir ~/.deepseekgui/kun --workspace "$PWD" --list-tools
+```
+
+#### 5. 在 GUI 中开始编码
+
+1. 启动 Kun，在 **Code** 模式中绑定本地项目文件夹。
+2. 新建会话并输入问题或指令。
+3. Kun 会读取项目上下文、执行工具，并在文件变更前展示内联 diff。
+
+> **提示：** Kun 直接将请求转发给 DeepSeek API，因此 `deepseek-v4-pro` 的深度思考/推理内容可以开箱即用，无需在 Kun CLI 层面额外设置 reasoning-effort 参数。


### PR DESCRIPTION
Add English and Simplified Chinese guides for integrating Kun with DeepSeek-V4-Pro / DeepSeek-V4-Flash via the kun serve runtime.

- Covers installation from GitHub Releases or source.
- Documents CLI flags and environment variables for DeepSeek API config.
- Notes the built-in 1M context window profiles.
- Adds Kun to the tools table in README.md and README.zh-CN.md in alphabetical order.

Closes #232

See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.

## Checklist

### Agent Configuration

- [ ] Model names are current (v4-pro / v4-flash, not v3 names)
- [ ] 1M context is configured or mentioned
- [ ] Max thinking effort level is supported
- [ ] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing)
- [ ] Config fields are verified to work in the agent
- [ ] No workarounds for already-fixed upstream bugs

### Documentation

- [ ] Both English and Chinese versions included in a single PR
- [ ] README table entry inserted in alphabetical order
- [ ] One tool per PR; unrelated tools not combined
- [ ] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes
