### PR TITLE
docs: update Claude Code CLI installation to official curl/irm method

### DIFF
--- a/docs/claude_code.md
+++ b/docs/claude_code.md
@@ -10,12 +10,24 @@ Claude Code can be used via CLI or VSCode Extension. Choose whichever you prefer
 
 #### Option 1: Install Claude Code CLI
 
-- Install [Node.js](https://nodejs.org/en/download/) 18+.
-- Windows users need to install [Git for Windows](https://git-scm.com/download/win).
-- Run the following command in your terminal to install Claude Code:
+Run the appropriate command for your platform:
+
+**macOS, Linux, WSL:**
 
 ```
-npm install -g @anthropic-ai/claude-code
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+**Windows PowerShell:**
+
+```
+irm https://claude.ai/install.ps1 | iex
+```
+
+**Windows CMD:**
+
+```
+curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
 ```
 
 - After installation, run the following command. If the version number is displayed, the installation is successful:

--- a/docs/claude_code.zh-CN.md
+++ b/docs/claude_code.zh-CN.md
@@ -10,12 +10,24 @@ Claude Code 可以通过 CLI 或者 VSCode Extension 的方式运行，按照使
 
 #### 选项一：安装 Claude Code CLI
 
-- 安装 [Node.js](https://nodejs.org/zh-cn/download/) 18+。
-- Windows 用户需安装 [Git for Windows](https://git-scm.com/download/win)。
-- 在命令行界面，执行以下命令安装 Claude Code：
+根据你的平台执行对应的命令：
+
+**macOS、Linux、WSL：**
 
 ```
-npm install -g @anthropic-ai/claude-code
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+**Windows PowerShell：**
+
+```
+irm https://claude.ai/install.ps1 | iex
+```
+
+**Windows CMD：**
+
+```
+curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
 ```
 
 - 安装结束后，执行以下命令，若显示版本号则安装成功：


### PR DESCRIPTION
Replace the deprecated npm-based installation (`npm install -g @anthropic-ai/claude-code`) with the official Anthropic installation scripts:

- macOS/Linux/WSL: curl -fsSL https://claude.ai/install.sh | bash
- Windows PowerShell: irm https://claude.ai/install.ps1 | iex
- Windows CMD: curl -fsSL https://claude.ai/install.cmd ...

Also remove the outdated Node.js 18+ and Git for Windows prerequisites which are no longer required with the new installer.

Updated both English (claude_code.md) and Chinese (claude_code.zh-CN.md) versions.

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against `https://api-docs.deepseek.com/quick_start/pricing`
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes