### PR TITLE
docs(codex): document native DeepSeek integration

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -2,9 +2,67 @@
 
 # Integrate with Codex
 
-Codex is OpenAI's coding agent, available as a CLI and app. Codex communicates with models through the OpenAI Responses API, so it needs a forwarding layer to handle requests. This guide uses [Moon Bridge](https://github.com/ZhiYi-R/moon-bridge) as that forwarding layer.
+Codex is OpenAI's coding agent, available through Codex CLI, the ChatGPT desktop app, and the Codex IDE extension for VS Code. Codex communicates with models through the OpenAI Responses API, which DeepSeek natively supports.
 
-#### 1. Install Requirements
+> **Support note:** At the moment, only `deepseek-v4-flash` supports native Codex integration. Native `deepseek-v4-pro` support is expected in early August 2026. If you need Pro today, use the [Moon Bridge](https://github.com/ZhiYi-R/moon-bridge) alternative below.
+
+## Recommended: Native DeepSeek Provider
+
+### 1. Configure DeepSeek as the Model Provider
+
+Before running the setup script, install Codex CLI or the ChatGPT desktop app and launch it at least once so that the `~/.codex` directory exists.
+
+On macOS or Linux, run:
+
+```shell
+bash <(curl -fsSL https://cdn.deepseek.com/api-docs/codex-deepseek-setup-en.sh)
+```
+
+On Windows PowerShell, run:
+
+```powershell
+irm https://cdn.deepseek.com/api-docs/codex-deepseek-setup-en.ps1 | iex
+```
+
+Choose `deepseek-v4-flash` from the menu and enter your DeepSeek API key when prompted. The script backs up the existing Codex configuration, writes `~/.codex/models.json`, updates `~/.codex/config.toml`, and validates both files before saving. Run it again to restore the pre-installation configuration or switch models after native Pro support becomes available.
+
+### 2. Configure Manually
+
+Create `~/.codex/models.json` with the full DeepSeek model catalog from the [DeepSeek Codex integration documentation](https://api-docs.deepseek.com/quick_start/agent_integrations/codex), then add the following to `~/.codex/config.toml` (create it if needed):
+
+```toml
+model = "deepseek-v4-flash"
+model_provider = "deepseek"
+preferred_auth_method = "apikey"
+forced_login_method = "api"
+model_reasoning_effort = "high"
+model_catalog_json = "~/.codex/models.json"
+
+[model_providers.deepseek]
+name = "deepseek"
+base_url = "https://api.deepseek.com/"
+wire_api = "responses"
+experimental_bearer_token = "<your DeepSeek API Key>"
+```
+
+The model catalog supplies Codex with the model's context window, reasoning levels, and tool-call capabilities. Keep the API key private because this configuration stores it directly in `config.toml`.
+
+### 3. Get Started
+
+All Codex clients read the same configuration, so no per-client setup is required. In a project directory, run:
+
+```shell
+cd /path/to/my-project
+codex
+```
+
+The Codex CLI startup banner should show `model: deepseek-v4-flash`. In the ChatGPT desktop app, locally configured models appear under the **Custom** model picker. The VS Code Codex extension shares the same configuration as Codex CLI.
+
+## Alternative: Moon Bridge
+
+Moon Bridge remains useful when you want to use `deepseek-v4-pro` with Codex before native Pro support is available. The proxy setup below also supports both V4 models.
+
+### 1. Install Requirements
 
 - [Node.js](https://nodejs.org/en/download/) 18+.
 - [Go](https://go.dev/dl/) 1.25+.
@@ -21,11 +79,11 @@ codex --version
 go version
 ```
 
-#### 2. Get a DeepSeek API Key
+### 2. Get a DeepSeek API Key
 
 Go to the [DeepSeek Platform](https://platform.deepseek.com/api_keys), create an API key, and copy it.
 
-#### 3. Configure Moon Bridge
+### 3. Configure Moon Bridge
 
 Clone Moon Bridge and create a local config file:
 
@@ -92,7 +150,7 @@ defaults:
 
 This minimal config uses the current Moon Bridge configuration structure and enables DeepSeek V4 Pro / Flash, Codex model metadata, and the DeepSeek V4 compatibility extension. **For image input, Web Search, or multi-provider routing**, extend it with the options from Moon Bridge's `config.example.yml`.
 
-#### 4. Start Moon Bridge
+### 4. Start Moon Bridge
 
 ```shell
 go run ./cmd/moonbridge --config config.yml
@@ -104,7 +162,7 @@ Keep this terminal open. By default Moon Bridge listens on `127.0.0.1:38440` and
 http://127.0.0.1:38440/v1/responses
 ```
 
-#### 5. Generate Codex Configuration
+### 5. Generate Codex Configuration
 
 In another terminal, run the following commands from the Moon Bridge directory to write Codex's `config.toml` and `models_catalog.json` into `CODEX_HOME_DIR`.
 
@@ -162,7 +220,7 @@ go run ./cmd/moonbridge --config config.yml --print-codex-model
 # moonbridge
 ```
 
-#### 6. Start Codex
+### 6. Start Codex
 
 Enter the project you want to work on and launch Codex:
 
@@ -175,7 +233,7 @@ Codex now sends OpenAI Responses requests to Moon Bridge, and Moon Bridge routes
 
 Codex App can use the same generated Codex configuration.
 
-#### One-Command Launcher
+### One-Command Launcher
 
 Moon Bridge provides a helper script for Codex CLI that can build and start the proxy, generate the Codex config, and launch Codex in one command:
 
@@ -189,7 +247,7 @@ Windows PowerShell users can use:
 .\scripts\start_codex_with_moonbridge.ps1 -ProjectDirectory C:\path\to\my-project
 ```
 
-#### Verify
+### Verify
 
 Check the available models:
 
@@ -224,7 +282,7 @@ curl http://127.0.0.1:38440/v1/responses \
   }'
 ```
 
-#### Troubleshooting
+### Troubleshooting
 
 - `connection refused`: Moon Bridge is not running, or `server.addr` in `config.yml` uses a different port.
 - Codex cannot see the model: rerun step 5; Codex needs `models_catalog.json` in `CODEX_HOME`.
@@ -233,8 +291,9 @@ curl http://127.0.0.1:38440/v1/responses \
 - `402` or payment errors: check your DeepSeek Platform balance.
 - Image input fails: if you enabled the Visual extension, configure a separate visual provider (e.g., Kimi) with its API key. You can configure that provider, or remove `visual.enabled: true` to disable the Visual extension.
 
-#### Resources
+### Resources
 
 - [Moon Bridge](https://github.com/ZhiYi-R/moon-bridge)
 - [Codex CLI](https://github.com/openai/codex)
+- [DeepSeek Codex Integration](https://api-docs.deepseek.com/quick_start/agent_integrations/codex)
 - [DeepSeek API Docs](https://api-docs.deepseek.com/)

--- a/docs/codex.zh-CN.md
+++ b/docs/codex.zh-CN.md
@@ -2,9 +2,67 @@
 
 # 接入 Codex
 
-Codex 是 OpenAI 的编程 Agent，支持 CLI 和 App 使用。Codex 使用 OpenAI Responses API 与模型通信，因此需要一个转发层处理请求，这里使用 [Moon Bridge](https://github.com/ZhiYi-R/moon-bridge) 作为转发层。
+Codex 是 OpenAI 的编程 Agent，支持 Codex CLI、ChatGPT 桌面应用和 VS Code 的 Codex IDE 扩展。Codex 使用 OpenAI Responses API 与模型通信，而 DeepSeek 原生支持该 API。
 
-#### 1. 安装依赖
+> **支持说明：** 目前只有 `deepseek-v4-flash` 支持原生接入 Codex。`deepseek-v4-pro` 预计在 2026 年 8 月初支持。如果现在需要使用 Pro，请使用下方的 [Moon Bridge](https://github.com/ZhiYi-R/moon-bridge) 方案。
+
+## 推荐方案：原生 DeepSeek Provider
+
+### 1. 配置 DeepSeek 模型 Provider
+
+运行配置脚本前，请先安装 Codex CLI 或 ChatGPT 桌面应用，并至少启动一次，以便创建 `~/.codex` 目录。
+
+macOS 或 Linux 用户运行：
+
+```shell
+bash <(curl -fsSL https://cdn.deepseek.com/api-docs/codex-deepseek-setup-en.sh)
+```
+
+Windows PowerShell 用户运行：
+
+```powershell
+irm https://cdn.deepseek.com/api-docs/codex-deepseek-setup-en.ps1 | iex
+```
+
+在菜单中选择 `deepseek-v4-flash`，并按提示输入 DeepSeek API Key。脚本会备份现有 Codex 配置，写入 `~/.codex/models.json`，更新 `~/.codex/config.toml`，并在保存前校验两个文件。之后可以再次运行脚本恢复安装前的配置，或在原生支持 Pro 后切换模型。
+
+### 2. 手动配置
+
+从 [DeepSeek Codex 接入文档](https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/codex) 中复制完整的 DeepSeek 模型目录，创建 `~/.codex/models.json`，然后将以下内容加入 `~/.codex/config.toml`（不存在时创建）：
+
+```toml
+model = "deepseek-v4-flash"
+model_provider = "deepseek"
+preferred_auth_method = "apikey"
+forced_login_method = "api"
+model_reasoning_effort = "high"
+model_catalog_json = "~/.codex/models.json"
+
+[model_providers.deepseek]
+name = "deepseek"
+base_url = "https://api.deepseek.com/"
+wire_api = "responses"
+experimental_bearer_token = "<your DeepSeek API Key>"
+```
+
+模型目录会向 Codex 声明上下文窗口、推理档位和工具调用能力。由于 API Key 会直接存储在 `config.toml` 中，请妥善保护该文件。
+
+### 3. 开始使用
+
+Codex CLI、ChatGPT 桌面应用和 VS Code 扩展读取同一份配置，不需要分别设置。在项目目录中运行：
+
+```shell
+cd /path/to/my-project
+codex
+```
+
+Codex CLI 启动横幅应显示 `model: deepseek-v4-flash`。ChatGPT 桌面应用会在模型选择器中显示 **Custom**，这表示正在使用本地配置的模型。VS Code 的 Codex 扩展与 Codex CLI 共享同一份配置。
+
+## 替代方案：Moon Bridge
+
+在原生 Codex 尚未支持 Pro 之前，如果需要使用 `deepseek-v4-pro`，可以使用 Moon Bridge。下面的代理方案同时支持两个 V4 模型。
+
+### 1. 安装依赖
 
 - [Node.js](https://nodejs.org/en/download/) 18+。
 - [Go](https://go.dev/dl/) 1.25+。
@@ -21,11 +79,11 @@ codex --version
 go version
 ```
 
-#### 2. 获取 DeepSeek API Key
+### 2. 获取 DeepSeek API Key
 
 前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 创建并复制 API Key。
 
-#### 3. 配置 Moon Bridge
+### 3. 配置 Moon Bridge
 
 克隆 Moon Bridge 并创建本地配置文件：
 
@@ -92,7 +150,7 @@ defaults:
 
 这个最小配置使用当前 Moon Bridge 配置结构，启用 DeepSeek V4 Pro / Flash、Codex 模型元数据和 DeepSeek V4 兼容扩展。**如果需要图片输入、Web Search 或多 Provider 路由**，可以再参考 Moon Bridge 的 `config.example.yml` 扩展配置。
 
-#### 4. 启动 Moon Bridge
+### 4. 启动 Moon Bridge
 
 ```shell
 go run ./cmd/moonbridge --config config.yml
@@ -104,7 +162,7 @@ go run ./cmd/moonbridge --config config.yml
 http://127.0.0.1:38440/v1/responses
 ```
 
-#### 5. 生成 Codex 配置
+### 5. 生成 Codex 配置
 
 另开一个终端，在 Moon Bridge 目录下执行以下命令，将 Codex 的 `config.toml` 和 `models_catalog.json` 写入 `CODEX_HOME_DIR`。
 
@@ -162,7 +220,7 @@ go run ./cmd/moonbridge --config config.yml --print-codex-model
 # moonbridge
 ```
 
-#### 6. 启动 Codex
+### 6. 启动 Codex
 
 进入要处理的项目目录，然后启动 Codex。
 
@@ -175,7 +233,7 @@ codex
 
 Codex App 也可以使用同一份生成的 Codex 配置。
 
-#### 一键启动脚本
+### 一键启动脚本
 
 Moon Bridge 提供了面向 Codex CLI 的辅助脚本，可以一键构建并启动代理、生成 Codex 配置并启动 Codex：
 
@@ -189,7 +247,7 @@ Windows PowerShell 用户可以使用：
 .\scripts\start_codex_with_moonbridge.ps1 -ProjectDirectory C:\path\to\my-project
 ```
 
-#### 验证
+### 验证
 
 查看可用模型：
 
@@ -224,7 +282,7 @@ curl http://127.0.0.1:38440/v1/responses \
   }'
 ```
 
-#### 常见问题
+### 常见问题
 
 - `connection refused`：Moon Bridge 未启动，或 `config.yml` 中的 `server.addr` 使用了其他端口。
 - Codex 看不到模型：重新执行第 5 步；Codex 需要 `CODEX_HOME` 目录下的 `models_catalog.json`。
@@ -233,8 +291,9 @@ curl http://127.0.0.1:38440/v1/responses \
 - `402` 或余额错误：检查 DeepSeek 开放平台账户余额。
 - 图片输入失败：如果启用了 Visual 扩展，需要单独配置视觉 Provider（如 Kimi）的 API Key。你可以配置该 Provider，或移除 `visual.enabled: true` 来禁用 Visual 扩展。
 
-#### 相关资源
+### 相关资源
 
 - [Moon Bridge](https://github.com/ZhiYi-R/moon-bridge)
 - [Codex CLI](https://github.com/openai/codex)
+- [DeepSeek Codex 接入文档](https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/codex)
 - [DeepSeek API 文档](https://api-docs.deepseek.com/zh-cn/)


### PR DESCRIPTION
Fixes #326.

## Summary

The Codex guides now document DeepSeek's native Responses API integration as the recommended setup.

The bilingual guides:

- add the macOS/Linux and Windows setup scripts;
- document the manual `config.toml` provider configuration and model catalog;
- explain shared configuration across Codex CLI, the ChatGPT desktop app, and the VS Code Codex extension;
- state that only `deepseek-v4-flash` currently supports native Codex integration, with `deepseek-v4-pro` expected in early August 2026; and
- retain Moon Bridge as the alternative for using Pro before native support is available.

The existing README Codex entries remain unchanged because they already link to these guides.

## Validation

- `git diff --check`
- Verified the English and Chinese DeepSeek Codex documentation URLs resolve.
- Reviewed the final bilingual diff against the repository PR checklist.

Documentation-only change; no runtime tests are applicable.