### PR TITLE
Add Dao Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Cline** | AI coding assistant extension for VS Code supporting multiple API providers. | [Guide](./docs/cline.md) |
 | **Codex** | OpenAI's coding agent. | [Guide](./docs/codex.md) |
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
+| **Dao Code** | Open-source TypeScript terminal coding agent for DeepSeek-V4 — builds on DeepSeek's strong price-performance and ultra-cheap cache pricing, engineering byte-stable prefixes and cache-reusing forks so cross-session memory and a continuous self-correction layer add almost no token cost; 1M context, layered-permission sandbox, Skills/MCP/Hooks, Claude Code config compatible. | [Guide](./docs/dao_code.md) |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,6 +21,7 @@
 | **Cline** | 运行在 VS Code 中的 AI 编程助手扩展，支持多种 API 供应商。 | [指南](./docs/cline.zh-CN.md) |
 | **Codex** | OpenAI 的编程 Agent。 | [指南](./docs/codex.zh-CN.md) |
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
+| **Dao Code** | 面向 DeepSeek-V4 的开源 TypeScript 终端编码 agent —— 充分发挥 DeepSeek 的高性价比与极低缓存定价，通过工程化的字节稳定前缀与缓存复用 fork，让跨会话记忆与全程自我纠错几乎不增加 token 开销；1M 上下文、分层权限安全沙箱、Skills/MCP/Hooks，兼容 Claude Code 配置。 | [指南](./docs/dao_code.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |

--- a/docs/dao_code.md
+++ b/docs/dao_code.md
@@ -1,0 +1,112 @@
+[English](./dao_code.md) | [简体中文](./dao_code.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Dao Code
+
+Dao Code (command `dao`) is an open-source, MIT-licensed terminal AI coding agent built around DeepSeek-V4 (up to 1M tokens of context). Its guiding principle is cache economics: DeepSeek prices a prefix-cache hit about two orders of magnitude below a miss — for deepseek-v4-pro, $0.003625 vs $0.435 per 1M input tokens, roughly 1/120. So Dao Code keeps the system prefix, tool table, and memory byte-stable to maximize the hit rate, and runs reflection and memory on forks that reuse the main prefix cache. The payoff: cross-session memory and a continuous self-correction layer — a challenger that re-examines repeated failures, a refocuser that catches scope creep — add almost no token cost. Across 7 real open-source bug-fix tasks (3.89M input tokens), it sustained a 95.8% aggregate cache-hit rate.
+
+What sets it apart from other DeepSeek terminal agents is memory you can trust: cross-session memory is deterministically re-verified against your live code on every startup — stale facts are pruned, not blindly accumulated — paired with a challenger/refocuser layer that self-corrects throughout: steadier and more accurate on everyday tasks, and markedly harder to derail on long ones.
+
+It also hardens long autonomous runs: crash recovery (`dao -c`), shadow-git checkpoints (`/restore`, `/rewind`) that never touch your `.git`, a Definition-of-Done gate (`verify_done`), stuck-loop detection, an autonomous `/goal` mode, and parallel / background / worktree-isolated sub-agents. The fundamentals are all there too: the full 1M-token context window, a complete built-in tool set, layered allow/ask/deny permissions with a security sandbox (secret scanning, SSRF guard, keychain), Agent Skills, MCP (stdio + HTTP/SSE), lifecycle hooks, custom sub-agents / slash commands / plugins, multi-account profiles, and OS-level scheduling. Config-compatible with Claude Code. Taiji-themed Ink TUI.
+
+- **GitHub:** <https://github.com/tigicion/dao-code>
+
+#### 1. Install Dao Code
+
+**Option A — one-line install (no Node required):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/tigicion/dao-code/master/install.sh | sh
+```
+
+Or download a prebuilt binary from [Releases](https://github.com/tigicion/dao-code/releases) (macOS arm64/x64, Linux arm64/x64, Windows x64).
+
+**Option B — npm (requires Node ≥ 20, all platforms):**
+
+```sh
+npx dao-code        # zero-install try
+npm i -g dao-code   # global install, command name `dao`
+```
+
+Verify the installation:
+
+```sh
+dao --version
+```
+
+#### 2. Configure Dao Code
+
+Get your API key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+The simplest path is to just run `dao` — on first launch with no key detected, it guides you to paste one and saves it to `~/.dao/config.json` (read automatically next time). You can also set it manually:
+
+| Method | Command |
+|--------|---------|
+| `.env` (project root, all platforms) | add a line `DEEPSEEK_API_KEY=sk-...` |
+| macOS / Linux | `export DEEPSEEK_API_KEY=sk-...` |
+| Windows PowerShell | `$env:DEEPSEEK_API_KEY="sk-..."` |
+| Windows CMD | `set DEEPSEEK_API_KEY=sk-...` |
+
+**Configuration options:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DEEPSEEK_API_KEY` | Your DeepSeek API key | — |
+| `DEEPSEEK_BASE_URL` | API endpoint | `https://api.deepseek.com` |
+| `DEEPSEEK_MODEL` | Model name — `deepseek-v4-pro` or `deepseek-v4-flash` | `deepseek-v4-pro` |
+| `DAO_REASONING_EFFORT` | Thinking effort — keep at `max` for the deepest reasoning | `max` |
+| `DAO_CONTEXT_WINDOW` | Context budget in tokens | `1000000` |
+| `DAO_MAX_TURNS` | Max tool turns per round | `50` |
+| `DAO_THEME` | `light` / `dark` terminal background | auto-detect |
+
+DeepSeek-V4 supports up to 1M tokens of context, and Dao Code sets its context budget to **1,000,000 tokens by default** (override with `DAO_CONTEXT_WINDOW`). Thinking mode ships at `max` effort out of the box.
+
+#### 3. Enter a project directory and launch Dao Code
+
+```sh
+cd /path/to/my-project
+dao
+```
+
+Run a one-shot task (runs and exits, good for scripts):
+
+```sh
+dao "make formatDate in src/utils.ts timezone-aware"
+```
+
+Resume the last session after a crash:
+
+```sh
+dao -c
+```
+
+#### Key Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Send the prompt |
+| `↑` / `↓` | Browse input history |
+| `Esc` | Interrupt the current round (stops both model stream and shell) |
+| `Shift+Tab` | Cycle permission mode (default / acceptEdits / auto / plan) |
+| `@` + path, then `Tab` | Reference a file with autocomplete |
+| `Ctrl+O` | Expand / collapse full tool output and thinking |
+| `Ctrl+A` / `Ctrl+E` | Move cursor to line start / end |
+
+#### Common Slash Commands
+
+| Command | Action |
+|---------|--------|
+| `/init` | Scan the repo and generate `DAO.md` (project overview, auto-loaded later) |
+| `/model [id]` | Switch model (toggles `deepseek-v4-pro` / `deepseek-v4-flash`) |
+| `/mode [x]` | Permission mode: `default` / `acceptEdits` / `auto` / `plan` |
+| `/goal <goal>` | Autonomous long-task mode (auto-approve + continuous progress) |
+| `/cost` | Show token usage and prefix-cache hit rate |
+| `/skills` | List / toggle Agent Skills |
+| `/compact` · `/clear` · `/help` · `/exit` | Compact · clear · command list · quit |
+
+#### Using Agent Skills
+
+Dao Code supports progressively-disclosed Agent Skills, plus MCP servers and lifecycle hooks. It is config-compatible with Claude Code (`settings.json`, `SKILL.md`, `hooks.json`, `mcp.json`), so existing CC skills and configs work directly.
+
+- **Project-level skills:** `./.dao/skills/<name>/SKILL.md`
+- **MCP servers:** `./.dao/mcp.json`
+- **Hooks:** `./.dao/hooks.json`

--- a/docs/dao_code.zh-CN.md
+++ b/docs/dao_code.zh-CN.md
@@ -1,0 +1,112 @@
+[English](./dao_code.md) | [简体中文](./dao_code.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 集成 Dao Code
+
+Dao Code（命令 `dao`）是一个开源（MIT）、面向 DeepSeek-V4（最高 1M 上下文）的终端 AI 编码助手，目标是把这个高性价比模型的性价比用到极致。它的核心原则是缓存经济学：DeepSeek 的前缀缓存命中价比未命中低约两个数量级——deepseek-v4-pro 命中 $0.003625、未命中 $0.435（每 1M 输入 token），约 1/120。于是 Dao Code 把系统前缀、工具表与记忆按字节级稳定组织，以拉高命中率，并让反思与记忆都跑在复用主前缀缓存的 fork 上。结果是：跨会话记忆与持续自纠层（挑战者复审重复失败、纠偏者盯住范围蔓延 scope creep）几乎不增加 token 开销。在 7 道真实开源 bug-fix 任务（389 万输入 token）上，实测聚合缓存命中率 95.8%。
+
+与其他 DeepSeek 终端 agent 相比，真正的不同在于"可信的记忆"：跨会话记忆在每次启动时按当前代码确定性校验——过期事实剔除，而非盲目堆积——再配合挑战者 / 纠偏者持续自纠，普通任务更稳更准，长任务尤其不易跑偏。
+
+它还为长任务兜底：崩溃恢复（`dao -c`）、影子 git 检查点（`/restore`、`/rewind`，不碰你的 `.git`）、验收门（`verify_done`）、卡死检测、自主模式（`/goal`），以及并行 / 后台 / worktree 隔离的子代理。基础也一应俱全：完整 1M 上下文、完备内置工具集、分层 allow/ask/deny 权限 + 安全纵深（密钥扫描 / SSRF 防护 / 钥匙串）、Agent Skills、MCP（stdio + HTTP/SSE）、生命周期 Hooks、自定义子代理 / slash 命令 / 插件、多账户 profile、OS 定时调度。兼容 Claude Code 配置。太极美学 Ink TUI。
+
+- **GitHub:** <https://github.com/tigicion/dao-code>
+
+#### 1. 安装 Dao Code
+
+**方式 A —— 一键安装（无需 Node）：**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/tigicion/dao-code/master/install.sh | sh
+```
+
+或到 [Releases](https://github.com/tigicion/dao-code/releases) 下载预编译二进制（macOS arm64/x64、Linux arm64/x64、Windows x64）。
+
+**方式 B —— npm（需 Node ≥ 20，全平台）：**
+
+```sh
+npx dao-code        # 零安装试用
+npm i -g dao-code   # 全局安装，命令名 dao
+```
+
+验证安装：
+
+```sh
+dao --version
+```
+
+#### 2. 配置 Dao Code
+
+到 [DeepSeek 平台](https://platform.deepseek.com/api_keys)获取 API key。
+
+最简单的方式是直接运行 `dao`：首次启动且未检测到 key 时，会引导你粘贴，并存到 `~/.dao/config.json`（下次自动读）。也可手动设置：
+
+| 方式 | 命令 |
+|------|------|
+| `.env`（项目根，全平台） | 写一行 `DEEPSEEK_API_KEY=sk-...` |
+| macOS / Linux | `export DEEPSEEK_API_KEY=sk-...` |
+| Windows PowerShell | `$env:DEEPSEEK_API_KEY="sk-..."` |
+| Windows CMD | `set DEEPSEEK_API_KEY=sk-...` |
+
+**配置项：**
+
+| 变量 | 说明 | 默认 |
+|------|------|------|
+| `DEEPSEEK_API_KEY` | DeepSeek API key | — |
+| `DEEPSEEK_BASE_URL` | API 端点 | `https://api.deepseek.com` |
+| `DEEPSEEK_MODEL` | 模型名 —— `deepseek-v4-pro` 或 `deepseek-v4-flash` | `deepseek-v4-pro` |
+| `DAO_REASONING_EFFORT` | 思考强度 —— 保持 `max` 获得最深推理 | `max` |
+| `DAO_CONTEXT_WINDOW` | 上下文预算（token） | `1000000` |
+| `DAO_MAX_TURNS` | 单回合最大工具轮数 | `50` |
+| `DAO_THEME` | `light` / `dark` 终端背景 | 自动探测 |
+
+DeepSeek-V4 最高支持 1M token 上下文，Dao Code 默认把上下文预算设为 **1,000,000 token**（可用 `DAO_CONTEXT_WINDOW` 覆盖）。思考模式默认以 `max` 强度开启。
+
+#### 3. 进入项目目录并启动 Dao Code
+
+```sh
+cd /path/to/my-project
+dao
+```
+
+一次性任务（跑完即退，适合脚本）：
+
+```sh
+dao "把 src/utils.ts 里的 formatDate 改成支持时区"
+```
+
+崩溃后恢复上次会话：
+
+```sh
+dao -c
+```
+
+#### 快捷键
+
+| 键 | 作用 |
+|----|------|
+| `Enter` | 发送 |
+| `↑` / `↓` | 翻输入历史 |
+| `Esc` | 打断当前回合（模型流与 shell 一并停） |
+| `Shift+Tab` | 循环权限模式（default / acceptEdits / auto / plan） |
+| `@` + 路径，再 `Tab` | 引用文件并补全 |
+| `Ctrl+O` | 展开 / 收起全量工具输出与思考 |
+| `Ctrl+A` / `Ctrl+E` | 光标移到行首 / 行尾 |
+
+#### 常用斜杠命令
+
+| 命令 | 作用 |
+|------|------|
+| `/init` | 扫描本仓库生成 `DAO.md`（项目概览，后续会话自动加载） |
+| `/model [id]` | 切换模型（在 `deepseek-v4-pro` / `deepseek-v4-flash` 间切换） |
+| `/mode [x]` | 权限模式：`default` / `acceptEdits` / `auto` / `plan` |
+| `/goal <目标>` | 长任务自主模式（自动批准 + 连续推进） |
+| `/cost` | 查看 token 用量与前缀缓存命中率 |
+| `/skills` | 列出 / 开关技能 |
+| `/compact` · `/clear` · `/help` · `/exit` | 压缩 · 清空 · 命令列表 · 退出 |
+
+#### 使用 Agent Skills
+
+Dao Code 支持渐进式披露的 Agent Skills，以及 MCP server 和生命周期 Hooks。它与 Claude Code 配置兼容（`settings.json`、`SKILL.md`、`hooks.json`、`mcp.json`），现成的 CC 技能与配置可直接使用。
+
+- **项目级技能：** `./.dao/skills/<name>/SKILL.md`
+- **MCP server：** `./.dao/mcp.json`
+- **Hooks：** `./.dao/hooks.json`


### PR DESCRIPTION
## Add Dao Code

Adds a bilingual integration guide for **Dao Code** — an open-source (MIT) TypeScript terminal AI coding agent built for DeepSeek-V4.

- Repo: https://github.com/tigicion/dao-code
- npm: `dao-code` (command `dao`)

### What it is
A terminal-native coding agent engineered around DeepSeek-V4's cache economics: a prefix-cache hit costs ~1/120 of a miss, so Dao Code keeps the system prefix, tool table and memory byte-stable to maximize the hit rate and runs reflection/memory on forks that reuse the main prefix cache — letting cross-session memory and a challenger/refocuser self-correction layer add almost no token cost (95.8% measured cache hit rate over 3.89M input tokens on 7 real OSS bug-fix tasks). Its distinctive feature is cross-session memory that is deterministically re-verified against the live codebase on startup, so stale facts are pruned rather than accumulated. Full 1M context, a security sandbox with layered `allow`/`ask`/`deny` permissions, Agent Skills, MCP (stdio + HTTP/SSE), hooks, sub-agents, and an autonomous long-task mode (`/goal`). Config-compatible with Claude Code (`settings.json` / `SKILL.md` / `hooks.json` / `mcp.json`).

### Files changed
- `docs/dao_code.md` (English guide)
- `docs/dao_code.zh-CN.md` (Simplified Chinese guide)
- `README.md` — added table row (alphabetical order, after Crush / before Deep Code)
- `README.zh-CN.md` — added table row (same position)

### Agent Configuration
- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against DeepSeek API Docs
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation
- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes (n/a — no images)
