### PR TITLE
Add MurongAgent DeepSeek integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **LobeHub** | LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. | [Guide](./docs/lobehub.md) |
+| **MurongAgent** | Android-first mobile AI agent with local project browsing, code editing, GitHub workflows, tool calling, and DeepSeek reasoning effort support. | [Guide](./docs/murongagent.md) |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,6 +29,7 @@
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
 | **Langcli** | 100% 兼容 Claude Code、支持 DeepSeek V4 等主流 LLM 模型的开源 AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **LobeHub** | LobeHub 是你的 Chief Agent Operator，通过招聘、排班并报告整个 AI 团队，将你的 Agent 组织成 7×24 小时运作。 | [指南](./docs/lobehub.zh-CN.md) |
+| **MurongAgent** | 面向 Android 的移动端 AI Agent，支持本地项目浏览、代码编辑、GitHub 工作流、工具调用与 DeepSeek 推理强度控制。 | [指南](./docs/murongagent.zh-CN.md) |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具、记忆、MCP 等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |

--- a/docs/murongagent.md
+++ b/docs/murongagent.md
@@ -1,0 +1,183 @@
+[English](./murongagent.md) | [简体中文](./murongagent.zh-CN.md)
+
+# Integrate DeepSeek with MurongAgent
+
+MurongAgent is a mobile multi-model AI agent for Android. It supports local project browsing, code editing, GitHub repository workflows, tool calling, and multi-turn agent sessions on-device.
+
+This guide shows how to install MurongAgent, configure DeepSeek as the active model provider, and start your first agent session.
+
+## Install MurongAgent
+
+The easiest way to install MurongAgent is to download the Android package directly.
+
+### Option 1. Install from the official website
+
+Visit:
+
+```text
+https://murongagent.rl1.cc/
+```
+
+Download the latest Android package from the website and install it on your device.
+
+### Option 2. Install from GitHub Releases
+
+If you prefer GitHub-based distribution, you can also install the app from the project's GitHub Releases page.
+
+```text
+https://github.com/murongruyan/MurongAgent/releases
+```
+
+### Option 3. Build from source
+
+Building from source is mainly for contributors or users who want to modify the app.
+
+Prerequisites:
+
+- Android Studio
+- JDK 26
+- Android SDK / Build Tools 37
+- A device running Android 13+ (`minSdk 33`)
+
+Then build the app:
+
+```bash
+git clone https://github.com/murongruyan/MurongAgent.git
+cd murongagent
+./gradlew :app:assembleRelease
+```
+
+If you want to install directly onto a connected device:
+
+```bash
+./gradlew :app:installRelease
+```
+
+If your local environment does not have release signing materials, use a debug build instead:
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+## Configure DeepSeek in MurongAgent
+
+Open MurongAgent, then go to the Settings page.
+
+### 1. Select the provider
+
+In `Settings` → `AI Model Provider`:
+
+- Set **Provider** to `DeepSeek`
+
+MurongAgent also supports `OpenAI Compatible` and `Claude`, but for the official DeepSeek API you should choose `DeepSeek`.
+
+### 2. Enter your API Key
+
+Fill in:
+
+- `API Key`: your DeepSeek API key from [DeepSeek Platform](https://platform.deepseek.com/api_keys)
+
+### 3. Set the Base URL
+
+For the official DeepSeek API, keep:
+
+```text
+https://api.deepseek.com
+```
+
+If you are routing through a compatible proxy or gateway, you can change the Base URL accordingly.
+
+### 4. Choose the model
+
+Use current DeepSeek V4 model names:
+
+- `deepseek-v4-pro`
+- `deepseek-v4-flash`
+
+Do not use deprecated V3-era names such as:
+
+- `deepseek-chat`
+- `deepseek-reasoner`
+- `deepseek-coder`
+
+### 5. Set reasoning effort
+
+MurongAgent exposes reasoning effort directly for the DeepSeek provider.
+
+Supported values in the app are:
+
+- `low`
+- `medium`
+- `high`
+- `max`
+
+For coding and agent workflows, `deepseek-v4-pro` with `max` is the recommended high-end setup.
+
+## Recommended DeepSeek setup
+
+For general coding and agent use:
+
+```text
+Provider: DeepSeek
+Base URL: https://api.deepseek.com
+Model: deepseek-v4-pro
+Reasoning effort: max
+```
+
+For faster and cheaper daily use:
+
+```text
+Provider: DeepSeek
+Base URL: https://api.deepseek.com
+Model: deepseek-v4-flash
+Reasoning effort: high
+```
+
+## 1M context note
+
+DeepSeek V4 models support up to **1M tokens** of context.
+
+MurongAgent does not currently expose a separate `context_window` field in the UI. Instead, it forwards the selected DeepSeek model and reasoning settings to the provider. If you select a current V4 model, you are using the current DeepSeek model family that supports 1M context.
+
+## First run
+
+After saving your settings:
+
+1. Open `Chat`
+2. Start a new session
+3. Enter a request such as:
+
+```text
+Read this Android project and tell me how the chat workflow is organized.
+```
+
+If you already attached a local project, you can also ask:
+
+```text
+Find the ChatScreen implementation and summarize the message sending flow.
+```
+
+MurongAgent can then:
+
+- browse the local project
+- search files
+- inspect code
+- run tool-assisted agent workflows
+- combine local project context with GitHub repository context
+
+## GitHub integration
+
+MurongAgent also supports GitHub-linked workflows.
+
+In `Settings` → `GitHub`, sign in or configure a GitHub token. After that, the app can use GitHub-backed repository browsing and remote file workflows in the project and chat flows.
+
+This is separate from the DeepSeek API key. You normally need both if you want:
+
+- DeepSeek as the model provider
+- GitHub repositories as remote project context
+
+## Notes
+
+- The app is Android-first and designed around mobile interaction patterns.
+- Tool calling, project context, GitHub context, and session state are tightly connected, so DeepSeek works best when the provider is configured before starting your session.
+- MurongAgent supports DeepSeek-specific reasoning controls and forwards `reasoning_effort` to the DeepSeek provider.

--- a/docs/murongagent.zh-CN.md
+++ b/docs/murongagent.zh-CN.md
@@ -1,0 +1,185 @@
+[English](./murongagent.md) | [简体中文](./murongagent.zh-CN.md)
+
+# 在 MurongAgent 中接入 DeepSeek
+
+MurongAgent 是一个面向 Android 的移动端多模型 AI Agent，支持本地项目浏览、代码编辑、GitHub 仓库工作流、工具调用和多轮 Agent 会话。
+
+这份指南说明如何安装 MurongAgent、将 DeepSeek 配置为当前模型提供商，并完成第一次实际使用。
+
+## 安装 MurongAgent
+
+安装 MurongAgent 最简单的方式，是直接下载安装 Android 安装包。
+
+### 方式 1：从官网安装
+
+访问：
+
+```text
+https://murongagent.rl1.cc/
+```
+
+下载安装最新 Android 安装包后，直接在设备上安装即可。
+
+### 方式 2：从 GitHub Release 安装
+
+如果你更习惯从 GitHub 获取发行版本，也可以直接从项目仓库的 Release 页面下载安装。
+
+```text
+https://github.com/murongruyan/MurongAgent/releases
+```
+
+### 方式 3：从源码构建
+
+源码构建更适合开发者或需要自行修改应用的人。
+
+前置条件：
+
+- Android Studio
+- JDK 26
+- Android SDK / Build Tools 37
+- Android 13 及以上设备（`minSdk 33`）
+
+然后执行：
+
+```bash
+git clone https://github.com/murongruyan/MurongAgent.git
+cd murongagent
+./gradlew :app:assembleRelease
+```
+
+如果你想直接安装到已连接设备：
+
+```bash
+./gradlew :app:installRelease
+```
+
+如果你的本地环境没有 release 签名材料，也可以先使用 debug 构建：
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+## 在 MurongAgent 中配置 DeepSeek
+
+打开 MurongAgent 后，进入设置页。
+
+### 1. 选择模型提供商
+
+在 `设置` → `AI 模型提供商` 中：
+
+- 将 **Provider** 设为 `DeepSeek`
+
+MurongAgent 也支持 `OpenAI Compatible` 和 `Claude`，但如果你要接官方 DeepSeek 接口，应直接选择 `DeepSeek`。
+
+### 2. 填写 API Key
+
+填写：
+
+- `API Key`：你的 DeepSeek API Key，可在 [DeepSeek Platform](https://platform.deepseek.com/api_keys) 获取
+
+### 3. 设置 Base URL
+
+如果你使用官方 DeepSeek API，保持：
+
+```text
+https://api.deepseek.com
+```
+
+如果你走兼容中转站或自定义网关，也可以在这里改成对应地址。
+
+### 4. 选择模型
+
+请使用当前的 DeepSeek V4 模型名：
+
+- `deepseek-v4-pro`
+- `deepseek-v4-flash`
+
+不要再使用已经过时的 V3 命名：
+
+- `deepseek-chat`
+- `deepseek-reasoner`
+- `deepseek-coder`
+
+### 5. 设置推理强度
+
+MurongAgent 已经把 DeepSeek 的推理强度直接做进设置项里。
+
+当前应用支持：
+
+- `low`
+- `medium`
+- `high`
+- `max`
+
+如果你主要拿它做代码与 Agent 工作流，推荐高配方案是 `deepseek-v4-pro` + `max`。
+
+## 推荐配置
+
+用于较强的代码与 Agent 任务：
+
+```text
+Provider: DeepSeek
+Base URL: https://api.deepseek.com
+Model: deepseek-v4-pro
+Reasoning effort: max
+```
+
+用于日常更快、更省钱的使用：
+
+```text
+Provider: DeepSeek
+Base URL: https://api.deepseek.com
+Model: deepseek-v4-flash
+Reasoning effort: high
+```
+
+## 100 万上下文说明
+
+DeepSeek V4 系列模型支持最高 **100 万 token** 上下文。
+
+MurongAgent 当前没有在设置页里单独暴露 `context_window` 字段，而是直接把你选择的 DeepSeek 模型和推理配置透传给 Provider。也就是说，只要你选择的是当前 V4 模型，就已经是在使用支持 1M context 的 DeepSeek 模型家族。
+
+## 首次运行
+
+保存设置之后：
+
+1. 打开 `聊天`
+2. 新建会话
+3. 输入类似下面的请求：
+
+```text
+读一下这个 Android 项目，告诉我聊天工作流是怎么组织的。
+```
+
+如果你已经绑定了本地项目，也可以直接问：
+
+```text
+找到 ChatScreen 的实现，并总结消息发送流程。
+```
+
+这时 MurongAgent 可以：
+
+- 浏览本地项目
+- 搜索文件
+- 阅读和分析代码
+- 运行带工具调用的 Agent 工作流
+- 结合本地项目上下文和 GitHub 远端仓库上下文协作
+
+## GitHub 联动
+
+MurongAgent 还支持 GitHub 联动工作流。
+
+在 `设置` → `GitHub` 中登录或配置 GitHub Token 后，应用就可以在项目页和聊天链路里使用 GitHub 仓库浏览、远端文件引用等能力。
+
+这和 DeepSeek API Key 是两套独立配置。通常如果你希望同时获得：
+
+- DeepSeek 作为模型
+- GitHub 仓库作为远端项目上下文
+
+那就需要把这两项都配置好。
+
+## 说明
+
+- 这是一个明显偏移动端交互的 Agent 应用。
+- 工具调用、项目上下文、GitHub 上下文、会话状态之间耦合较深，所以建议先把 DeepSeek Provider 配好，再开始正式会话。
+- MurongAgent 已支持 DeepSeek 的推理强度控制，并会向 DeepSeek Provider 透传 `reasoning_effort`。


### PR DESCRIPTION
## Summary

Add MurongAgent to awesome-deepseek-agent with bilingual integration guides and README table entries.

## Changes

- add docs/murongagent.md
- add docs/murongagent.zh-CN.md
- add MurongAgent entry to README.md
- add MurongAgent entry to README.zh-CN.md

## Notes

- uses current model names: deepseek-v4-pro / deepseek-v4-flash
- mentions 1M context support for DeepSeek V4
- documents easoning_effort support in MurongAgent
- installation flow prioritizes official website and GitHub Releases