### PR TITLE
docs: use the supported Claude Code Flash model ID

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ DeepSeek renamed its models in April 2026. All code examples, config snippets, a
 
 DeepSeek V4 models support up to **1 million tokens** of context. Make sure your configuration reflects this:
 
-- **Claude Code / Anthropic-compatible**: append `[1m]` to model names, e.g. `deepseek-v4-pro[1m]`
+- **Claude Code / Anthropic-compatible**: use `deepseek-v4-pro[1m]` for Pro and `deepseek-v4-flash` for Flash
 - **OpenAI-compatible configs**: set `context_window: 1000000` / `max_tokens: 384000` where the tool supports it
 - **Other tools**: at minimum, note in prose that DeepSeek V4 supports 1M context
 

--- a/docs/claude_code.md
+++ b/docs/claude_code.md
@@ -52,7 +52,7 @@ Configuration file content:
     "ANTHROPIC_MODEL": "deepseek-v4-pro[1m]",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-pro[1m]",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash[1m]",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "CLAUDE_CODE_EFFORT_LEVEL": "max"
   }
@@ -69,7 +69,7 @@ export ANTHROPIC_AUTH_TOKEN=<your DeepSeek API Key>
 export ANTHROPIC_MODEL=deepseek-v4-pro[1m]
 export ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-pro[1m]
 export ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-pro[1m]
-export ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash[1m]
+export ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash
 export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 export CLAUDE_CODE_EFFORT_LEVEL=max
 ```
@@ -82,7 +82,7 @@ $env:ANTHROPIC_AUTH_TOKEN="<your DeepSeek API Key>"
 $env:ANTHROPIC_MODEL="deepseek-v4-pro[1m]"
 $env:ANTHROPIC_DEFAULT_OPUS_MODEL="deepseek-v4-pro[1m]"
 $env:ANTHROPIC_DEFAULT_SONNET_MODEL="deepseek-v4-pro[1m]"
-$env:ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-v4-flash[1m]"
+$env:ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-v4-flash"
 $env:CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
 $env:CLAUDE_CODE_EFFORT_LEVEL="max"
 ```

--- a/docs/claude_code.zh-CN.md
+++ b/docs/claude_code.zh-CN.md
@@ -52,7 +52,7 @@ Claude Code 可以通过配置文件或环境变量的方法进行配置。在�
     "ANTHROPIC_MODEL": "deepseek-v4-pro[1m]",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-pro[1m]",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash[1m]",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "CLAUDE_CODE_EFFORT_LEVEL": "max"
   }
@@ -69,7 +69,7 @@ export ANTHROPIC_AUTH_TOKEN=<你的 DeepSeek API Key>
 export ANTHROPIC_MODEL=deepseek-v4-pro[1m]
 export ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-pro[1m]
 export ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-pro[1m]
-export ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash[1m]
+export ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash
 export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 export CLAUDE_CODE_EFFORT_LEVEL=max
 ```
@@ -82,7 +82,7 @@ $env:ANTHROPIC_AUTH_TOKEN="<你的 DeepSeek API Key>"
 $env:ANTHROPIC_MODEL="deepseek-v4-pro[1m]"
 $env:ANTHROPIC_DEFAULT_OPUS_MODEL="deepseek-v4-pro[1m]"
 $env:ANTHROPIC_DEFAULT_SONNET_MODEL="deepseek-v4-pro[1m]"
-$env:ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-v4-flash[1m]"
+$env:ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-v4-flash"
 $env:CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
 $env:CLAUDE_CODE_EFFORT_LEVEL="max"
 ```


### PR DESCRIPTION
## Summary

- Remove the unsupported `[1m]` suffix from `deepseek-v4-flash` in the Claude Code English and Simplified Chinese guides.
- Narrow the contributor guidance so `[1m]` is documented for Pro while Flash uses its plain API model ID.
- Keep the existing `deepseek-v4-pro[1m]` configuration unchanged.

The current DeepSeek Claude Code integration guide uses `deepseek-v4-flash` without `[1m]`. The affected repository guidance showed `deepseek-v4-flash[1m]` in all three Claude Code configuration examples, which could lead users to an invalid or unsupported model name. Related user report: #96.

## Validation

- `git diff --check`
- Confirmed no `deepseek-v4-flash[1m]` remains in the affected documentation.
- `npx --yes markdownlint-cli --disable MD001 MD013 MD041 MD060 -- CONTRIBUTING.md docs/claude_code.md docs/claude_code.zh-CN.md` — existing lint findings remain for unlabeled fences, list spacing, inline HTML, and missing image alt text; none were introduced by this change.

Reference: https://api-docs.deepseek.com/quick_start/agent_integrations/claude_code
