### PR TITLE
docs: add flair DeepSeek guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **flair** | Open-source DeepSeek-first agentic assistant with a coding agent and a general desktop-automation agent; cross-platform CLI/REPL. | [Guide](https://github.com/deepseek-ai/awesome-deepseek-agent/blob/main/docs/flair.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **flair** | 开源、以 DeepSeek 为先的智能体助手，含编程智能体与通用桌面自动化智能体；跨平台 CLI/REPL。 | [指南](https://github.com/deepseek-ai/awesome-deepseek-agent/blob/main/docs/flair.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |

--- a/docs/flair.md
+++ b/docs/flair.md
@@ -1,0 +1,83 @@
+[English](https://github.com/deepseek-ai/awesome-deepseek-agent/blob/main/docs/flair.md) | [简体中文](https://github.com/deepseek-ai/awesome-deepseek-agent/blob/main/docs/flair.zh-CN.md) · [← Back](https://github.com/deepseek-ai/awesome-deepseek-agent/blob/main/README.md)
+
+# Integrate with flair
+
+flair is an open-source, DeepSeek-first agentic AI assistant with two sides — advanced **coding** and general **desktop automation** — that runs on Linux, macOS, and Windows. It speaks the OpenAI-compatible protocol, with DeepSeek V4 as its primary provider.
+
+- **GitHub:** <https://github.com/NAST0R/flair>
+
+#### 1. Install flair
+
+Requires Python ≥ 3.10.
+
+```
+git clone https://github.com/NAST0R/flair.git
+cd flair
+pip install -e .
+# optional extras (detailed RAM/CPU info, portable clipboard) used by the general agent:
+pip install -e ".[extras]"
+```
+
+#### 2. Configure flair for DeepSeek
+
+flair loads its configuration from a `.env` file. Copy the template and add your DeepSeek key:
+
+```
+cp .env.example .env
+```
+
+Then edit `.env` so DeepSeek is the active provider:
+
+```
+FLAIR_PROVIDER=deepseek
+
+DEEPSEEK_API_KEY=sk-...
+DEEPSEEK_MODEL=deepseek-v4-flash       # fast workhorse (non-thinking)
+DEEPSEEK_THINK_MODEL=deepseek-v4-pro   # reasoner used for --think
+
+FLAIR_ROOT=.                           # working root the coding agent is sandboxed to
+FLAIR_AUTO_APPROVE=false               # ask for confirmation before destructive tools
+```
+
+Get your API key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+**Configuration options:**
+
+| Variable | Description |
+| --- | --- |
+| `FLAIR_PROVIDER` | Active provider — set to `deepseek` |
+| `DEEPSEEK_API_KEY` | Your DeepSeek API key |
+| `DEEPSEEK_MODEL` | Fast, non-thinking model (default `deepseek-v4-flash`) |
+| `DEEPSEEK_THINK_MODEL` | Reasoner used on the `--think` step (default `deepseek-v4-pro`) |
+| `FLAIR_ROOT` | Working root the coding agent is confined to |
+| `FLAIR_AUTO_APPROVE` | Skip the confirmation prompt for destructive tools (default `false`) |
+
+> **Thinking mode & 1M context.** On DeepSeek **V4**, thinking is turned on by a *parameter* rather than a separate model name. flair enables it automatically only on the `--think` step, using `deepseek-v4-pro` (a genuine reasoner); the fast tool loop stays on `deepseek-v4-flash`. Both V4 models expose a **1M-token** context window — flair measures context exactly from the API's `prompt_tokens` and compacts the history automatically as it nears a threshold (75% of the window by default), keeping the prefix cache active.
+
+> **Cost tracking.** flair estimates cost per turn from a per-model price table (overridable via `FLAIR_PRICE_*`) and can enforce a hard ceiling with `--max-cost <usd>`. Check current DeepSeek rates on the [DeepSeek pricing page](https://api-docs.deepseek.com/quick_start/pricing).
+
+#### 3. Run flair
+
+```
+flair                                  # interactive REPL, auto-routes between coding and general
+flair -p "open youtube for me"         # one-shot task
+flair --think -p "refactor the parsing module to reduce complexity"   # reasoner on the first step
+flair --root ~/projects/my-repo        # point the coding agent at a project
+flair --yes -p "run the tests and fix the errors"                     # no confirmations
+```
+
+**Useful REPL commands:**
+
+| Command | Effect |
+| --- | --- |
+| `/code <task>` | Force the coding agent |
+| `/do <task>` | Force the general agent |
+| `/think <task>` | Use the thinking model on the first step |
+| `/provider [name]` | Show or switch provider at runtime (`deepseek` / `openai`) |
+| `/model <name>` | Switch the fast model at runtime |
+| `/think-model <name>` | Switch the thinking model at runtime |
+| `/cost` | Session token / cost summary |
+| `/compact` | Compact the active agent's context now |
+| `exit` | Quit |
+
+That's it — flair is now running on DeepSeek V4.

--- a/docs/flair.zh-CN.md
+++ b/docs/flair.zh-CN.md
@@ -1,0 +1,83 @@
+[English](https://github.com/deepseek-ai/awesome-deepseek-agent/blob/main/docs/flair.md) | [简体中文](https://github.com/deepseek-ai/awesome-deepseek-agent/blob/main/docs/flair.zh-CN.md) · [← 返回](https://github.com/deepseek-ai/awesome-deepseek-agent/blob/main/README.md)
+
+# 集成 flair
+
+flair 是一个开源、以 DeepSeek 为先的智能体 AI 助手，具备两大能力——高级**编程**与通用**桌面自动化**——可运行于 Linux、macOS 和 Windows。它使用兼容 OpenAI 的协议，并以 DeepSeek V4 作为主要提供方。
+
+- **GitHub:** <https://github.com/NAST0R/flair>
+
+#### 1. 安装 flair
+
+需要 Python ≥ 3.10。
+
+```
+git clone https://github.com/NAST0R/flair.git
+cd flair
+pip install -e .
+# 可选扩展（更详细的内存/CPU 信息、跨平台剪贴板），供通用智能体使用：
+pip install -e ".[extras]"
+```
+
+#### 2. 为 DeepSeek 配置 flair
+
+flair 从 `.env` 文件加载配置。复制模板并填入你的 DeepSeek 密钥：
+
+```
+cp .env.example .env
+```
+
+然后编辑 `.env`，将 DeepSeek 设为当前提供方：
+
+```
+FLAIR_PROVIDER=deepseek
+
+DEEPSEEK_API_KEY=sk-...
+DEEPSEEK_MODEL=deepseek-v4-flash       # 快速主力模型（非思考）
+DEEPSEEK_THINK_MODEL=deepseek-v4-pro   # 用于 --think 的推理模型
+
+FLAIR_ROOT=.                           # 编程智能体被限制的工作根目录
+FLAIR_AUTO_APPROVE=false               # 执行破坏性操作前需确认
+```
+
+在 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取你的 API 密钥。
+
+**配置项：**
+
+| 变量 | 说明 |
+| --- | --- |
+| `FLAIR_PROVIDER` | 当前提供方——设为 `deepseek` |
+| `DEEPSEEK_API_KEY` | 你的 DeepSeek API 密钥 |
+| `DEEPSEEK_MODEL` | 快速、非思考模型（默认 `deepseek-v4-flash`） |
+| `DEEPSEEK_THINK_MODEL` | 用于 `--think` 步骤的推理模型（默认 `deepseek-v4-pro`） |
+| `FLAIR_ROOT` | 编程智能体被限制的工作根目录 |
+| `FLAIR_AUTO_APPROVE` | 跳过破坏性操作的确认提示（默认 `false`） |
+
+> **思考模式与 1M 上下文。** 在 DeepSeek **V4** 上，思考模式通过*参数*开启，而非使用单独的模型名。flair 仅在 `--think` 步骤自动启用它，并使用 `deepseek-v4-pro`（真正的推理模型）；快速工具循环则保持在 `deepseek-v4-flash`。两个 V4 模型都提供 **100 万 token** 的上下文窗口——flair 直接依据 API 返回的 `prompt_tokens` 精确测量上下文，并在接近阈值（默认为窗口的 75%）时自动压缩历史，从而保持前缀缓存有效。
+
+> **成本跟踪。** flair 依据每个模型的价格表（可通过 `FLAIR_PRICE_*` 覆盖）估算每轮成本，并可用 `--max-cost <usd>` 设置硬性上限。请在 [DeepSeek 价格页面](https://api-docs.deepseek.com/quick_start/pricing) 查看当前费率。
+
+#### 3. 运行 flair
+
+```
+flair                                  # 交互式 REPL，在编程与通用之间自动路由
+flair -p "open youtube for me"         # 单次任务
+flair --think -p "refactor the parsing module to reduce complexity"   # 首步使用推理模型
+flair --root ~/projects/my-repo        # 让编程智能体指向某个项目
+flair --yes -p "run the tests and fix the errors"                     # 不需确认
+```
+
+**常用 REPL 命令：**
+
+| 命令 | 作用 |
+| --- | --- |
+| `/code <task>` | 强制使用编程智能体 |
+| `/do <task>` | 强制使用通用智能体 |
+| `/think <task>` | 首步使用思考模型 |
+| `/provider [name]` | 查看或在运行时切换提供方（`deepseek` / `openai`） |
+| `/model <name>` | 运行时切换快速模型 |
+| `/think-model <name>` | 运行时切换思考模型 |
+| `/cost` | 会话 token / 成本汇总 |
+| `/compact` | 立即压缩当前智能体的上下文 |
+| `exit` | 退出 |
+
+大功告成——flair 现在已经在 DeepSeek V4 上运行了。


### PR DESCRIPTION
Adds an integration guide for flair, an open-source DeepSeek-first agentic assistant
(coding agent + general desktop-automation agent), cross-platform.

- Repo: https://github.com/NAST0R/flair
- New guide: docs/flair.md (English) + docs/flair.zh-CN.md (Chinese)
- Added the table entry to README.md and README.zh-CN.md

### Checklist
**Agent Configuration**
- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against DeepSeek API Docs (pricing is reflected by static mapping updated by maintainer)
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

**Documentation**
- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] No images (n/a)