### PR TITLE
docs: Add super-code integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Qwen Code** | Coding agent CLI by the Alibaba Qwen team — now with built-in DeepSeek provider support. | [Guide](./docs/qwen_code.md) |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
+| **super-code** | Terminal AI coding assistant in Python with multi-agent orchestration, persistent memory, and snippet-based edit safety. | [Guide](./docs/super-code.md) |
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
 
 ## Resources

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,6 +36,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Qwen Code** | 阿里巴巴通义千问团队推出的 Coding Agent CLI，现已全面支持 DeepSeek 提供商。 | [指南](./docs/qwen_code.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
+| **super-code** | 基于 Python 的终端 AI 编程助手，支持多 Agent 编排、持久化记忆与 Snippet 编辑安全机制。 | [指南](./docs/super-code.zh-CN.md) |
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
 
 ## 相关资源

--- a/docs/super-code.md
+++ b/docs/super-code.md
@@ -1,0 +1,100 @@
+[English](./super-code.md) | [简体中文](./super-code.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Super Code
+
+Super Code is a terminal AI coding assistant built in Python, featuring multi-agent orchestration, persistent memory across sessions, snippet-based edit safety, and multi-model support via OpenAI-compatible API.
+
+- **GitHub:** <https://github.com/weiqiang136/super-code>
+
+#### 1. Install Super Code
+
+**From source (all platforms)**
+
+- Install [Python](https://www.python.org/downloads/) 3.11+.
+- Clone the repository and install dependencies:
+
+```sh
+git clone https://github.com/weiqiang136/super-code.git
+cd super-code
+pip install -r requirements.txt
+```
+
+**Portable executable (Windows)**
+
+Download `super-code.exe` from the [Releases page](https://github.com/weiqiang136/super-code/releases) and place it in a directory on your `PATH`.
+
+#### 2. Configure Super Code
+
+Create `~/.config/super-code/super-code.json` (global) or `./.super-code.json` (project-level) with your DeepSeek API key:
+
+```json
+{
+  "provider": "openai",
+  "model": "deepseek-v4-pro",
+  "api_key": "sk-...",
+  "base_url": "https://api.deepseek.com",
+  "max_tokens": 131072,
+  "timeout": 300,
+  "model_profiles": {
+    "deepseek": {
+      "extra_body": {
+        "reasoning_effort": "max"
+      }
+    }
+  }
+}
+```
+
+Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+> **Note:** DeepSeek V4 models support up to **1 million tokens** of context. Super Code uses the OpenAI-compatible protocol — `base_url` points to DeepSeek's API endpoint. For the faster model, set `"model": "deepseek-v4-flash"`.
+
+**Configuration options:**
+
+| Option | Description |
+|--------|-------------|
+| `provider` | Always `"openai"` (DeepSeek uses OpenAI-compatible protocol) |
+| `model` | `deepseek-v4-pro` or `deepseek-v4-flash` |
+| `api_key` | Your DeepSeek API key |
+| `base_url` | `https://api.deepseek.com` |
+| `max_tokens` | Max output tokens (default 131072) |
+| `timeout` | HTTP timeout in seconds (default 300, recommended ≥ 300 for thinking models) |
+| `model_profiles` | Per-model extra request body parameters. For DeepSeek, set `reasoning_effort` to `"max"` or `"high"` via `extra_body` |
+| `coordinator` | Enable multi-agent coordinator mode (default `false`) |
+
+**Portable distribution:** Place `super-code.json` in the same directory as `super-code.exe` for zero-config deployment — the executable auto-detects it.
+
+#### 3. Launch Super Code
+
+```sh
+cd /path/to/my-project
+python -m src.tui.app
+# or: super-code (if using the portable executable)
+```
+
+#### Key Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Send the prompt |
+| `Shift+Tab` | Toggle Plan mode (read-only tools) |
+| `Esc` | Interrupt the current model turn |
+| `/help` | Show available slash commands |
+| `/resume` | Continue a previous conversation |
+| `/clear` | Start a fresh conversation |
+| `/rename <title>` | Rename the current session |
+| `/memory` | View memory index |
+| `/dream` | Consolidate session memories |
+
+#### Using Agent Skills
+
+Super Code discovers Skills from these locations:
+
+- **User-level:** `~/.config/super-code/skills/<name>/SKILL.md`
+- **Project-level:** `./.super-code/skills/<name>/SKILL.md`
+
+Type `/<skill-name>` to invoke a skill directly, or use the `Skill` tool.
+
+#### Multi-Agent Coordinator Mode
+
+Enable `"coordinator": true` in the config to unlock parallel agent orchestration. The coordinator spawns workers with the `Agent` tool, sends follow-ups via `SendMessage`, and stops workers with `TaskStop`. Each worker runs in an isolated Engine with auto-approved read-only tools.

--- a/docs/super-code.zh-CN.md
+++ b/docs/super-code.zh-CN.md
@@ -1,0 +1,100 @@
+[English](./super-code.md) | [简体中文](./super-code.zh-CN.md) · [← Back](../README.zh-CN.md)
+
+# 集成 Super Code
+
+Super Code 是一款基于 Python 的终端 AI 编程助手，支持多 Agent 编排、跨会话持久化记忆、Snippet 编辑安全机制，以及通过 OpenAI 兼容协议接入多种模型。
+
+- **GitHub：** <https://github.com/weiqiang136/super-code>
+
+#### 1. 安装 Super Code
+
+**从源码运行（全平台）**
+
+- 安装 [Python](https://www.python.org/downloads/) 3.11+ 版本。
+- 克隆仓库并安装依赖：
+
+```sh
+git clone https://github.com/weiqiang136/super-code.git
+cd super-code
+pip install -r requirements.txt
+```
+
+**便携可执行文件（Windows）**
+
+从 [Releases 页面](https://github.com/weiqiang136/super-code/releases) 下载 `super-code.exe`，放到 `PATH` 中的某个目录即可。
+
+#### 2. 配置 Super Code
+
+创建 `~/.config/super-code/super-code.json`（全局）或 `./.super-code.json`（项目级），填入你的 DeepSeek API Key：
+
+```json
+{
+  "provider": "openai",
+  "model": "deepseek-v4-pro",
+  "api_key": "sk-...",
+  "base_url": "https://api.deepseek.com",
+  "max_tokens": 131072,
+  "timeout": 300,
+  "model_profiles": {
+    "deepseek": {
+      "extra_body": {
+        "reasoning_effort": "max"
+      }
+    }
+  }
+}
+```
+
+从 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取你的 API Key。
+
+> **注意：** DeepSeek V4 模型支持最高 **100 万 token** 的上下文窗口。Super Code 使用 OpenAI 兼容协议，`base_url` 指向 DeepSeek 的 API 地址。如需使用快速模型，将 `model` 设为 `"deepseek-v4-flash"`。
+
+**配置选项：**
+
+| 选项 | 说明 |
+|------|------|
+| `provider` | 固定为 `"openai"`（DeepSeek 使用 OpenAI 兼容协议） |
+| `model` | `deepseek-v4-pro` 或 `deepseek-v4-flash` |
+| `api_key` | DeepSeek API Key |
+| `base_url` | `https://api.deepseek.com` |
+| `max_tokens` | 最大输出 token 数（默认 131072） |
+| `timeout` | HTTP 超时时间（秒），默认 300，思考模型建议 ≥ 300 |
+| `model_profiles` | 按模型的额外请求体参数。DeepSeek 可通过 `extra_body` 设置 `reasoning_effort` 为 `"max"` 或 `"high"` |
+| `coordinator` | 启用多 Agent 协调模式（默认 `false`） |
+
+**便携分发：** 将 `super-code.json` 放在 `super-code.exe` 同级目录即可实现零配置部署，程序会自动检测。
+
+#### 3. 启动 Super Code
+
+```sh
+cd /path/to/my-project
+python -m src.tui.app
+# 或：super-code（使用便携可执行文件时）
+```
+
+#### 快捷键
+
+| 按键 | 功能 |
+|------|------|
+| `Enter` | 发送消息 |
+| `Shift+Tab` | 切换 Plan 模式（仅允许只读工具） |
+| `Esc` | 中断当前模型回复 |
+| `/help` | 查看可用的斜杠命令 |
+| `/resume` | 继续之前的会话 |
+| `/clear` | 开始新的对话 |
+| `/rename <标题>` | 重命名当前会话 |
+| `/memory` | 查看记忆索引 |
+| `/dream` | 整合会话记忆 |
+
+#### 使用 Agent Skills
+
+Super Code 从以下位置自动发现 Skills：
+
+- **用户级别：** `~/.config/super-code/skills/<name>/SKILL.md`
+- **项目级别：** `./.super-code/skills/<name>/SKILL.md`
+
+输入 `/<skill-name>` 直接调用技能，或使用 `Skill` 工具。
+
+#### 多 Agent 协调模式
+
+在配置中将 `coordinator` 设为 `true` 即可启用并行 Agent 编排。协调者可通过 `Agent` 工具创建 Worker、`SendMessage` 发送跟进指令、`TaskStop` 停止 Worker。每个 Worker 在独立的 Engine 中运行，自动批准只读工具调用。


### PR DESCRIPTION
Add integration guide for super-code, a terminal AI coding assistant built in Python with multi-agent orchestration,
 persistent memory, and snippet-based edit safety.


 • GitHub: https://github.com/weiqiang136/super-code

 • 4 files: super-code.md, super-code.zh-CN.md, README.md, README.zh-CN.md
Checklist
Agent Configuration

 • [x] Model names are current (v4-pro / v4-flash, not v3 names)

 • [x] 1M context is configured or mentioned

 • [x] Max thinking effort level is supported

 • [x] Pricing is current, verified against DeepSeek API Docs

 • [x] Config fields are verified to work in the agent

 • [x] No workarounds for already-fixed upstream bugs
Documentation

 • [x] Both English and Chinese versions included in a single PR

 • [x] README table entry inserted in alphabetical order

 • [x] One tool per PR; unrelated tools not combined

 • [x] Images placed in docs/assets/ with descriptive filenames and reasonable sizes (N/A — no images)