### PR TITLE
docs: add Kimi Code integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |
 | **Kilo Code** | AI coding assistant available as a CLI and editor extension. | [Guide](./docs/kilo_code.md) |
+| **Kimi Code** | Open-source terminal AI coding agent developed by Moonshot AI. | [Guide](./docs/kimi_code.md) |
 | **Langcli** | Open-source AI coding assistant that is 100% compatible with Claude Code and supports mainstream LLM models | [Guide](./docs/langcli.md) |
 | **LobeHub** | LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. | [Guide](./docs/lobehub.md) |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,6 +27,7 @@
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |
 | **Kilo Code** | 支持 CLI 和编辑器扩展的 AI 编程助手。 | [指南](./docs/kilo_code.zh-CN.md) |
+| **Kimi Code** | 月之暗面开发的开源终端 AI 编程 Agent。 | [指南](./docs/kimi_code.zh-CN.md) |
 | **Langcli** | 100% 兼容 Claude Code、支持 DeepSeek V4 等主流 LLM 模型的开源 AI 编程助手。 | [指南](./docs/langcli.zh-CN.md) |
 | **LobeHub** | LobeHub 是你的 Chief Agent Operator，通过招聘、排班并报告整个 AI 团队，将你的 Agent 组织成 7×24 小时运作。 | [指南](./docs/lobehub.zh-CN.md) |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具、记忆、MCP 等。 | [指南](./docs/nanobot.zh-CN.md) |

