### PR TITLE
docs: record DeepSeek V4 release versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ Before submitting, verify these items. PRs missing any of them will be flagged d
 ✅ deepseek-v4-pro / deepseek-v4-flash                   (current)
 ```
 
+The current release versions are `DeepSeek-V4-Flash-0731` for `deepseek-v4-flash` and `DeepSeek-V4-Pro-0813` for `deepseek-v4-pro`. Keep the API model IDs in configuration examples; use the release versions only when documenting or identifying a deployed model.
+
 DeepSeek renamed its models in April 2026. All code examples, config snippets, and prose must use the current names. Search your diff for `deepseek-chat` — if you find it, fix it.
 
 ### 2. 1M Context Window

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Each guide walks through installation, configuration, and first run — so you c
 
 </div>
 
+## Current Models
+
+Use the API model IDs in configuration. The corresponding release versions are listed here for identifying the deployed model:
+
+| API model ID | Release version |
+| ------------ | --------------- |
+| `deepseek-v4-flash` | `DeepSeek-V4-Flash-0731` |
+| `deepseek-v4-pro` | `DeepSeek-V4-Pro-0813` |
+
 
 ## Contents
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,6 +10,15 @@
 
 </div>
 
+## 当前模型
+
+配置时请使用 API 模型 ID。下表列出对应的发布版本，便于确认当前使用的模型：
+
+| API 模型 ID | 发布版本 |
+| ----------- | -------- |
+| `deepseek-v4-flash` | `DeepSeek-V4-Flash-0731` |
+| `deepseek-v4-pro` | `DeepSeek-V4-Pro-0813` |
+
 
 ## 目录
 


### PR DESCRIPTION
## Summary

- Add the release-version mapping for `deepseek-v4-flash` and `deepseek-v4-pro` to both README files.
- Add the same mapping to the contributor model-naming guidance.
- Keep the callable API IDs in configuration examples and document the release strings as identification metadata.

The mapping is:

| API model ID | Release version |
| ------------ | --------------- |
| `deepseek-v4-flash` | `DeepSeek-V4-Flash-0731` |
| `deepseek-v4-pro` | `DeepSeek-V4-Pro-0813` |

## Validation

- `git diff --check`
- `npx --yes markdownlint-cli --disable MD001 MD013 MD041 MD060 -- README.md README.zh-CN.md CONTRIBUTING.md`

The Markdown lint command reports pre-existing errors for the repository's HTML-wrapped READMEs, multiple blank lines, and an unlabeled code fence in `CONTRIBUTING.md`; it reports no new issue in the added sections.

The API model IDs remain aligned with DeepSeek's model list: https://api-docs.deepseek.com/api/list-models
