### PR TITLE
docs: add OpenAgentd integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **LobeHub** | LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. | [Guide](./docs/lobehub.md) |
 | **nanobot** | Open-source lightweight AI agent with chat platform integration, memory, MCP, and more. | [Guide](./docs/nanobot.md) |
 | **Oh My Pi** | Terminal AI coding agent forked from Pi with OMP-specific tools, model roles, MCP, plugins, and agent workflows. | [Guide](./docs/oh-my-pi.md) |
+| **OpenAgentd** | Mobile-first cockpit for local AI agents supporting multi-agent workflows, CLI, desktop, and mobile. | [Guide](./docs/openagentd.md) |
 | **OpenClaw**    | Open-source personal AI assistant that plugs into chat tools (Feishu, WeChat) and is extensible via Skills. | [Guide](./docs/openclaw.md)    |
 | **OpenCode**    | Open-source AI coding assistant available in terminal, web, and other forms.                                | [Guide](./docs/opencode.md)    |
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,7 @@
 | **LobeHub** | LobeHub 是你的 Chief Agent Operator，通过招聘、排班并报告整个 AI 团队，将你的 Agent 组织成 7×24 小时运作。 | [指南](./docs/lobehub.zh-CN.md) |
 | **nanobot** | 开源轻量级 AI 智能体，支持接入聊天工具、记忆、MCP 等。 | [指南](./docs/nanobot.zh-CN.md) |
 | **Oh My Pi** | 基于 Pi 分支扩展的终端 AI 编程 Agent，提供 OMP 专用工具、模型角色、MCP、插件与 Agent 工作流。 | [指南](./docs/oh-my-pi.zh-CN.md) |
+| **OpenAgentd** | 面向本地 AI Agent 的移动优先 Cockpit，支持多 Agent 协同、CLI、桌面端与移动端。 | [指南](./docs/openagentd.zh-CN.md) |
 | **OpenClaw**    | 开源个人 AI 助手，可接入飞书、微信等聊天工具，并通过 Skill 扩展能力。 | [指南](./docs/openclaw.zh-CN.md)    |
 | **OpenCode**    | 开源 AI 编程助手，提供终端、网页等多种运行形式。                      | [指南](./docs/opencode.zh-CN.md)    |
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |

