### PR TITLE
[codex] add dsh-openclaw-acp integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **dsh-openclaw-acp** | Native Harness bundle that lets OpenClaw channels, including WeChat, invoke DeepSeek Harness through ACP. | [Guide](./docs/dsh_openclaw_acp.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **dsh-openclaw-acp** | 原生 Harness 组合包，让 OpenClaw 的微信等渠道通过 ACP 调用 DeepSeek Harness。 | [指南](./docs/dsh_openclaw_acp.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |

--- a/docs/dsh_openclaw_acp.md
+++ b/docs/dsh_openclaw_acp.md
@@ -24,9 +24,11 @@ Install the current verified Harness release and the bundle:
 
 ```bash
 npm install -g pnpm@10.28.2 @deepseek-ai/dsh@0.1.0-rc.6
-dsh plugin --profile openclaw add github:BeAChanger/dsh-openclaw-acp#v0.1.2
+dsh plugin --profile openclaw add https://github.com/BeAChanger/dsh-openclaw-acp/releases/download/v0.1.2/dsh-openclaw-acp-0.1.2.tgz
 dsh --profile openclaw --dump-config
 ```
+
+This uses the prebuilt release artifact (SHA-256 `c27d863f65d3ce4518e25cc6ef3758b66d956ea51ab11678e4c67d42803d7240`), so installation does not execute a repository build.
 
 The config dump should contain both `id: openclaw-acp` and `name: dsh-openclaw-acp`.
 

--- a/docs/dsh_openclaw_acp.md
+++ b/docs/dsh_openclaw_acp.md
@@ -1,0 +1,151 @@
+[English](./dsh_openclaw_acp.md) | [简体中文](./dsh_openclaw_acp.zh-CN.md) · [← Back](../README.md)
+
+# Use DeepSeek Harness from OpenClaw and WeChat
+
+[`dsh-openclaw-acp`](https://github.com/BeAChanger/dsh-openclaw-acp) is a native DeepSeek Harness bundle that exposes a Harness profile through the official Agent Client Protocol (ACP) transport. OpenClaw's official ACPX plugin can register that profile as an external agent, so any configured OpenClaw channel—including WeChat—can invoke it.
+
+The integration keeps three responsibilities separate:
+
+- DeepSeek Harness owns the agent, DeepSeek model, tools, workspace sandbox, and session log.
+- OpenClaw ACPX owns the ACP process, dispatch, and conversation routing.
+- The OpenClaw channel plugin owns WeChat authentication, sender identity, and message delivery.
+
+The bundle does not read or forward WeChat credentials or sender identifiers; those channel facts remain OpenClaw's responsibility.
+
+## 1. Install DeepSeek Harness and the bundle
+
+Prerequisites:
+
+- Node.js 22 or newer and pnpm 10
+- A [DeepSeek API key](https://platform.deepseek.com/api_keys)
+- OpenClaw with a configured channel; for WeChat, see Tencent's [`openclaw-weixin`](https://github.com/Tencent/openclaw-weixin)
+
+Install the current verified Harness release and the bundle:
+
+```bash
+npm install -g pnpm@10.28.2 @deepseek-ai/dsh@0.1.0-rc.6
+dsh plugin --profile openclaw add github:BeAChanger/dsh-openclaw-acp#v0.1.2
+dsh --profile openclaw --dump-config
+```
+
+The config dump should contain both `id: openclaw-acp` and `name: dsh-openclaw-acp`.
+
+Make the API key available to the OpenClaw Gateway process:
+
+```bash
+export DEEPSEEK_API_KEY="your-api-key"
+```
+
+PowerShell:
+
+```powershell
+$env:DEEPSEEK_API_KEY = "your-api-key"
+```
+
+If OpenClaw runs as a service, configure the variable in the service environment rather than only in an interactive shell.
+
+## 2. Register Harness in OpenClaw
+
+Install and enable OpenClaw's official ACP runtime:
+
+```bash
+openclaw plugins install @openclaw/acpx
+openclaw config set plugins.entries.acpx.enabled true
+```
+
+Add the following settings to the OpenClaw config:
+
+```json5
+{
+  acp: {
+    enabled: true,
+    backend: "acpx",
+    defaultAgent: "deepseek-harness",
+    allowedAgents: ["deepseek-harness"]
+  },
+  plugins: {
+    entries: {
+      acpx: {
+        enabled: true,
+        config: {
+          agents: {
+            "deepseek-harness": {
+              command: "dsh",
+              args: ["--profile", "openclaw"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the Gateway after changing the plugin configuration.
+
+## 3. First run
+
+From an OpenClaw conversation, verify the runtime before delegating real work:
+
+```text
+/acp doctor
+/acp spawn deepseek-harness --cwd /absolute/path/to/workspace
+```
+
+For a WeChat channel, send the same commands in the chat connected to that Gateway. The message path is:
+
+```text
+WeChat -> OpenClaw channel -> ACPX -> dsh --profile openclaw -> DeepSeek Harness
+```
+
+If the channel advertises conversation binding, add `--bind here` to keep follow-up messages on the same ACP session. If it does not, use the unbound one-shot command; OpenClaw relays the completed result to the parent conversation.
+
+## DeepSeek V4 configuration
+
+The bundle uses the verified `deepseek-official` Harness adapter and configures:
+
+- model: `deepseek-v4-flash`
+- thinking: enabled
+- reasoning effort: `max`
+- context window: 1,000,000 tokens
+- output cap: 384,000 tokens
+
+Select DeepSeek V4 Pro in the Gateway environment when the task needs the stronger model:
+
+```bash
+export DSH_OPENCLAW_MODEL=deepseek-v4-pro
+```
+
+The model names are passed through by Harness; both `deepseek-v4-flash` and `deepseek-v4-pro` use the same 1M-context and max-reasoning profile.
+
+## Security and current protocol limits
+
+- OpenClaw's sandbox does not wrap an external ACP process. DeepSeek Harness enforces its own boundary through `DSH_PERMISSION_MODE`; keep the default `workspace-write` mode for normal deployments.
+- ACPX defaults to read approvals. Write or shell tasks can fail until an operator selects a non-interactive permission policy. Use `approve-all` only with a dedicated OS account and restricted workspace; it is not a safe shared-Gateway default.
+- Do not enable OpenClaw's ACPX MCP tool bridges for this target yet. Harness ACP `0.1.0-rc.6` rejects non-empty `mcpServers`.
+- Harness ACP currently supports new sessions only; it does not advertise load, resume, fork, or session listing.
+- The ACP transport returns committed assistant text, not live reasoning or tool events.
+- Persistent chat binding depends on the channel adapter. One-shot parent relay remains available when binding is unsupported.
+
+## Verification evidence
+
+The bundle repository includes unit, package, and real stdio protocol checks. The ACP smoke test installs the packed bundle into an isolated profile, launches the published `dsh` CLI, negotiates ACP, creates a session, and verifies that stdout contains JSON-RPC frames only:
+
+```bash
+git clone https://github.com/BeAChanger/dsh-openclaw-acp.git
+cd dsh-openclaw-acp
+pnpm install
+pnpm test
+pnpm run test:acp
+pnpm audit --prod --audit-level high --registry https://registry.npmjs.org
+```
+
+The protocol smoke does not make a model request, so a real API key is required only for the first live prompt through OpenClaw.
+
+## References
+
+- [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+- [DeepSeek Harness plugin packaging](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/develop/basic/publish.md)
+- [OpenClaw ACP agents](https://github.com/openclaw/openclaw/blob/main/docs/tools/acp-agents.md)
+- [OpenClaw ACPX setup](https://github.com/openclaw/openclaw/blob/main/docs/tools/acp-agents-setup.md)
+- [Tencent OpenClaw WeChat channel](https://github.com/Tencent/openclaw-weixin)

--- a/docs/dsh_openclaw_acp.md
+++ b/docs/dsh_openclaw_acp.md
@@ -55,6 +55,14 @@ openclaw plugins install @openclaw/acpx@2026.7.1
 openclaw config set plugins.entries.acpx.enabled true
 ```
 
+For WeChat, install the Tencent channel version verified with this stack. The final command displays a QR code and requires operator confirmation:
+
+```bash
+openclaw plugins install @tencent-weixin/openclaw-weixin@2.4.6
+openclaw config set plugins.entries.openclaw-weixin.enabled true
+openclaw channels login --channel openclaw-weixin
+```
+
 Add the following settings to the OpenClaw config:
 
 ```json5
@@ -77,6 +85,9 @@ Add the following settings to the OpenClaw config:
             }
           }
         }
+      },
+      "openclaw-weixin": {
+        enabled: true
       }
     }
   }
@@ -98,6 +109,12 @@ For a WeChat channel, send the same commands in the chat connected to that Gatew
 
 ```text
 WeChat -> OpenClaw channel -> ACPX -> dsh --profile openclaw -> DeepSeek Harness
+```
+
+For multiple logged-in WeChat accounts, isolate direct-message sessions by account, channel, and sender:
+
+```bash
+openclaw config set session.dmScope per-account-channel-peer
 ```
 
 If the channel advertises conversation binding, add `--bind here` to keep follow-up messages on the same ACP session. If it does not, use the unbound one-shot command; OpenClaw relays the completed result to the parent conversation.
@@ -142,7 +159,7 @@ pnpm run test:acp
 pnpm audit --prod --audit-level high --registry https://registry.npmjs.org
 ```
 
-The protocol smoke does not make a model request, so a real API key is required only for the first live prompt through OpenClaw.
+The protocol smoke does not make a model request, so a real API key is required only for the first live prompt through OpenClaw. In a separate isolated OpenClaw `2026.7.1-2` state, both `@openclaw/acpx@2026.7.1` and `@tencent-weixin/openclaw-weixin@2.4.6` loaded as enabled plugins with all required dependencies installed; the combined custom-agent, channel, and per-account session configuration passed `openclaw config validate`. QR login and live message delivery remain operator-owned checks.
 
 ## References
 

--- a/docs/dsh_openclaw_acp.md
+++ b/docs/dsh_openclaw_acp.md
@@ -16,9 +16,9 @@ The bundle does not read or forward WeChat credentials or sender identifiers; th
 
 Prerequisites:
 
-- Node.js 22 or newer and pnpm 10
+- pnpm 10 and a Node.js release supported by OpenClaw; stable OpenClaw `2026.7.1-2` requires Node.js 22.22.3+, 24.15.0+, or 25.9.0+
 - A [DeepSeek API key](https://platform.deepseek.com/api_keys)
-- OpenClaw with a configured channel; for WeChat, see Tencent's [`openclaw-weixin`](https://github.com/Tencent/openclaw-weixin)
+- OpenClaw `2026.7.1-2` or newer with a configured channel; for WeChat, see Tencent's [`openclaw-weixin`](https://github.com/Tencent/openclaw-weixin)
 
 Install the current verified Harness release and the bundle:
 
@@ -49,7 +49,7 @@ If OpenClaw runs as a service, configure the variable in the service environment
 Install and enable OpenClaw's official ACP runtime:
 
 ```bash
-openclaw plugins install @openclaw/acpx
+openclaw plugins install @openclaw/acpx@2026.7.1
 openclaw config set plugins.entries.acpx.enabled true
 ```
 

--- a/docs/dsh_openclaw_acp.md
+++ b/docs/dsh_openclaw_acp.md
@@ -24,11 +24,11 @@ Install the current verified Harness release and the bundle:
 
 ```bash
 npm install -g pnpm@10.28.2 @deepseek-ai/dsh@0.1.0-rc.6
-dsh plugin --profile openclaw add https://github.com/BeAChanger/dsh-openclaw-acp/releases/download/v0.1.2/dsh-openclaw-acp-0.1.2.tgz
+dsh plugin --profile openclaw add https://github.com/BeAChanger/dsh-openclaw-acp/releases/download/v0.1.3/dsh-openclaw-acp-0.1.3.tgz
 dsh --profile openclaw --dump-config
 ```
 
-This uses the prebuilt release artifact (SHA-256 `c27d863f65d3ce4518e25cc6ef3758b66d956ea51ab11678e4c67d42803d7240`), so installation does not execute a repository build.
+This uses the prebuilt release artifact (SHA-256 `51ab3d78a7505448b5827b84a79081ae9fd11a5553949eafa3a317b5ee4763fd`), so installation does not execute a repository build. The release also provides a checksum asset.
 
 The config dump should contain both `id: openclaw-acp` and `name: dsh-openclaw-acp`.
 
@@ -131,7 +131,7 @@ The model names are passed through by Harness; both `deepseek-v4-flash` and `dee
 
 ## Verification evidence
 
-The bundle repository includes unit, package, and real stdio protocol checks. The ACP smoke test installs the packed bundle into an isolated profile, launches the published `dsh` CLI, negotiates ACP, creates a session, and verifies that stdout contains JSON-RPC frames only:
+The bundle repository includes unit, package, and real protocol checks. The smoke test installs the packed bundle into an isolated profile, then completes `initialize` and `session/new` twice: first against the published `dsh` CLI directly with JSON-RPC-only stdout, then through a custom-agent registration in the published `acpx@0.11.2` runtime used by OpenClaw's official ACPX plugin:
 
 ```bash
 git clone https://github.com/BeAChanger/dsh-openclaw-acp.git

--- a/docs/dsh_openclaw_acp.zh-CN.md
+++ b/docs/dsh_openclaw_acp.zh-CN.md
@@ -1,0 +1,151 @@
+[English](./dsh_openclaw_acp.md) | [简体中文](./dsh_openclaw_acp.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 从 OpenClaw 和微信调用 DeepSeek Harness
+
+[`dsh-openclaw-acp`](https://github.com/BeAChanger/dsh-openclaw-acp) 是一个原生 DeepSeek Harness 组合包，通过官方 Agent Client Protocol（ACP）传输暴露 Harness profile。OpenClaw 官方 ACPX 插件可以把该 profile 注册为外部 Agent，因此 OpenClaw 已配置的任何渠道——包括微信——都能调用它。
+
+本集成把三类责任明确分开：
+
+- DeepSeek Harness 负责 Agent、DeepSeek 模型、工具、工作区沙箱与会话日志。
+- OpenClaw ACPX 负责 ACP 进程、调度与对话路由。
+- OpenClaw 渠道插件负责微信认证、发送者身份与消息投递。
+
+本组合包不会读取或转发微信凭据与发送者标识；这些渠道信息仍由 OpenClaw 负责。
+
+## 1. 安装 DeepSeek Harness 与组合包
+
+前置条件：
+
+- Node.js 22 或更高版本，以及 pnpm 10
+- 一个 [DeepSeek API Key](https://platform.deepseek.com/api_keys)
+- 已配置渠道的 OpenClaw；微信渠道可参考腾讯 [`openclaw-weixin`](https://github.com/Tencent/openclaw-weixin)
+
+安装当前已验证的 Harness 版本与组合包：
+
+```bash
+npm install -g pnpm@10.28.2 @deepseek-ai/dsh@0.1.0-rc.6
+dsh plugin --profile openclaw add github:BeAChanger/dsh-openclaw-acp#v0.1.2
+dsh --profile openclaw --dump-config
+```
+
+配置输出中应同时出现 `id: openclaw-acp` 和 `name: dsh-openclaw-acp`。
+
+让 OpenClaw Gateway 进程可以读取 API Key：
+
+```bash
+export DEEPSEEK_API_KEY="your-api-key"
+```
+
+PowerShell：
+
+```powershell
+$env:DEEPSEEK_API_KEY = "your-api-key"
+```
+
+如果 OpenClaw 作为系统服务运行，应在服务环境中配置变量，不能只在交互式终端中临时设置。
+
+## 2. 在 OpenClaw 注册 Harness
+
+安装并启用 OpenClaw 官方 ACP runtime：
+
+```bash
+openclaw plugins install @openclaw/acpx
+openclaw config set plugins.entries.acpx.enabled true
+```
+
+把以下设置加入 OpenClaw 配置：
+
+```json5
+{
+  acp: {
+    enabled: true,
+    backend: "acpx",
+    defaultAgent: "deepseek-harness",
+    allowedAgents: ["deepseek-harness"]
+  },
+  plugins: {
+    entries: {
+      acpx: {
+        enabled: true,
+        config: {
+          agents: {
+            "deepseek-harness": {
+              command: "dsh",
+              args: ["--profile", "openclaw"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+修改插件配置后重启 Gateway。
+
+## 3. 首次运行
+
+先在 OpenClaw 对话中验证 runtime，再交付真实任务：
+
+```text
+/acp doctor
+/acp spawn deepseek-harness --cwd /工作区绝对路径
+```
+
+使用微信渠道时，在连接到同一个 Gateway 的微信会话中发送相同命令。消息链路是：
+
+```text
+微信 -> OpenClaw 渠道 -> ACPX -> dsh --profile openclaw -> DeepSeek Harness
+```
+
+如果渠道声明了当前对话绑定能力，可以加 `--bind here`，让后续消息继续进入同一个 ACP 会话。如果渠道没有该能力，就使用不绑定的一次性命令；OpenClaw 会把完成结果回传给父对话。
+
+## DeepSeek V4 配置
+
+组合包使用已验证的 `deepseek-official` Harness 适配器，并配置：
+
+- 模型：`deepseek-v4-flash`
+- thinking：启用
+- 推理强度：`max`
+- 上下文窗口：1,000,000 token
+- 输出上限：384,000 token
+
+任务需要更强模型时，可在 Gateway 环境中选择 DeepSeek V4 Pro：
+
+```bash
+export DSH_OPENCLAW_MODEL=deepseek-v4-pro
+```
+
+Harness 会原样传递模型名；`deepseek-v4-flash` 和 `deepseek-v4-pro` 共用 1M 上下文与最大推理强度 profile。
+
+## 安全边界与当前协议限制
+
+- OpenClaw 沙箱不会包裹外部 ACP 进程。DeepSeek Harness 通过自己的 `DSH_PERMISSION_MODE` 执行边界；普通部署保留默认 `workspace-write`。
+- ACPX 默认只批准读取。写文件或执行 shell 的任务可能在运维者选择非交互权限策略前失败。只有在独立操作系统账号和受限工作区中才使用 `approve-all`；它不适合作为共享 Gateway 的默认值。
+- 暂时不要为此 Agent 启用 OpenClaw ACPX 的 MCP 工具桥。Harness ACP `0.1.0-rc.6` 会拒绝非空 `mcpServers`。
+- Harness ACP 当前只支持新会话，不声明加载、恢复、fork 或会话列表能力。
+- ACP 只返回已提交的 assistant 文本，不转发实时推理或工具事件。
+- 持久对话绑定取决于渠道适配器；不支持绑定时仍可使用一次性父对话回传。
+
+## 验证证据
+
+组合包仓库包含单元、打包和真实 stdio 协议检查。ACP 冒烟测试会把打包产物安装进隔离 profile，启动已发布的 `dsh` CLI，完成 ACP 协商、创建会话，并验证 stdout 只有 JSON-RPC 帧：
+
+```bash
+git clone https://github.com/BeAChanger/dsh-openclaw-acp.git
+cd dsh-openclaw-acp
+pnpm install
+pnpm test
+pnpm run test:acp
+pnpm audit --prod --audit-level high --registry https://registry.npmjs.org
+```
+
+协议冒烟不会发起模型请求；只有首次通过 OpenClaw 发送真实提示词时才需要有效 API Key。
+
+## 参考资料
+
+- [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+- [DeepSeek Harness 插件打包](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/develop/basic/publish.zh.md)
+- [OpenClaw ACP Agent](https://github.com/openclaw/openclaw/blob/main/docs/tools/acp-agents.md)
+- [OpenClaw ACPX 配置](https://github.com/openclaw/openclaw/blob/main/docs/tools/acp-agents-setup.md)
+- [腾讯 OpenClaw 微信渠道](https://github.com/Tencent/openclaw-weixin)

--- a/docs/dsh_openclaw_acp.zh-CN.md
+++ b/docs/dsh_openclaw_acp.zh-CN.md
@@ -24,9 +24,11 @@
 
 ```bash
 npm install -g pnpm@10.28.2 @deepseek-ai/dsh@0.1.0-rc.6
-dsh plugin --profile openclaw add github:BeAChanger/dsh-openclaw-acp#v0.1.2
+dsh plugin --profile openclaw add https://github.com/BeAChanger/dsh-openclaw-acp/releases/download/v0.1.2/dsh-openclaw-acp-0.1.2.tgz
 dsh --profile openclaw --dump-config
 ```
+
+该命令使用预构建的 release 产物（SHA-256：`c27d863f65d3ce4518e25cc6ef3758b66d956ea51ab11678e4c67d42803d7240`），安装时不会执行仓库构建脚本。
 
 配置输出中应同时出现 `id: openclaw-acp` 和 `name: dsh-openclaw-acp`。
 

--- a/docs/dsh_openclaw_acp.zh-CN.md
+++ b/docs/dsh_openclaw_acp.zh-CN.md
@@ -16,9 +16,9 @@
 
 前置条件：
 
-- Node.js 22 或更高版本，以及 pnpm 10
+- pnpm 10，以及 OpenClaw 支持的 Node.js 版本；稳定版 OpenClaw `2026.7.1-2` 要求 Node.js 22.22.3+、24.15.0+ 或 25.9.0+
 - 一个 [DeepSeek API Key](https://platform.deepseek.com/api_keys)
-- 已配置渠道的 OpenClaw；微信渠道可参考腾讯 [`openclaw-weixin`](https://github.com/Tencent/openclaw-weixin)
+- OpenClaw `2026.7.1-2` 或更高版本，并已配置渠道；微信渠道可参考腾讯 [`openclaw-weixin`](https://github.com/Tencent/openclaw-weixin)
 
 安装当前已验证的 Harness 版本与组合包：
 
@@ -49,7 +49,7 @@ $env:DEEPSEEK_API_KEY = "your-api-key"
 安装并启用 OpenClaw 官方 ACP runtime：
 
 ```bash
-openclaw plugins install @openclaw/acpx
+openclaw plugins install @openclaw/acpx@2026.7.1
 openclaw config set plugins.entries.acpx.enabled true
 ```
 

--- a/docs/dsh_openclaw_acp.zh-CN.md
+++ b/docs/dsh_openclaw_acp.zh-CN.md
@@ -24,11 +24,11 @@
 
 ```bash
 npm install -g pnpm@10.28.2 @deepseek-ai/dsh@0.1.0-rc.6
-dsh plugin --profile openclaw add https://github.com/BeAChanger/dsh-openclaw-acp/releases/download/v0.1.2/dsh-openclaw-acp-0.1.2.tgz
+dsh plugin --profile openclaw add https://github.com/BeAChanger/dsh-openclaw-acp/releases/download/v0.1.3/dsh-openclaw-acp-0.1.3.tgz
 dsh --profile openclaw --dump-config
 ```
 
-该命令使用预构建的 release 产物（SHA-256：`c27d863f65d3ce4518e25cc6ef3758b66d956ea51ab11678e4c67d42803d7240`），安装时不会执行仓库构建脚本。
+该命令使用预构建的 release 产物（SHA-256：`51ab3d78a7505448b5827b84a79081ae9fd11a5553949eafa3a317b5ee4763fd`），安装时不会执行仓库构建脚本。Release 同时提供校验文件。
 
 配置输出中应同时出现 `id: openclaw-acp` 和 `name: dsh-openclaw-acp`。
 
@@ -131,7 +131,7 @@ Harness 会原样传递模型名；`deepseek-v4-flash` 和 `deepseek-v4-pro` 共
 
 ## 验证证据
 
-组合包仓库包含单元、打包和真实 stdio 协议检查。ACP 冒烟测试会把打包产物安装进隔离 profile，启动已发布的 `dsh` CLI，完成 ACP 协商、创建会话，并验证 stdout 只有 JSON-RPC 帧：
+组合包仓库包含单元、打包和真实协议检查。冒烟测试会把打包产物安装进隔离 profile，并两次完成 `initialize` 与 `session/new`：先直接启动已发布的 `dsh` CLI 并验证纯 JSON-RPC stdout，再通过 OpenClaw 官方 ACPX 插件所使用的已发布 `acpx@0.11.2` runtime，以自定义 Agent 注册方式拉起该 profile：
 
 ```bash
 git clone https://github.com/BeAChanger/dsh-openclaw-acp.git

--- a/docs/dsh_openclaw_acp.zh-CN.md
+++ b/docs/dsh_openclaw_acp.zh-CN.md
@@ -55,6 +55,14 @@ openclaw plugins install @openclaw/acpx@2026.7.1
 openclaw config set plugins.entries.acpx.enabled true
 ```
 
+如需接入微信，安装本组合已验证的腾讯渠道版本。最后一条命令会显示二维码，必须由运营方确认授权：
+
+```bash
+openclaw plugins install @tencent-weixin/openclaw-weixin@2.4.6
+openclaw config set plugins.entries.openclaw-weixin.enabled true
+openclaw channels login --channel openclaw-weixin
+```
+
 把以下设置加入 OpenClaw 配置：
 
 ```json5
@@ -77,6 +85,9 @@ openclaw config set plugins.entries.acpx.enabled true
             }
           }
         }
+      },
+      "openclaw-weixin": {
+        enabled: true
       }
     }
   }
@@ -98,6 +109,12 @@ openclaw config set plugins.entries.acpx.enabled true
 
 ```text
 微信 -> OpenClaw 渠道 -> ACPX -> dsh --profile openclaw -> DeepSeek Harness
+```
+
+多个微信号同时登录时，建议按账号、渠道和发送者隔离私聊会话：
+
+```bash
+openclaw config set session.dmScope per-account-channel-peer
 ```
 
 如果渠道声明了当前对话绑定能力，可以加 `--bind here`，让后续消息继续进入同一个 ACP 会话。如果渠道没有该能力，就使用不绑定的一次性命令；OpenClaw 会把完成结果回传给父对话。
@@ -142,7 +159,7 @@ pnpm run test:acp
 pnpm audit --prod --audit-level high --registry https://registry.npmjs.org
 ```
 
-协议冒烟不会发起模型请求；只有首次通过 OpenClaw 发送真实提示词时才需要有效 API Key。
+协议冒烟不会发起模型请求；只有首次通过 OpenClaw 发送真实提示词时才需要有效 API Key。另一个隔离的 OpenClaw `2026.7.1-2` 状态目录中，`@openclaw/acpx@2026.7.1` 与 `@tencent-weixin/openclaw-weixin@2.4.6` 均以启用状态成功加载，所有必需依赖完整；包含自定义 Agent、微信渠道和多账号会话隔离的组合配置通过了 `openclaw config validate`。扫码登录与真实消息投递仍需由运营方完成。
 
 ## 参考资料
 


### PR DESCRIPTION
## Summary

Add a bilingual integration guide for [`dsh-openclaw-acp`](https://github.com/BeAChanger/dsh-openclaw-acp), an external DeepSeek Harness bundle that mounts the official `@deepseek-ai/dsh-acp` transport and lets OpenClaw ACPX invoke Harness from configured channels, including WeChat.

This is intentionally an ecosystem plugin, not a Harness core patch:

- Harness owns the agent, model, tools, sandbox, and session log.
- OpenClaw ACPX owns process lifecycle and conversation routing.
- The OpenClaw channel plugin owns WeChat identity and delivery.

## Scope

- add `docs/dsh_openclaw_acp.md`
- add `docs/dsh_openclaw_acp.zh-CN.md`
- add the tool to both README tables in alphabetical order
- cover installation, configuration, first run, security boundaries, and current ACP limitations

## DeepSeek V4 checklist

- [x] current model ids only: `deepseek-v4-flash` and `deepseek-v4-pro`
- [x] 1,000,000-token context window configured and documented
- [x] `max` reasoning effort configured and documented
- [x] 384,000-token output cap configured and documented
- [x] English and Simplified Chinese guides included in one PR
- [x] README entries are in alphabetical order in both languages
- [x] one tool/integration only
- [x] configuration fields verified in the composed Harness profile and stable OpenClaw schema
- [x] no workaround for a fixed upstream bug
- [x] pricing not included; pricing verification is not applicable
- [x] no screenshots required for this CLI/configuration-only guide

## Verification

The linked bundle release is pinned to `v0.1.3` and was verified against `@deepseek-ai/dsh@0.1.0-rc.6`:

- `pnpm test` ? 2/2 tests passed
- `pnpm run test:acp` ? packed-artifact install; direct real-`dsh` ACP initialize/session/new with JSON-RPC-only stdout; then a second custom-agent initialize/session/new through the published `acpx@0.11.2` runtime used by OpenClaw ACPX
- production dependencies are unchanged from `v0.1.2`; its `pnpm audit --prod --audit-level high --registry https://registry.npmjs.org` run reported no known vulnerabilities
- Prebuilt GitHub release tarball install into a fresh profile ? public URL and SHA-256 `51ab3d78a7505448b5827b84a79081ae9fd11a5553949eafa3a317b5ee4763fd` were verified; composed config contains the bundle row, 1M context, max reasoning, and 384k output cap
- OpenClaw `2026.7.1-2` with `@openclaw/acpx@2026.7.1` ? `openclaw config validate` accepted `acp.defaultAgent`, `acp.allowedAgents`, and structured `plugins.entries.acpx.config.agents.<id>.command/args`; the CLI then read the values back unchanged
- Tencent `@tencent-weixin/openclaw-weixin@2.4.6` and `@openclaw/acpx@2026.7.1` were installed together in an isolated OpenClaw state; both reported `loaded`, `enabled`, all required dependencies installed, and the combined channel/custom-agent/per-account-session config passed validation
- a live WeChat delivery test still requires operator-owned Gateway and channel credentials and is not claimed here

The OpenClaw test also caught its actual Node safety gate, so the guide now states the supported ranges for that stable release: Node 22.22.3+, 24.15.0+, or 25.9.0+.

## Non-overlap with open PRs

- #378 documents DeepSeek Harness itself (web/headless and general plugin usage). This PR documents a separate installable tool, `dsh-openclaw-acp`, and its OpenClaw/WeChat ACP boundary.
- #220 rewrites the existing OpenClaw model-provider guide. This PR does not modify `docs/openclaw.md` or `docs/openclaw.zh-CN.md`.

## Current limitations called out in the guide

- Harness ACP `0.1.0-rc.6` rejects non-empty `mcpServers`, so OpenClaw ACPX MCP bridges must remain disabled for this target.
- Harness ACP currently exposes new sessions and committed assistant text; it does not advertise resume/fork/session listing or live reasoning/tool events.
- Persistent conversation binding depends on the OpenClaw channel adapter; one-shot parent relay is the fallback.
