### PR TITLE
docs: add gptme integration guide (EN + zh-CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
+| **gptme** | Provider-agnostic, local-first terminal AI agent (alternative to Claude Code) — works with DeepSeek, Anthropic, OpenAI, or local models. | [Guide](./docs/gptme.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,7 @@
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
+| **gptme** | Provider 无关、本地优先的终端 AI agent（可替代 Claude Code）——支持 DeepSeek、Anthropic、OpenAI 或本地模型。 | [指南](./docs/gptme.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **Langcli** | 100% 兼容 Claude Code、支持 DeepSeek V4 等主流 LLM 模型的开源 AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |

--- a/docs/gptme.md
+++ b/docs/gptme.md
@@ -1,0 +1,59 @@
+[English](./gptme.md) | [简体中文](./gptme.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with gptme
+
+gptme is a provider-agnostic, local-first terminal AI agent — a capable alternative to Claude Code. It ships shell, Python, and web tools out of the box and works with Anthropic, OpenAI, Google, xAI, **DeepSeek**, OpenRouter, or fully local models via `llama.cpp`.
+
+- **GitHub:** <https://github.com/gptme/gptme>
+
+#### 1. Install gptme
+
+```sh
+pipx install gptme
+```
+
+Verify:
+
+```sh
+gptme --version
+```
+
+#### 2. Get a DeepSeek API Key
+
+Sign up at the [DeepSeek Platform](https://platform.deepseek.com/api_keys), add credit, and copy your API key.
+
+#### 3. Configure the DeepSeek provider
+
+gptme resolves the API key by the `${PROVIDER_NAME}_API_KEY` convention, so export it as `DEEPSEEK_API_KEY`:
+
+```bash
+echo 'export DEEPSEEK_API_KEY="sk-your-key-here"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Then register DeepSeek as a custom OpenAI-compatible provider in `~/.config/gptme/config.toml`:
+
+```toml
+[[providers]]
+name = "deepseek"
+base_url = "https://api.deepseek.com/v1"
+api_key_env = "DEEPSEEK_API_KEY"
+default_model = "deepseek-chat"
+```
+
+(`deepseek-chat` for the V4 chat model; use `deepseek-reasoner` for the R1 reasoning model.)
+
+#### 4. First run
+
+```sh
+# Use the custom provider with its default model
+gptme --model deepseek "explain this codebase"
+
+# Or pick a specific model
+gptme --model deepseek/deepseek-reasoner "design a retry decorator"
+
+# List configured providers
+gptme-util providers list
+```
+
+gptme also supports MCP servers for databases/APIs/filesystems, a plugin system, and local models via `llama.cpp` (no key needed) — see the [providers docs](https://gptme.org/docs/providers.html) and [custom providers](https://gptme.org/docs/custom-providers.html) for the full surface.

--- a/docs/gptme.zh-CN.md
+++ b/docs/gptme.zh-CN.md
@@ -1,0 +1,59 @@
+[English](./gptme.md) | [简体中文](./gptme.zh-CN.md) · [← Back](../README.md)
+
+# 接入 gptme
+
+gptme 是一个 provider 无关、本地优先的终端 AI agent——可替代 Claude Code。内置 shell、Python、web 工具，支持 Anthropic、OpenAI、Google、xAI、**DeepSeek**、OpenRouter，或通过 `llama.cpp` 完全本地运行。
+
+- **GitHub:** <https://github.com/gptme/gptme>
+
+#### 1. 安装 gptme
+
+```sh
+pipx install gptme
+```
+
+验证：
+
+```sh
+gptme --version
+```
+
+#### 2. 获取 DeepSeek API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 注册、充值，复制你的 API Key。
+
+#### 3. 配置 DeepSeek provider
+
+gptme 按 `${PROVIDER_NAME}_API_KEY` 约定解析密钥，所以导出为 `DEEPSEEK_API_KEY`：
+
+```bash
+echo 'export DEEPSEEK_API_KEY="sk-your-key-here"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+然后在 `~/.config/gptme/config.toml` 中把 DeepSeek 注册为自定义 OpenAI 兼容 provider：
+
+```toml
+[[providers]]
+name = "deepseek"
+base_url = "https://api.deepseek.com/v1"
+api_key_env = "DEEPSEEK_API_KEY"
+default_model = "deepseek-chat"
+```
+
+（`deepseek-chat` 为 V4 对话模型；用 `deepseek-reasoner` 调用 R1 推理模型。）
+
+#### 4. 首次运行
+
+```sh
+# 用自定义 provider 的默认模型
+gptme --model deepseek "解释这个代码库"
+
+# 或指定具体模型
+gptme --model deepseek/deepseek-reasoner "设计一个重试装饰器"
+
+# 列出已配置的 provider
+gptme-util providers list
+```
+
+gptme 还支持 MCP 服务器（数据库/API/文件系统）、插件系统，以及通过 `llama.cpp` 跑本地模型（无需密钥）——完整能力见 [providers 文档](https://gptme.org/docs/providers.html) 与 [自定义 provider](https://gptme.org/docs/custom-providers.html)。


### PR DESCRIPTION
Adds a bilingual integration guide for **gptme** (github.com/gptme/gptme, ~4.3k stars).

## What is gptme

A provider-agnostic, local-first terminal AI agent — a Claude Code alternative that ships shell/Python/web tools and works with **DeepSeek**, Anthropic, OpenAI, Google, xAI, OpenRouter, or local models via `llama.cpp`.

## Why it belongs here

README explicitly lists DeepSeek as a supported provider, and the v0.27.0 release added DeepSeek R1 support. Not yet listed in the table; no open PR adds it (checked before opening).

## What the guide covers

Installation → configuration → first run, following the existing guide format:
1. `pipx install gptme`
2. Get a DeepSeek API key
3. Register DeepSeek as a custom OpenAI-compatible provider in `~/.config/gptme/config.toml` (`api_key_env = DEEPSEEK_API_KEY`, `default_model = deepseek-chat` / `deepseek-reasoner`)
4. `gptme --model deepseek` first run + `gptme-util providers list`

## CONTRIBUTING checks

- [x] Bilingual: `docs/gptme.md` + `docs/gptme.zh-CN.md` in one PR
- [x] README + README.zh-CN table entries in **alphabetical order** (between **GitHub Copilot CLI** and **Hermes**)
- [x] Follows the format of existing guides
- [x] No duplicate of an existing guide or open PR