--- a/docs/openagentd.md
+++ b/docs/openagentd.md
@@ -1,0 +1,98 @@
+[English](./openagentd.md) | [简体中文](./openagentd.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with OpenAgentd
+
+OpenAgentd is an open-source, mobile-first cockpit for local AI agents. It features a FastAPI backend, React Web UI, and cross-platform desktop/mobile Tauri shell with multi-agent orchestration, CLI, and native MCP support.
+
+#### 1. Install OpenAgentd
+
+Install OpenAgentd using `uv` or `pip`:
+
+```bash
+uv tool install openagentd
+```
+
+Or via `pip`:
+
+```bash
+pip install openagentd
+```
+
+Verify the installation:
+
+```bash
+openagentd status
+```
+
+> **Note:** Desktop and mobile app installers are also available on the [OpenAgentd Releases](https://github.com/openagentd/openagentd/releases) page.
+
+#### 2. Configure DeepSeek Provider
+
+OpenAgentd supports DeepSeek out of the box using direct API keys or keyless free models via OpenCode Zen (`opencode:deepseek-v4-flash-free`).
+
+To configure direct DeepSeek API access:
+
+1. Obtain an API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+2. Set the `DEEPSEEK_API_KEY` environment variable:
+
+**Linux / macOS**:
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+```
+
+**Windows (PowerShell)**:
+```powershell
+$env:DEEPSEEK_API_KEY="sk-..."
+```
+
+Alternatively, configure the API key via the Web/Desktop UI in **Settings → Providers → DeepSeek** or add it to `~/.config/openagentd/.env`:
+
+```env
+DEEPSEEK_API_KEY=sk-...
+```
+
+#### 3. Select Model and Configure Agent
+
+Agent configurations live in `~/.config/openagentd/agents/` as Markdown files with YAML frontmatter.
+
+To set your lead agent model to DeepSeek V4:
+
+Edit `~/.config/openagentd/agents/lead.md`:
+
+```yaml
+---
+name: lead
+description: Lead orchestrator agent
+model: deepseek:deepseek-v4-flash
+---
+```
+
+For complex reasoning tasks, use `deepseek-v4-pro`:
+
+```yaml
+---
+name: lead
+description: Lead orchestrator agent
+model: deepseek:deepseek-v4-pro
+---
+```
+
+OpenAgentd natively handles DeepSeek V4 features:
+- Full **1M context window** (1,048,576 tokens).
+- Thinking / reasoning mode support (`thinking: {type: "enabled"}`) and proper handling of reasoning content during agent tool calls.
+
+#### 4. Run OpenAgentd
+
+Launch the OpenAgentd backend service and Web Cockpit:
+
+```bash
+openagentd serve
+```
+
+Or open interactive CLI chat directly in your terminal:
+
+```bash
+openagentd chat
+```
+
+You can also switch models dynamically during a session from the UI agent settings or model picker.

--- a/docs/openagentd.md
+++ b/docs/openagentd.md
@@ -2,17 +2,42 @@
 
 # Integrate with OpenAgentd
 
-OpenAgentd is an open-source, mobile-first cockpit for local AI agents. It features a FastAPI backend, React Web UI, and cross-platform desktop/mobile Tauri shell with multi-agent orchestration, CLI, and native MCP support.
+OpenAgentd is an open-source, mobile-first cockpit for local AI agents. It features a cross-platform desktop app (macOS, Windows, Linux), mobile shell, FastAPI backend, React Web UI, multi-agent orchestration, CLI, and native MCP support.
 
 #### 1. Install OpenAgentd
 
-Install OpenAgentd using `uv` or `pip`:
+You can install OpenAgentd either as a standalone **Desktop App** or as a **CLI / Backend Service**.
+
+##### Option A: Desktop App (Command Line Installer)
+
+Run the one-command installer in your terminal:
+
+**macOS / Linux**:
+```bash
+curl -fsSL https://raw.githubusercontent.com/lthoangg/openagentd/main/install.sh | sh
+```
+
+**Windows (PowerShell)**:
+```powershell
+irm https://raw.githubusercontent.com/lthoangg/openagentd/main/install.ps1 | iex
+```
+
+**Windows (Command Prompt / CMD)**:
+```cmd
+powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/lthoangg/openagentd/main/install.ps1 | iex"
+```
+
+> **Note:** Standalone installers (DMG, MSI, AppImage, Deb) are also available on the [OpenAgentd Releases](https://github.com/lthoangg/openagentd/releases/latest) page. Launch **OpenAgentd** from your Applications folder or Start menu.
+
+##### Option B: CLI / Backend Service
+
+Install via `uv` or `pip`:
 
 ```bash
 uv tool install openagentd
 ```
 
-Or via `pip`:
+Or using `pip`:
 
 ```bash
 pip install openagentd
@@ -21,10 +46,8 @@ pip install openagentd
 Verify the installation:
 
 ```bash
-openagentd status
+openagentd --version
 ```
-
-> **Note:** Desktop and mobile app installers are also available on the [OpenAgentd Releases](https://github.com/openagentd/openagentd/releases) page.
 
 #### 2. Configure DeepSeek Provider
 
@@ -32,10 +55,10 @@ OpenAgentd supports DeepSeek out of the box using direct API keys or keyless fre
 
 To configure direct DeepSeek API access:
 
-1. Obtain an API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+1. Obtain an API key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
 2. Set the `DEEPSEEK_API_KEY` environment variable:
 
-**Linux / macOS**:
+**macOS / Linux**:
 ```bash
 export DEEPSEEK_API_KEY="sk-..."
 ```
@@ -45,11 +68,17 @@ export DEEPSEEK_API_KEY="sk-..."
 $env:DEEPSEEK_API_KEY="sk-..."
 ```
 
-Alternatively, configure the API key via the Web/Desktop UI in **Settings → Providers → DeepSeek** or add it to `~/.config/openagentd/.env`:
-
-```env
-DEEPSEEK_API_KEY=sk-...
+**Windows (CMD)**:
+```cmd
+set DEEPSEEK_API_KEY=sk-...
 ```
+
+Alternatively, configure the API key:
+- In the Web / Desktop UI: **Settings → Providers → DeepSeek**
+- Or in `~/.config/openagentd/.env`:
+  ```env
+  DEEPSEEK_API_KEY=sk-...
+  ```
 
 #### 3. Select Model and Configure Agent
 
@@ -77,22 +106,28 @@ model: deepseek:deepseek-v4-pro
 ---
 ```
 
-OpenAgentd natively handles DeepSeek V4 features:
-- Full **1M context window** (1,048,576 tokens).
-- Thinking / reasoning mode support (`thinking: {type: "enabled"}`) and proper handling of reasoning content during agent tool calls.
+OpenAgentd natively handles DeepSeek V4 capabilities:
+- **1M Context Window**: Full 1,048,576 token context window support.
+- **Thinking / Reasoning Mode**: Native payload configuration (`thinking: {type: "enabled"}`) and proper handling of `reasoning_content` in assistant messages during agent tool turns.
 
 #### 4. Run OpenAgentd
 
-Launch the OpenAgentd backend service and Web Cockpit:
+Launch the OpenAgentd desktop app from your system menu, or run the server from your terminal:
 
 ```bash
-openagentd serve
+openagentd
 ```
 
-Or open interactive CLI chat directly in your terminal:
+For network / LAN access:
+
+```bash
+openagentd start --lan --key
+```
+
+Or launch an interactive CLI chat session:
 
 ```bash
 openagentd chat
 ```
 
-You can also switch models dynamically during a session from the UI agent settings or model picker.
+You can also dynamically switch models at any time from the in-app model selector or agent settings panel.

--- a/docs/openagentd.zh-CN.md
+++ b/docs/openagentd.zh-CN.md
@@ -1,0 +1,98 @@
+[English](./openagentd.md) | [简体中文](./openagentd.zh-CN.md) · [← Back](../README.md)
+
+# 接入 OpenAgentd
+
+OpenAgentd 是一个开源的移动优先本地 AI Agent 控制台（Cockpit）。它包含 FastAPI 后端、React Web UI 以及基于 Tauri 的跨平台桌面端和移动端，原生支持多 Agent 协同、命令行交互与 MCP 协议。
+
+#### 1. 安装 OpenAgentd
+
+可以通过 `uv` 或 `pip` 安装 OpenAgentd：
+
+```bash
+uv tool install openagentd
+```
+
+或者使用 `pip`：
+
+```bash
+pip install openagentd
+```
+
+验证安装是否成功：
+
+```bash
+openagentd status
+```
+
+> **说明：** 桌面端与移动端应用安装包可在 [OpenAgentd Releases](https://github.com/openagentd/openagentd/releases) 页面下载。
+
+#### 2. 配置 DeepSeek 提供商
+
+OpenAgentd 原生支持 DeepSeek，既可以使用自备 API Key 直连，也支持开箱即用的免 Key 免费模型（`opencode:deepseek-v4-flash-free`）。
+
+配置 DeepSeek 官方 API Key 直连步骤如下：
+
+1. 前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
+2. 设置 `DEEPSEEK_API_KEY` 环境变量：
+
+**Linux / macOS**：
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+```
+
+**Windows (PowerShell)**：
+```powershell
+$env:DEEPSEEK_API_KEY="sk-..."
+```
+
+也可以通过 Web / 桌面客户端 UI 在 **设置 → 提供商 → DeepSeek** 中配置，或者在 `~/.config/openagentd/.env` 文件中写入：
+
+```env
+DEEPSEEK_API_KEY=sk-...
+```
+
+#### 3. 选择模型与配置 Agent
+
+OpenAgentd 的 Agent 配置文件保存在 `~/.config/openagentd/agents/` 目录中（包含 YAML frontmatter 的 Markdown 文件）。
+
+将主控 Agent（Lead Agent）模型设置为 DeepSeek V4：
+
+编辑 `~/.config/openagentd/agents/lead.md`：
+
+```yaml
+---
+name: lead
+description: 主控协调 Agent
+model: deepseek:deepseek-v4-flash
+---
+```
+
+如需进行高难度推理编码任务，可选择 `deepseek-v4-pro`：
+
+```yaml
+---
+name: lead
+description: 主控协调 Agent
+model: deepseek:deepseek-v4-pro
+---
+```
+
+OpenAgentd 原生适配 DeepSeek V4 特性：
+- 完整支持 **100 万 Token**（1,048,576）上下文窗口。
+- 支持 DeepSeek 深度思考/推理模式（`thinking: {type: "enabled"}`），并能正确处理 Agent 工具调用过程中的 reasoning content。
+
+#### 4. 开始使用
+
+启动 OpenAgentd 后端服务与 Web 控制台：
+
+```bash
+openagentd serve
+```
+
+或直接在终端启动交互式对话：
+
+```bash
+openagentd chat
+```
+
+你也可以在界面或客户端的设置中随时动态切换模型。

--- a/docs/openagentd.zh-CN.md
+++ b/docs/openagentd.zh-CN.md
@@ -1,4 +1,4 @@
-[English](./openagentd.md) | [简体中文](./openagentd.zh-CN.md) · [← Back](../README.md)
+[English](./openagentd.md) | [简体中文](./openagentd.zh-CN.md) · [← 返回](../README.zh-CN.md)
 
 # 接入 OpenAgentd
 

--- a/docs/openagentd.zh-CN.md
+++ b/docs/openagentd.zh-CN.md
@@ -2,29 +2,52 @@
 
 # 接入 OpenAgentd
 
-OpenAgentd 是一个开源的移动优先本地 AI Agent 控制台（Cockpit）。它包含 FastAPI 后端、React Web UI 以及基于 Tauri 的跨平台桌面端和移动端，原生支持多 Agent 协同、命令行交互与 MCP 协议。
+OpenAgentd 是一个开源的移动优先本地 AI Agent 控制台（Cockpit）。它包含跨平台桌面客户端（macOS、Windows、Linux）、移动端 Shell、FastAPI 后端以及 React Web UI，原生支持多 Agent 协同、命令行交互与 MCP 协议。
 
 #### 1. 安装 OpenAgentd
 
-可以通过 `uv` 或 `pip` 安装 OpenAgentd：
+你可以选择安装 **桌面客户端（Desktop App）** 或 **CLI / 后端服务**。
+
+##### 选项 A：桌面客户端（命令行一键安装）
+
+在终端中运行对应系统的安装命令：
+
+**macOS / Linux**：
+```bash
+curl -fsSL https://raw.githubusercontent.com/lthoangg/openagentd/main/install.sh | sh
+```
+
+**Windows (PowerShell)**：
+```powershell
+irm https://raw.githubusercontent.com/lthoangg/openagentd/main/install.ps1 | iex
+```
+
+**Windows (Command Prompt / CMD)**：
+```cmd
+powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/lthoangg/openagentd/main/install.ps1 | iex"
+```
+
+> **说明：** 桌面端独立安装包（DMG、MSI、AppImage、Deb）也可在 [OpenAgentd Releases](https://github.com/lthoangg/openagentd/releases/latest) 页面下载。安装完成后，可从应用程序文件夹或开始菜单启动 **OpenAgentd**。
+
+##### 选项 B：CLI / 后端服务
+
+使用 `uv` 或 `pip` 安装：
 
 ```bash
 uv tool install openagentd
 ```
 
-或者使用 `pip`：
+或使用 `pip`：
 
 ```bash
 pip install openagentd
 ```
 
-验证安装是否成功：
+验证安装：
 
 ```bash
-openagentd status
+openagentd --version
 ```
-
-> **说明：** 桌面端与移动端应用安装包可在 [OpenAgentd Releases](https://github.com/openagentd/openagentd/releases) 页面下载。
 
 #### 2. 配置 DeepSeek 提供商
 
@@ -35,7 +58,7 @@ OpenAgentd 原生支持 DeepSeek，既可以使用自备 API Key 直连，也支
 1. 前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取 API Key。
 2. 设置 `DEEPSEEK_API_KEY` 环境变量：
 
-**Linux / macOS**：
+**macOS / Linux**：
 ```bash
 export DEEPSEEK_API_KEY="sk-..."
 ```
@@ -45,15 +68,21 @@ export DEEPSEEK_API_KEY="sk-..."
 $env:DEEPSEEK_API_KEY="sk-..."
 ```
 
-也可以通过 Web / 桌面客户端 UI 在 **设置 → 提供商 → DeepSeek** 中配置，或者在 `~/.config/openagentd/.env` 文件中写入：
-
-```env
-DEEPSEEK_API_KEY=sk-...
+**Windows (CMD)**：
+```cmd
+set DEEPSEEK_API_KEY=sk-...
 ```
+
+也可以通过以下方式配置：
+- 在 Web / 桌面客户端 UI 中：**设置 → 提供商 → DeepSeek**
+- 或在 `~/.config/openagentd/.env` 中添加：
+  ```env
+  DEEPSEEK_API_KEY=sk-...
+  ```
 
 #### 3. 选择模型与配置 Agent
 
-OpenAgentd 的 Agent 配置文件保存在 `~/.config/openagentd/agents/` 目录中（包含 YAML frontmatter 的 Markdown 文件）。
+OpenAgentd 的 Agent 配置文件保存在 `~/.config/openagentd/agents/` 目录中（带有 YAML frontmatter 的 Markdown 文件）。
 
 将主控 Agent（Lead Agent）模型设置为 DeepSeek V4：
 
@@ -78,21 +107,27 @@ model: deepseek:deepseek-v4-pro
 ```
 
 OpenAgentd 原生适配 DeepSeek V4 特性：
-- 完整支持 **100 万 Token**（1,048,576）上下文窗口。
-- 支持 DeepSeek 深度思考/推理模式（`thinking: {type: "enabled"}`），并能正确处理 Agent 工具调用过程中的 reasoning content。
+- **100 万 Token 上下文**：完整支持 1,048,576 Token 上下文窗口。
+- **深度思考/推理模式**：原生支持推理开关（`thinking: {type: "enabled"}`）与推理强度控制，并正确处理工具调用过程中的 `reasoning_content`。
 
 #### 4. 开始使用
 
-启动 OpenAgentd 后端服务与 Web 控制台：
+从系统菜单启动 OpenAgentd 桌面应用，或在终端中运行后端服务：
 
 ```bash
-openagentd serve
+openagentd
 ```
 
-或直接在终端启动交互式对话：
+开启局域网/跨设备连接：
+
+```bash
+openagentd start --lan --key
+```
+
+或直接启动终端交互式对话：
 
 ```bash
 openagentd chat
 ```
 
-你也可以在界面或客户端的设置中随时动态切换模型。
+你也可以在应用界面或客户端设置中随时动态切换模型。


### PR DESCRIPTION
This PR adds the integration guide for OpenAgentd to `awesome-deepseek-agent`.

### Summary
- Adds English integration guide (`docs/openagentd.md`)
- Adds Simplified Chinese integration guide (`docs/openagentd.zh-CN.md`)
- Updates tools table in both `README.md` and `README.zh-CN.md` in alphabetical order

### Agent Configuration
- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing)
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation
- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes