### PR TITLE
docs: add LingXi integration guide (English + Chinese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
+| **LingXi** | Multi-model AI coding agent with built-in skills, MCP support, and rich tool ecosystem — runs in the terminal. | [Guide](./docs/lingxi.md) |
 | **LobeHub** | LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. | [Guide](./docs/lobehub.md) |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,6 +28,7 @@
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **Langcli** | 100% 兼容 Claude Code、支持 DeepSeek V4 等主流 LLM 模型的开源 AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
+| **LingXi** | 多模型 AI 编程 Agent，内置 Skills、MCP 支持与丰富工具生态，运行在终端内。 | [指南](./docs/lingxi.zh-CN.md) |
 | **LobeHub** | LobeHub 是你的 Chief Agent Operator，通过招聘、排班并报告整个 AI 团队，将你的 Agent 组织成 7×24 小时运作。 | [指南](./docs/lobehub.zh-CN.md) |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具、记忆、MCP 等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |

--- a/docs/lingxi.md
+++ b/docs/lingxi.md
@@ -1,0 +1,113 @@
+[English](./lingxi.md) | [简体中文](./lingxi.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with LingXi
+
+LingXi (灵犀) is a multi-model AI coding agent that runs in the terminal, powered by a pluggable LLM layer. It comes with built-in skills, MCP support, HTTP server mode, and a rich tool ecosystem (shell, file operations, and browser).
+
+- **Homepage:** <https://lingxi.regaing.com>
+- **npm:** <https://www.npmjs.com/package/@lingxi-agent/core>
+
+#### 1. Install LingXi
+
+- Install [Node.js](https://nodejs.org/en/download/) 20+.
+- Run the following command in your terminal:
+
+```sh
+npm install -g @lingxi-agent/core
+```
+
+- Verify the installation:
+
+```sh
+lingxi --version
+```
+
+#### 2. Configure DeepSeek
+
+LingXi defaults to DeepSeek as the provider with `deepseek-v4-flash` (fast) and `deepseek-v4-pro` (think). Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+**Option 1: Environment variable (simplest)**
+
+Linux / Mac:
+
+```bash
+export DEEPSEEK_API_KEY="<your DeepSeek API Key>"
+```
+
+Windows:
+
+```powershell
+$env:DEEPSEEK_API_KEY="<your DeepSeek API Key>"
+```
+
+**Option 2: Configuration file**
+
+Create `~/.LingXi/config.json` for user-level config, or `.agent/config.json` in your project for project-level settings:
+
+```json
+{
+  "agentProviders": [
+    {
+      "id": "deepseek",
+      "name": "DeepSeek",
+      "provider": "deepseek",
+      "fastModel": "deepseek-v4-flash",
+      "thinkModel": "deepseek-v4-pro",
+      "visionModel": "",
+      "apiKey": "<your DeepSeek API Key>",
+      "baseURL": "https://api.deepseek.com"
+    }
+  ]
+}
+```
+
+> **Note:** You can also use `"apiKey": "$DEEPSEEK_API_KEY"` to reference an environment variable instead of hardcoding the key.
+
+**Configuration overview:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `permissionMode` | `normal` | Tool execution policy (`normal`, `auto`, `strict`) |
+| `maxTokens` | `1048576` | Context window (1M tokens, matching DeepSeek V4) |
+| `maxToolCallRounds` | `100` | Maximum tool-calling iterations per task |
+| `reasoningEffort` | `medium` | Reasoning level (`low`, `medium`, `high`) |
+| `toolTimeout` | `300000` | Per-tool execution timeout in ms |
+
+LingXi supports DeepSeek's full 1M-token context window out of the box. Set `reasoningEffort` to `high` in your config for maximum reasoning depth with DeepSeek-V4-Pro.
+
+#### 3. Run LingXi
+
+**Interactive REPL mode:**
+
+```sh
+cd /path/to/my-project
+lingxi
+```
+
+**Task mode (non-interactive):**
+
+```sh
+lingxi --task "Write a Python script to analyze CSV files" --auto
+```
+
+**HTTP Server mode (for programmatic access):**
+
+```sh
+lingxi serve --port 7907
+```
+
+The server exposes:
+- `POST /rpc` — Send tasks and receive responses
+- `GET /events?sessionId=` — Server-sent events stream
+- `GET /healthz` — Health check
+
+#### Key Features
+
+| Feature | Description |
+|---------|-------------|
+| **13 Built-in Skills** | Auto-discovered from `~/.LingXi/skills/` and project `.agent/skills/` |
+| **MCP Support** | Connect external tools via Model Context Protocol |
+| **Multi-Provider** | DeepSeek, OpenAI, Anthropic, Qwen, Groq, Mistral, Gemini |
+| **Tool Ecosystem** | Shell commands, file read/write, browser automation, SSH remote execution |
+| **Task Tracking** | Built-in structured task management with desktop notification sync |
+| **Compaction** | Automatic context compaction to stay within token limits |

--- a/docs/lingxi.zh-CN.md
+++ b/docs/lingxi.zh-CN.md
@@ -1,0 +1,113 @@
+[English](./lingxi.md) | [简体中文](./lingxi.zh-CN.md) · [← Back](../README.md)
+
+# 接入 LingXi（灵犀）
+
+LingXi（灵犀）是一款运行在终端内的多模型 AI 编程 Agent，由可插拔 LLM 层驱动。内置 Skills、MCP 支持、HTTP 服务模式，以及丰富的工具生态（Shell 命令、文件操作、浏览器自动化等）。
+
+- **官网:** <https://lingxi.regaing.com>
+- **npm:** <https://www.npmjs.com/package/@lingxi-agent/core>
+
+#### 1. 安装 LingXi
+
+- 安装 [Node.js](https://nodejs.org/en/download/) 20+。
+- 在终端中运行以下命令：
+
+```sh
+npm install -g @lingxi-agent/core
+```
+
+- 验证安装：
+
+```sh
+lingxi --version
+```
+
+#### 2. 配置 DeepSeek
+
+LingXi 默认使用 DeepSeek 作为提供商，fast 模型为 `deepseek-v4-flash`、think 模型为 `deepseek-v4-pro`。从 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
+
+**方式一：环境变量（推荐）**
+
+Linux / Mac：
+
+```bash
+export DEEPSEEK_API_KEY="<你的 DeepSeek API Key>"
+```
+
+Windows：
+
+```powershell
+$env:DEEPSEEK_API_KEY="<你的 DeepSeek API Key>"
+```
+
+**方式二：配置文件**
+
+创建 `~/.LingXi/config.json`（用户级）或项目中的 `.agent/config.json`（项目级）：
+
+```json
+{
+  "agentProviders": [
+    {
+      "id": "deepseek",
+      "name": "DeepSeek",
+      "provider": "deepseek",
+      "fastModel": "deepseek-v4-flash",
+      "thinkModel": "deepseek-v4-pro",
+      "visionModel": "",
+      "apiKey": "<你的 DeepSeek API Key>",
+      "baseURL": "https://api.deepseek.com"
+    }
+  ]
+}
+```
+
+> **提示：** 也可使用 `"apiKey": "$DEEPSEEK_API_KEY"` 引用环境变量，避免在配置文件中明文存储密钥。
+
+**配置项概览：**
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `permissionMode` | `normal` | 工具执行策略（`normal`、`auto`、`strict`） |
+| `maxTokens` | `1048576` | 上下文窗口（1M tokens，完整支持 DeepSeek V4） |
+| `maxToolCallRounds` | `100` | 单次任务最大工具调用轮数 |
+| `reasoningEffort` | `medium` | 推理强度（`low`、`medium`、`high`） |
+| `toolTimeout` | `300000` | 单次工具执行超时（毫秒） |
+
+LingXi 原生支持 DeepSeek V4 的 100 万 token 上下文窗口。将 `reasoningEffort` 设为 `high` 可获得 DeepSeek-V4-Pro 的最大推理深度。
+
+#### 3. 运行 LingXi
+
+**交互式 REPL 模式：**
+
+```sh
+cd /path/to/my-project
+lingxi
+```
+
+**任务模式（非交互）：**
+
+```sh
+lingxi --task "写一个 Python 脚本来分析 CSV 文件" --auto
+```
+
+**HTTP 服务模式（供程序调用）：**
+
+```sh
+lingxi serve --port 7907
+```
+
+服务端提供以下端点：
+- `POST /rpc` — 发送任务并接收响应
+- `GET /events?sessionId=` — Server-Sent Events 流
+- `GET /healthz` — 健康检查
+
+#### 核心特性
+
+| 特性 | 说明 |
+|------|------|
+| **13 个内置 Skills** | 自动发现 `~/.LingXi/skills/` 和项目 `.agent/skills/` 中的技能 |
+| **MCP 支持** | 通过 Model Context Protocol 接入外部工具 |
+| **多提供商** | DeepSeek、OpenAI、Anthropic、Qwen、Groq、Mistral、Gemini |
+| **工具生态** | Shell 命令、文件读写、浏览器自动化、SSH 远程执行 |
+| **任务追踪** | 内置结构化任务管理，支持桌面通知同步 |
+| **上下文压缩** | 自动压缩上下文以保持在 token 限制内 |


### PR DESCRIPTION
## Summary

Add LingXi (灵犀) integration guide to awesome-deepseek-agent.

LingXi is a multi-model AI coding agent that runs in the terminal, powered by a pluggable LLM layer. It comes with built-in skills, MCP support, HTTP server mode, and a rich tool ecosystem.

- **Homepage:** https://lingxi.regaing.com
- **npm:** https://www.npmjs.com/package/@lingxi-agent/core

## Changes

- Add English guide: `docs/lingxi.md`
- Add Chinese guide: `docs/lingxi.zh-CN.md`
- Update README.md table (alphabetical order, between Langcli and LobeHub)
- Update README.zh-CN.md table (alphabetical order, between Langcli and LobeHub)

## Checklist

- [x] Both English and Chinese versions included in a single PR
- [x] Model names use current v4-pro / v4-flash naming
- [x] 1M context window documented (maxTokens: 1048576)
- [x] Reasoning effort level documented
- [x] README table entry inserted in alphabetical order
- [x] No workarounds for upstream bugs