### PR TITLE
docs: add deepclaude integration guide (EN + zh-CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Codex** | OpenAI's coding agent. | [Guide](./docs/codex.md) |
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
+| **deepclaude** | Thin launcher that runs Claude Code's autonomous agent loop against DeepSeek V4 Pro (or any Anthropic-compatible backend) — same UX, a fraction of the cost. | [Guide](./docs/deepclaude.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@
 | **Codex** | OpenAI 的编程 Agent。 | [指南](./docs/codex.zh-CN.md) |
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
+| **deepclaude** | 轻量启动器，让 Claude Code 的自主 agent 循环跑在 DeepSeek V4 Pro（或任意 Anthropic 兼容后端）上——同样体验，成本只是零头。 | [指南](./docs/deepclaude.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |

--- a/docs/deepclaude.md
+++ b/docs/deepclaude.md
@@ -1,0 +1,70 @@
+[English](./deepclaude.md) | [简体中文](./deepclaude.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with deepclaude
+
+deepclaude is a thin launcher that runs [Claude Code](https://github.com/anthropics/claude-code)'s autonomous agent loop against **DeepSeek V4 Pro** (or any Anthropic-compatible backend) instead of Anthropic — same UX, a fraction of the cost. It is a single shell/PowerShell script plus a local proxy, with no separate runtime to maintain.
+
+- **GitHub:** <https://github.com/aattaran/deepclaude>
+
+#### 1. Get a DeepSeek API Key
+
+Sign up at the [DeepSeek Platform](https://platform.deepseek.com/api_keys), add credit, and copy your API key.
+
+#### 2. Set the environment variable
+
+**macOS / Linux:**
+
+```bash
+echo 'export DEEPSEEK_API_KEY="sk-your-key-here"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+**Windows (PowerShell):**
+
+```powershell
+setx DEEPSEEK_API_KEY "sk-your-key-here"
+```
+
+#### 3. Install deepclaude
+
+Clone the repo and put the launcher on your `PATH`:
+
+```sh
+git clone https://github.com/aattaran/deepclaude.git
+cd deepclaude
+```
+
+**macOS / Linux:**
+
+```bash
+chmod +x deepclaude.sh
+sudo ln -s "$(pwd)/deepclaude.sh" /usr/local/bin/deepclaude
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# Copy the script to a directory already in your PATH, or add the repo dir to PATH
+Copy-Item deepclaude.ps1 "$env:USERPROFILE\.local\bin\deepclaude.ps1"
+```
+
+#### 4. First run
+
+From any project directory:
+
+```sh
+deepclaude
+```
+
+This launches Claude Code routed through DeepSeek V4 Pro. Other useful flags:
+
+```sh
+deepclaude --status        # Show available backends and keys
+deepclaude --backend or    # Use OpenRouter (cheapest)
+deepclaude --backend fw    # Use Fireworks AI (fastest)
+deepclaude --backend anthropic  # Normal Claude Code (when you need Opus)
+deepclaude --cost          # Show pricing comparison
+deepclaude --benchmark     # Latency test across providers
+```
+
+deepclaude also exposes an OpenAI-compatible proxy (`/v1/chat/completions`) so other tools can reach DeepSeek V4 Pro through the same key — see the repo README for the proxy details.

--- a/docs/deepclaude.zh-CN.md
+++ b/docs/deepclaude.zh-CN.md
@@ -1,0 +1,70 @@
+[English](./deepclaude.md) | [简体中文](./deepclaude.zh-CN.md) · [← Back](../README.md)
+
+# 接入 deepclaude
+
+deepclaude 是一个轻量启动器，让 [Claude Code](https://github.com/anthropics/claude-code) 的自主 agent 循环跑在 **DeepSeek V4 Pro**（或任意 Anthropic 兼容后端）上，而非 Anthropic——同样的体验，成本只是零头。它只是一个 shell/PowerShell 脚本加一个本地代理，无需单独维护运行时。
+
+- **GitHub:** <https://github.com/aattaran/deepclaude>
+
+#### 1. 获取 DeepSeek API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 注册、充值，复制你的 API Key。
+
+#### 2. 设置环境变量
+
+**macOS / Linux:**
+
+```bash
+echo 'export DEEPSEEK_API_KEY="sk-your-key-here"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+**Windows (PowerShell):**
+
+```powershell
+setx DEEPSEEK_API_KEY "sk-your-key-here"
+```
+
+#### 3. 安装 deepclaude
+
+克隆仓库并把启动器放到 `PATH`：
+
+```sh
+git clone https://github.com/aattaran/deepclaude.git
+cd deepclaude
+```
+
+**macOS / Linux:**
+
+```bash
+chmod +x deepclaude.sh
+sudo ln -s "$(pwd)/deepclaude.sh" /usr/local/bin/deepclaude
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# 把脚本复制到已在 PATH 中的目录，或把仓库目录加入 PATH
+Copy-Item deepclaude.ps1 "$env:USERPROFILE\.local\bin\deepclaude.ps1"
+```
+
+#### 4. 首次运行
+
+在任意项目目录下：
+
+```sh
+deepclaude
+```
+
+这会启动经 DeepSeek V4 Pro 路由的 Claude Code。其他常用参数：
+
+```sh
+deepclaude --status        # 查看可用后端与密钥
+deepclaude --backend or    # 使用 OpenRouter（最便宜）
+deepclaude --backend fw    # 使用 Fireworks AI（最快）
+deepclaude --backend anthropic  # 正常 Claude Code（需要 Opus 时）
+deepclaude --cost          # 显示价格对比
+deepclaude --benchmark     # 跨供应商延迟测试
+```
+
+deepclaude 还提供一个 OpenAI 兼容代理（`/v1/chat/completions`），让其他工具也能通过同一个 Key 访问 DeepSeek V4 Pro——详见仓库 README。


### PR DESCRIPTION
Adds a bilingual integration guide for **deepclaude** (github.com/aattaran/deepclaude, ~2.2k stars).

## What is deepclaude

A thin launcher that runs [Claude Code](https://github.com/anthropics/claude-code)'s autonomous agent loop against **DeepSeek V4 Pro** (or any Anthropic-compatible backend) instead of Anthropic — same UX, a fraction of the cost. Single shell/PowerShell script + local proxy, no separate runtime.

## Why it belongs here

Explicitly DeepSeek-first: the default backend is DeepSeek V4 Pro, configured via a single `DEEPSEEK_API_KEY`. It is not yet listed in the table and no open PR adds it (checked before opening).

## What the guide covers

Installation → configuration → first run, following the existing guide format:
1. Get a DeepSeek API key
2. Set `DEEPSEEK_API_KEY` (macOS/Linux and Windows)
3. Install the launcher (symlink on \*nix, copy-to-PATH on Windows)
4. `deepclaude` first run + the `--backend/--cost/--benchmark` flags

## CONTRIBUTING checks

- [x] Bilingual: `docs/deepclaude.md` + `docs/deepclaude.zh-CN.md` in one PR
- [x] README + README.zh-CN table entries inserted in **alphabetical order** (between **Deep Code** and **DeepSeek-TUI**)
- [x] Follows the format of existing guides (installation → configuration → first run)
- [x] No duplicate of an existing guide or open PR