--- a/docs/kimi_code.md
+++ b/docs/kimi_code.md
@@ -1,0 +1,119 @@
+[English](./kimi_code.md) | [简体中文](./kimi_code.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with Kimi Code
+
+Kimi Code is an open-source terminal AI agent developed by Moonshot AI.
+
+- **GitHub:** <https://github.com/MoonshotAI/kimi-code>
+- **Docs:** <https://moonshotai.github.io/kimi-code/en/>
+
+#### 1. Install Kimi Code
+
+Run the official installation script for your platform.
+
+Linux / macOS:
+
+```shell
+curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://code.kimi.com/kimi-code/install.ps1 | iex
+```
+
+Alternatively, install Kimi Code with npm. This requires Node.js 22.19.0 or later:
+
+```shell
+npm install -g @moonshot-ai/kimi-code
+```
+
+Confirm the installation:
+
+```shell
+kimi --version
+```
+
+#### 2. Get a DeepSeek API Key
+
+Create and copy an API key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+
+#### 3. Configure DeepSeek
+
+Create or edit Kimi Code's configuration file:
+
+- Linux / macOS: `~/.kimi-code/config.toml`
+- Windows: `C:\Users\<name>\.kimi-code\config.toml`
+
+If the file already contains other settings, merge the following blocks into it instead of replacing the entire file. Replace `YOUR_DEEPSEEK_API_KEY` with your DeepSeek API key:
+
+```toml
+default_model = "deepseek-v4-pro"
+
+[thinking]
+enabled = true
+effort = "max"
+keep = "all"
+
+[providers.deepseek]
+type = "openai"
+base_url = "https://api.deepseek.com"
+api_key = "YOUR_DEEPSEEK_API_KEY"
+
+[models.deepseek-v4-pro]
+provider = "deepseek"
+model = "deepseek-v4-pro"
+display_name = "DeepSeek V4 Pro"
+max_context_size = 1000000
+capabilities = ["always_thinking", "tool_use"]
+support_efforts = ["high", "max"]
+default_effort = "max"
+
+[models.deepseek-v4-flash]
+provider = "deepseek"
+model = "deepseek-v4-flash"
+display_name = "DeepSeek V4 Flash"
+max_context_size = 1000000
+capabilities = ["always_thinking", "tool_use"]
+support_efforts = ["high", "max"]
+default_effort = "max"
+```
+
+This configuration adds DeepSeek V4 Pro and DeepSeek V4 Flash with their 1-million-token context window, enables tool use and Thinking mode, and selects DeepSeek V4 Pro with `max` reasoning effort by default.
+
+Kimi Code's OpenAI-compatible provider automatically preserves DeepSeek's `reasoning_content` across tool-call turns. This keeps Thinking mode working during multi-step agent tasks.
+
+#### 4. Validate the Configuration
+
+Validate the configuration without starting the TUI:
+
+```shell
+kimi doctor config
+```
+
+If the file is valid, Kimi Code reports that `config.toml` is OK.
+
+#### 5. Start Kimi Code
+
+Enter a project directory and launch Kimi Code:
+
+```shell
+cd /path/to/your-project
+kimi
+```
+
+Kimi Code now uses DeepSeek V4 Pro by default. Type `/model` in the interactive session to switch between DeepSeek V4 Pro and DeepSeek V4 Flash.
+
+To run a one-shot task without opening the interactive TUI:
+
+```shell
+kimi -p "Inspect this project's top-level files and summarize what the project does."
+```
+
+#### Troubleshooting
+
+- `401` or authentication errors: confirm that `api_key` contains a valid DeepSeek API key.
+- `402` or insufficient balance: check your DeepSeek Platform balance.
+- `404` or model not found: confirm that the model ID is exactly `deepseek-v4-pro` or `deepseek-v4-flash`.
+- `No model configured`: make sure `default_model` matches a key under `[models]`, then run `kimi doctor config`.

--- a/docs/kimi_code.zh-CN.md
+++ b/docs/kimi_code.zh-CN.md
@@ -1,0 +1,119 @@
+[English](./kimi_code.md) | [简体中文](./kimi_code.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 Kimi Code
+
+Kimi Code 是月之暗面开发的一款开源的终端 AI Agent。
+
+- **GitHub：** <https://github.com/MoonshotAI/kimi-code>
+- **文档：** <https://moonshotai.github.io/kimi-code/zh/>
+
+#### 1. 安装 Kimi Code
+
+运行对应平台的官方安装脚本。
+
+Linux / macOS：
+
+```shell
+curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash
+```
+
+Windows PowerShell：
+
+```powershell
+irm https://code.kimi.com/kimi-code/install.ps1 | iex
+```
+
+也可以通过 npm 安装 Kimi Code。此方式要求 Node.js 22.19.0 或更高版本：
+
+```shell
+npm install -g @moonshot-ai/kimi-code
+```
+
+确认安装成功：
+
+```shell
+kimi --version
+```
+
+#### 2. 获取 DeepSeek API Key
+
+前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 创建并复制 API Key。
+
+#### 3. 配置 DeepSeek
+
+创建或编辑 Kimi Code 配置文件：
+
+- Linux / macOS：`~/.kimi-code/config.toml`
+- Windows：`C:\Users\<name>\.kimi-code\config.toml`
+
+如果文件中已有其他设置，请把下面的配置块合并进去，不要覆盖整个文件。将 `YOUR_DEEPSEEK_API_KEY` 替换为你的 DeepSeek API Key：
+
+```toml
+default_model = "deepseek-v4-pro"
+
+[thinking]
+enabled = true
+effort = "max"
+keep = "all"
+
+[providers.deepseek]
+type = "openai"
+base_url = "https://api.deepseek.com"
+api_key = "YOUR_DEEPSEEK_API_KEY"
+
+[models.deepseek-v4-pro]
+provider = "deepseek"
+model = "deepseek-v4-pro"
+display_name = "DeepSeek V4 Pro"
+max_context_size = 1000000
+capabilities = ["always_thinking", "tool_use"]
+support_efforts = ["high", "max"]
+default_effort = "max"
+
+[models.deepseek-v4-flash]
+provider = "deepseek"
+model = "deepseek-v4-flash"
+display_name = "DeepSeek V4 Flash"
+max_context_size = 1000000
+capabilities = ["always_thinking", "tool_use"]
+support_efforts = ["high", "max"]
+default_effort = "max"
+```
+
+这份配置会添加 DeepSeek V4 Pro 和 DeepSeek V4 Flash，设置模型的 100 万 token 上下文窗口，启用工具调用与 Thinking 模式，并默认使用 DeepSeek V4 Pro 和 `max` 推理强度。
+
+Kimi Code 的 OpenAI 兼容 Provider 会自动在工具调用轮次之间保留 DeepSeek 的 `reasoning_content`，确保 Thinking 模式可以正常执行多步骤 Agent 任务。
+
+#### 4. 校验配置
+
+无需启动 TUI，直接运行以下命令校验配置：
+
+```shell
+kimi doctor config
+```
+
+配置有效时，Kimi Code 会报告 `config.toml` 状态为 OK。
+
+#### 5. 启动 Kimi Code
+
+进入项目目录并启动 Kimi Code：
+
+```shell
+cd /path/to/your-project
+kimi
+```
+
+Kimi Code 默认使用 DeepSeek V4 Pro。在交互会话中输入 `/model`，可在 DeepSeek V4 Pro 和 DeepSeek V4 Flash 之间切换。
+
+如需跳过交互式 TUI，直接运行单次任务：
+
+```shell
+kimi -p "检查这个项目的顶层文件，并总结项目用途。"
+```
+
+#### 常见问题
+
+- 出现 `401` 或认证错误：确认 `api_key` 中填写了有效的 DeepSeek API Key。
+- 出现 `402` 或余额不足：检查 DeepSeek 开放平台余额。
+- 出现 `404` 或找不到模型：确认模型 ID 严格写成 `deepseek-v4-pro` 或 `deepseek-v4-flash`。
+- 提示 `No model configured`：确认 `default_model` 与 `[models]` 下的某个 key 完全一致，然后运行 `kimi doctor config`。


### PR DESCRIPTION
See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.

## Summary

Add bilingual guides for integrating DeepSeek V4 with Kimi Code, Moonshot AI's open-source terminal coding agent.

## What's included

- Add `docs/kimi_code.md` and `docs/kimi_code.zh-CN.md`.
- Add Kimi Code to both README guide tables in alphabetical order.
- Document installation, API key setup, custom OpenAI-compatible provider configuration, model selection, config validation, one-shot usage, and troubleshooting.
- Configure `deepseek-v4-pro` and `deepseek-v4-flash` with 1M context, tool use, preserved `reasoning_content`, and `max` reasoning effort.

## Validation

- Checked the documented fields against the current Kimi Code config schema and OpenAI-compatible provider implementation.
- Verified DeepSeek V4 model IDs, base URL, 1M context, tool calling, and `high`/`max` reasoning effort against the official DeepSeek API docs.
- Ran `kimi doctor config` successfully with the documented configuration structure.
- Ran `git diff --check`.
- Confirmed the guide contains no deprecated DeepSeek model IDs.

## Checklist

### Agent Configuration

- [x] Model names are current (`deepseek-v4-pro` / `deepseek-v4-flash`).
- [x] 1M context is configured.
- [x] Max thinking effort level is supported.
- [x] Pricing is not included (not applicable).
- [x] Config fields are verified against the current Kimi Code implementation.
- [x] No workarounds for already-fixed upstream bugs are documented.

### Documentation

- [x] Both English and Chinese versions are included in a single PR.
- [x] README table entries are inserted in alphabetical order.
- [x] The PR covers one tool only.
- [x] No images are included (not applicable).
