### PR TITLE
docs: add Rikkahub integration guide (EN + zh-CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Qwen Code** | Coding agent CLI by the Alibaba Qwen team — now with built-in DeepSeek provider support. | [Guide](./docs/qwen_code.md) |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
+| **Rikkahub** | Native Android LLM chat client supporting OpenAI / Anthropic / Google-compatible APIs, with MCP, multimodal input, search tools, and a proot-based Linux agent workspace. | [Guide](./docs/rikkahub.md) |
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
 
 ## Resources

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,6 +36,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Qwen Code** | 阿里巴巴通义千问团队推出的 Coding Agent CLI，现已全面支持 DeepSeek 提供商。 | [指南](./docs/qwen_code.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
+| **Rikkahub** | 原生 Android LLM 聊天客户端，支持 OpenAI / Anthropic / Google 兼容 API，内置 MCP、多模态输入、搜索工具与基于 proot 的 Linux Agent 工作环境。 | [指南](./docs/rikkahub.zh-CN.md) |
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
 
 ## 相关资源

--- a/docs/rikkahub.md
+++ b/docs/rikkahub.md
@@ -1,0 +1,74 @@
+[English](./rikkahub.md) | [简体中文](./rikkahub.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with RikkaHub
+
+RikkaHub is a native Android LLM chat client (Kotlin + Jetpack Compose + Material 3) that unifies OpenAI, Google Gemini, Anthropic Claude, and any OpenAI-compatible endpoint behind a single interface — with MCP, multimodal input, web search, prompt variables, message branching, and a proot-based Linux agent workspace.
+
+- **Website:** <https://rikka-ai.com>
+- **Docs:** <https://docs.rikka-ai.com>
+- **GitHub:** <https://github.com/rikkahub/rikkahub>
+
+#### 1. Install RikkaHub
+
+Pick one of the official channels:
+
+- **Website (recommended):** <https://rikka-ai.com/download> — always the latest APK.
+- **Google Play:** search "RikkaHub" or open <https://play.google.com/store/apps/details?id=me.rerere.rikkahub>
+
+RikkaHub runs on Android (minSdk 26 / Android 8.0+). After install, open the app from your home screen or app drawer.
+
+#### 2. Add the DeepSeek Provider
+
+DeepSeek ships as a **pre-configured provider** in RikkaHub — you do not need to enter the base URL by hand.
+
+1. Tap the **Settings** icon (gear) at the bottom of the sidebar to open the settings screen.
+2. Select **Providers** from the settings list. You'll see all configured providers as cards.
+3. Find the **DeepSeek** card (pre-configured with `Base URL = https://api.deepseek.com/v1`) and tap it. If it's missing, tap **Add Provider** in the top-right corner, choose **OpenAI** as the type, and fill in `https://api.deepseek.com/v1` as the Base URL.
+4. On the provider detail screen, paste your [DeepSeek API Key](https://platform.deepseek.com/api_keys) into the **API Key** field. Leave **Base URL** as `https://api.deepseek.com/v1` — the `/v1` suffix is required because RikkaHub appends the chat-completions path (`/chat/completions`) to it.
+5. Tap **Save** / **Confirm** to store the configuration, then use the toggle on the provider card to enable it.
+
+> **Balance checking.** The built-in DeepSeek provider has **Balance Checking** enabled by default — the provider card shows your remaining credit by querying `/user/balance` and extracting `balance_infos[0].total_balance`. If you add DeepSeek manually, enable **Balance Checking** in the provider settings and supply the same API path and JSON field path.
+
+> **1M context window.** RikkaHub does not expose an explicit `context_window` field; the app forwards the full message history to the API on every turn (subject to the assistant's `contextMessageSize` setting, which defaults to 0 = all messages). DeepSeek V4 supports up to **1,000,000 tokens** of context on the API side, and RikkaHub will use whatever you send it — there is no client-side truncation to worry about.
+
+#### 3. Add the DeepSeek V4 Models
+
+1. On the same DeepSeek provider detail screen, scroll to the **Models** section at the bottom and tap it.
+2. Tap the expand button to fetch the model list automatically from the DeepSeek API, then tick **`deepseek-v4-pro`** and **`deepseek-v4-flash`**.
+3. (If the auto-fetch doesn't list V4 models — e.g. you're using a relay that hasn't caught up — tap **Add** to enter the model ID manually: `deepseek-v4-pro` / `deepseek-v4-flash`.)
+
+RikkaHub's model registry already recognises both IDs and automatically tags them with **Tool** and **Reasoning** capabilities — no need to toggle these manually.
+
+#### 4. Start Chatting
+
+1. Head back to the main screen. Tap the **model selector** shown below the conversation title in the top bar (or inside the input bar on some screen sizes) and pick **`deepseek-v4-pro`** (or **`deepseek-v4-flash`** for cheaper / faster turns).
+2. Type your first message in the input bar at the bottom and tap the **send** button (arrow-up). Rikka streams the reply back in real time.
+3. DeepSeek V4 returns thinking content by default; Rikka renders the reasoning trace as a collapsible block above the final answer.
+
+##### Reasoning effort
+
+RikkaHub exposes reasoning effort through the assistant's **Reasoning level** setting (`Settings → Assistants → <your assistant> → Reasoning level`), which defaults to `AUTO`. The levels are:
+
+| Level | Token budget | Effort string sent to DeepSeek API |
+|---|---|---|
+| OFF | 0 | *(thinking disabled)* |
+| AUTO | -1 | *(provider default — no `reasoning_effort` field sent)* |
+| LOW | 1,000 | `low` |
+| MEDIUM | 2,000 | `medium` |
+| HIGH | 8,000 | `high` |
+| XHIGH | 16,000 | `xhigh` |
+
+For DeepSeek specifically (provider whose Base URL host is `api.deepseek.com`), RikkaHub's request builder emits both `thinking: {type: "enabled"}` and `reasoning_effort: <effort>` in the request body. To get the strongest reasoning the UI exposes, set the level to **XHIGH**.
+
+> **About `reasoning_effort: "max"`.** RikkaHub's enum tops out at `XHIGH`, so the UI on its own sends `reasoning_effort: "xhigh"` to the DeepSeek API — not `"max"`. If you need the `max` level, use the assistant's **Custom request body** override: open the assistant → **HTTP overrides → Custom Bodies** → add a key `reasoning_effort` with value `"max"`. RikkaHub merges custom body entries **last**, so this override wins over the level the assistant selected. This is the documented mechanism for pinning request fields RikkaHub does not surface in the UI — not a workaround for an upstream bug.
+
+#### 5. Going Further
+
+Once DeepSeek V4 is configured, you can use it across the rest of RikkaHub:
+
+- **Workspace.** Go to **Settings → Extension Management → Workspace**, tap **+** to create a workspace, enter a name (English only), then tap the new card → **Install Rootfs**. Open a chat, tap the **+** button in the chat bar, and bind the workspace to the current assistant. The assistant (powered by `deepseek-v4-pro`) can then run shell commands, edit files, install packages via `apt`, and even clone Git repos — all inside the sandboxed Linux environment.
+- **MCP servers.** Go to **Settings → MCP**, tap the **+** button in the top-right, and add a server (SSE or Streamable HTTP transport). After it connects, open the assistant's settings → **MCP Servers** → toggle on the servers whose tools this assistant should access. Tool calls go through an approval flow — set **Needs Approval** on any tool that performs irreversible actions.
+- **Web search.** Go to **Settings → Search**, tap **Add**, and pick a service — RikkaHub supports Bing, Brave, Tavily, Exa, Perplexity, LinkUp, Firecrawl, Jina, Grok, Bocha, Metaso, Zhipu, SearXNG, Ollama, RikkaHub's own API, and Custom JS. With a search service configured, toggle the search icon in the chat input toolbar before sending a message; Rikka injects fresh web results into the model's context automatically.
+- **Multimodal input.** Tap the **+** button on the left of the chat input bar to attach images, PDF, DOCX, PPTX, or EPUB files. Vision-capable models receive images as base64; non-vision models trigger automatic OCR via the OCR model you set in **Settings → Models → OCR Model**.
+- **Prompt variables & message branching.** Use `{model}`, `{time}`, etc. in your assistant's system prompt. Long-press any assistant message → **Regenerate** to create a branch and explore alternative completions without losing the original thread.
+- **QR-code provider export.** Open the DeepSeek provider → tap the **Share** button → export the configuration (API key + base URL + settings, excluding added models) as a QR code. Scan it on another device to replicate the provider in seconds.

--- a/docs/rikkahub.zh-CN.md
+++ b/docs/rikkahub.zh-CN.md
@@ -1,0 +1,74 @@
+[English](./rikkahub.md) | [简体中文](./rikkahub.zh-CN.md) · [← Back](../README.zh-CN.md)
+
+# 接入 RikkaHub
+
+RikkaHub 是一款原生 Android LLM 聊天客户端（Kotlin + Jetpack Compose + Material 3），将 OpenAI、Google Gemini、Anthropic Claude 以及任何 OpenAI 兼容端点整合在同一界面中，内置 MCP、多模态输入、网络搜索、Prompt 变量、消息分支，以及基于 proot 的 Linux Agent 工作环境（Workspace）。
+
+- **官网：** <https://rikka-ai.com>
+- **官方文档：** <https://docs.rikka-ai.com>
+- **GitHub：** <https://github.com/rikkahub/rikkahub>
+
+#### 1. 安装 RikkaHub
+
+任选一个官方渠道下载：
+
+- **官网（推荐）：** <https://rikka-ai.com/download> —— 始终是最新 APK。
+- **Google Play：** 搜索 "RikkaHub"，或直接打开 <https://play.google.com/store/apps/details?id=me.rerere.rikkahub>
+
+RikkaHub 仅支持 Android 平台（minSdk 26 / Android 8.0+）。安装完成后从桌面或抽屉打开 App。
+
+#### 2. 配置 DeepSeek Provider
+
+DeepSeek 在 RikkaHub 中是**预配置 Provider**，无需手动填写 Base URL。
+
+1. 点击侧边栏底部的 **设置** 图标（齿轮），打开设置页。
+2. 在设置列表中选择 **Providers（服务商）**，进入 Provider 列表页。
+3. 找到 **DeepSeek** 卡片（已预配 `Base URL = https://api.deepseek.com/v1`），点击进入。如果列表里没有，点击右上角 **Add Provider（添加 Provider）**，类型选 **OpenAI**，Base URL 填 `https://api.deepseek.com/v1`。
+4. 在 Provider 详情页，把 [DeepSeek API Key](https://platform.deepseek.com/api_keys) 粘贴到 **API Key** 字段。**Base URL** 保持 `https://api.deepseek.com/v1` 不变 —— `/v1` 后缀是必须的，因为 RikkaHub 会在其后追加 chat completions 路径（`/chat/completions`）。
+5. 点击 **保存** / **确认** 存储配置，然后用 Provider 卡片上的开关启用它。
+
+> **余额检查。** 内置 DeepSeek Provider 默认已开启 **Balance Checking（余额检查）** —— 通过查询 `/user/balance` 并提取 `balance_infos[0].total_balance` 在卡片上显示剩余额度。如果你是手动添加的 DeepSeek，请在 Provider 设置里手动开启 **Balance Checking**，并填入相同的 API path 与 JSON field path。
+
+> **100 万 token 上下文。** RikkaHub 不暴露 `context_window` 字段；App 每次请求都会把完整消息历史透传给 API（受 Assistant 的 `contextMessageSize` 设置约束，默认 0 = 全部消息）。DeepSeek V4 在 API 侧支持最高 **1,000,000 token** 上下文，RikkaHub 不做任何客户端侧截断，发多少用多少。
+
+#### 3. 添加 DeepSeek V4 模型
+
+1. 在同一 DeepSeek Provider 详情页，滚动到底部的 **Models（模型）** 区域并点击。
+2. 点击展开按钮，RikkaHub 会自动从 DeepSeek API 拉取模型列表，勾选 **`deepseek-v4-pro`** 与 **`deepseek-v4-flash`**。
+3. （如果自动拉取没列出 V4 模型 —— 比如你用的是尚未跟进的第三方中转 —— 点击 **Add（添加）** 手动输入模型 ID：`deepseek-v4-pro` / `deepseek-v4-flash`。）
+
+RikkaHub 的模型注册表已识别这两个 ID，并自动给它们打上 **Tool** 与 **Reasoning** 能力标签 —— 无需手动勾选。
+
+#### 4. 开始对话
+
+1. 返回主界面。点击顶部对话标题下方的 **模型选择器**（部分屏幕尺寸下位于输入栏内），选择 **`deepseek-v4-pro`**（追求性价比或速度时用 `deepseek-v4-flash`）。
+2. 在底部输入栏输入第一条消息，点击 **发送** 按钮（向上箭头）。RikkaHub 会实时流式返回回答。
+3. DeepSeek V4 默认会返回思维链内容，RikkaHub 会把推理过程作为可折叠块显示在最终回答上方。
+
+##### 思考强度
+
+RikkaHub 通过 Assistant 的 **Reasoning level（思考级别）** 设置（`设置 → Assistants → <你的 Assistant> → Reasoning level`，默认 `AUTO`）控制思考强度，各档位如下：
+
+| 级别 | Token 预算 | 发给 DeepSeek API 的 effort 字符串 |
+|---|---|---|
+| OFF | 0 | *（关闭思考）* |
+| AUTO | -1 | *（由 Provider 决定，不发送 `reasoning_effort` 字段）* |
+| LOW | 1,000 | `low` |
+| MEDIUM | 2,000 | `medium` |
+| HIGH | 8,000 | `high` |
+| XHIGH | 16,000 | `xhigh` |
+
+针对 DeepSeek（Base URL host 为 `api.deepseek.com` 的 Provider），RikkaHub 的请求构建器会同时发送 `thinking: {type: "enabled"}` 与 `reasoning_effort: <effort>`。要在 UI 暴露的范围内获得最强推理，把级别设为 **XHIGH**。
+
+> **关于 `reasoning_effort: "max"`。** RikkaHub 的枚举最高只到 `XHIGH`，所以 UI 自身向 DeepSeek API 发送的是 `reasoning_effort: "xhigh"`，而非 `"max"`。如果你确实需要 `max` 档，使用 Assistant 的**自定义请求体**覆盖：打开 Assistant → **HTTP overrides → Custom Bodies** → 添加键 `reasoning_effort`，值 `"max"`。RikkaHub 的 custom body 是**最后合并**的，会覆盖 Assistant 选定的级别。这是 RikkaHub 官方提供的"固定 UI 未暴露字段"机制，并非针对上游 bug 的 workaround。
+
+#### 5. 进阶用法
+
+完成 DeepSeek V4 配置后，可以在 RikkaHub 的其他场景中复用：
+
+- **Workspace**：进入 **设置 → 扩展管理 → Workspace**，点击右下角 **+** 创建工作区（名称必须为英文），点击新卡片 → **Install Rootfs** 安装系统文件。打开聊天页，点击聊天栏的 **+** 按钮，将 Workspace 绑定到当前 Assistant。由 `deepseek-v4-pro` 驱动的 Assistant 即可在沙箱 Linux 环境里执行 shell 命令、编辑文件、通过 `apt` 安装软件包，甚至克隆 Git 仓库。
+- **MCP 服务**：进入 **设置 → MCP**，点击右上角 **+** 添加服务（支持 SSE 与 Streamable HTTP 两种 transport）。连接成功后，打开 Assistant 设置 → **MCP Servers** → 勾选该 Assistant 可调用的服务。工具调用经过审批流 —— 对任何不可逆操作的工具，请打开 **Needs Approval（需要批准）** 选项。
+- **网络搜索**：进入 **设置 → Search（搜索）**，点击 **Add（添加）** 选择搜索服务 —— RikkaHub 支持 Bing、Brave、Tavily、Exa、Perplexity、LinkUp、Firecrawl、Jina、Grok、Bocha（博查）、Metaso（秘塔）、Zhipu（智谱）、SearXNG、Ollama、RikkaHub 自有 API 以及 Custom JS。配置完成后，发送消息前在聊天输入栏工具栏点亮搜索图标，RikkaHub 会自动把最新网页结果注入模型上下文。
+- **多模态输入**：点击聊天输入栏左侧的 **+** 按钮附加图片、PDF、DOCX、PPTX、EPUB 文件。支持视觉输入的模型会以 base64 形式收到图片；非视觉模型会自动触发 OCR（通过 **设置 → Models → OCR Model** 配置的 OCR 模型完成）。
+- **提示词变量与消息分支**：Assistant 的系统提示里可使用 `{model}`、`{time}` 等变量。长按任一助手回复 → **Regenerate（重新生成）** 即可创建分支，探索不同续写而不破坏原会话。
+- **二维码 Provider 导出**：打开 DeepSeek Provider → 点击 **Share（分享）** 按钮 → 将配置（API key + base URL + 设置，不含已添加的模型）导出为二维码。在另一台设备扫码即可一键复制整套 Provider 配置。


### PR DESCRIPTION
See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.

## Checklist

### Agent Configuration

- [ ] Model names are current (v4-pro / v4-flash, not v3 names)
- [ ] 1M context is configured or mentioned
- [ ] Max thinking effort level is supported
- [ ] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing)
- [ ] Config fields are verified to work in the agent
- [ ] No workarounds for already-fixed upstream bugs

### Documentation

- [ ] Both English and Chinese versions included in a single PR
- [ ] README table entry inserted in alphabetical order
- [ ] One tool per PR; unrelated tools not combined
- [ ] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes
