### PR TITLE
docs: add open-multi-agent integration guide (EN + zh-CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
+| **open-multi-agent** | TypeScript multi-agent orchestration framework — a coordinator turns one goal into a multi-agent DAG with a live dashboard. Bundled DeepSeek provider shortcut. | [Guide](./docs/open-multi-agent.md) |
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Qwen Code** | Coding agent CLI by the Alibaba Qwen team — now with built-in DeepSeek provider support. | [Guide](./docs/qwen_code.md) |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,6 +33,7 @@
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
+| **open-multi-agent** | TypeScript 多智能体编排框架——协调器把一个目标拆解为多智能体 DAG 并带实时看板。内置 DeepSeek provider 快捷方式。 | [指南](./docs/open-multi-agent.zh-CN.md) |
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Qwen Code** | 阿里巴巴通义千问团队推出的 Coding Agent CLI，现已全面支持 DeepSeek 提供商。 | [指南](./docs/qwen_code.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |

--- a/docs/open-multi-agent.md
+++ b/docs/open-multi-agent.md
@@ -1,0 +1,54 @@
+[English](./open-multi-agent.md) | [简体中文](./open-multi-agent.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with open-multi-agent
+
+open-multi-agent (OMA) is a TypeScript multi-agent orchestration framework: describe a goal, and a coordinator turns it into a multi-agent DAG with a live dashboard. It ships built-in provider shortcuts including **DeepSeek**, so you only set `provider: 'deepseek'` and `DEEPSEEK_API_KEY`.
+
+- **GitHub:** <https://github.com/open-multi-agent/open-multi-agent>
+
+#### 1. Install
+
+```sh
+npm install @open-multi-agent/core
+```
+
+For a quick run without a project:
+
+```sh
+npx tsx packages/core/examples/basics/team-collaboration.ts
+```
+
+#### 2. Get a DeepSeek API Key
+
+Sign up at the [DeepSeek Platform](https://platform.deepseek.com/api_keys), add credit, and copy your API key.
+
+#### 3. Configure the DeepSeek provider
+
+OMA has a bundled `deepseek` shortcut — set the env var and use `provider: 'deepseek'` in your agent definition:
+
+```bash
+export DEEPSEEK_API_KEY="sk-your-key-here"
+```
+
+```typescript
+import { createAdapter } from '@open-multi-agent/core'
+
+const adapter = createAdapter('deepseek', 'deepseek-v4-flash')
+
+const agent = {
+  name: 'my-agent',
+  provider: 'deepseek',
+  model: 'deepseek-v4-flash', // or 'deepseek-v4-pro' (flagship for coding); both support 1M context, 384K max output
+  systemPrompt: 'You are a helpful assistant.',
+}
+```
+
+#### 4. First run
+
+Run a coordinated team — the first run shows the coordinator turn one goal into a multi-agent DAG and open a dashboard:
+
+```sh
+oma "design a retry decorator with tests"
+```
+
+OMA also supports Anthropic/OpenAI/Gemini/Bedrock built-ins, any OpenAI-compatible endpoint (Ollama/vLLM/OpenRouter/Groq/Mistral), MCP, an AI SDK bridge, and a one-click Vercel starter — see the [providers docs](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) for the full list.

--- a/docs/open-multi-agent.zh-CN.md
+++ b/docs/open-multi-agent.zh-CN.md
@@ -1,0 +1,54 @@
+[English](./open-multi-agent.md) | [简体中文](./open-multi-agent.zh-CN.md) · [← Back](../README.md)
+
+# 接入 open-multi-agent
+
+open-multi-agent（OMA）是一个 TypeScript 多智能体编排框架：描述一个目标，协调器会将其拆解为多智能体 DAG 并带实时看板。内置 **DeepSeek** 等 provider 快捷方式，只需设置 `provider: 'deepseek'` 和 `DEEPSEEK_API_KEY`。
+
+- **GitHub:** <https://github.com/open-multi-agent/open-multi-agent>
+
+#### 1. 安装
+
+```sh
+npm install @open-multi-agent/core
+```
+
+无项目快速体验：
+
+```sh
+npx tsx packages/core/examples/basics/team-collaboration.ts
+```
+
+#### 2. 获取 DeepSeek API Key
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 注册、充值，复制你的 API Key。
+
+#### 3. 配置 DeepSeek provider
+
+OMA 内置 `deepseek` 快捷方式——设置环境变量并在 agent 定义中使用 `provider: 'deepseek'`：
+
+```bash
+export DEEPSEEK_API_KEY="sk-your-key-here"
+```
+
+```typescript
+import { createAdapter } from '@open-multi-agent/core'
+
+const adapter = createAdapter('deepseek', 'deepseek-v4-flash')
+
+const agent = {
+  name: 'my-agent',
+  provider: 'deepseek',
+  model: 'deepseek-v4-flash', // 或 'deepseek-v4-pro'（编程旗舰款）；均支持 1M 上下文、384K 最大输出
+  systemPrompt: 'You are a helpful assistant.',
+}
+```
+
+#### 4. 首次运行
+
+运行一个协作团队——首次运行会展示协调器把一个目标拆解为多智能体 DAG 并打开看板：
+
+```sh
+oma "设计一个带测试的重试装饰器"
+```
+
+OMA 还支持 Anthropic/OpenAI/Gemini/Bedrock 内置、任意 OpenAI 兼容端点（Ollama/vLLM/OpenRouter/Groq/Mistral）、MCP、AI SDK 桥接，以及一键 Vercel 启动模板——完整列表见 [providers 文档](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md)。


### PR DESCRIPTION
Adds a bilingual integration guide for **open-multi-agent** (github.com/open-multi-agent/open-multi-agent, ~6.4k stars).

## What is open-multi-agent

A TypeScript multi-agent orchestration framework: describe a goal, and a coordinator turns it into a multi-agent DAG with a live dashboard. Ships a bundled `deepseek` provider shortcut (OpenAI-compatible), so configuration is just `provider: 'deepseek'` + `DEEPSEEK_API_KEY`.

## Why it belongs here

The framework's providers doc explicitly lists DeepSeek as a built-in shortcut with `deepseek-v4-flash` / `deepseek-v4-pro` models (1M context, 384K max output). Not yet listed in the table; no open PR adds it (checked before opening).

## What the guide covers

Installation → configuration → first run, following the existing guide format:
1. `npm install @open-multi-agent/core`
2. Get a DeepSeek API key
3. `export DEEPSEEK_API_KEY=...` + use `provider: 'deepseek'` / `model: 'deepseek-v4-flash'` in an agent definition
4. First run shows the coordinator turn one goal into a multi-agent DAG + dashboard

## CONTRIBUTING checks

- [x] Bilingual: `docs/open-multi-agent.md` + `docs/open-multi-agent.zh-CN.md` in one PR
- [x] README + README.zh-CN table entries in **alphabetical order** (between **OpenCode** and **Pi**)
- [x] Follows the format of existing guides
- [x] No duplicate of an existing guide or open PR