### PR TITLE
Add DSH Studio integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **DSH Studio** | Open-source cross-platform desktop shell that installs, supervises, and hosts DeepSeek Harness locally. | [Guide](./docs/dsh-studio.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **DSH Studio** | 开源跨平台桌面外壳，可在本地安装、监控并承载 DeepSeek Harness。 | [指南](./docs/dsh-studio.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |

--- a/docs/dsh-studio.md
+++ b/docs/dsh-studio.md
@@ -1,0 +1,82 @@
+[English](./dsh-studio.md) | [简体中文](./dsh-studio.zh-CN.md) · [← Back](../README.md)
+
+# Use DeepSeek with DSH Studio
+
+[DSH Studio](https://github.com/Moresyl/dsh-studio) is an MIT-licensed cross-platform desktop shell for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). It installs the upstream harness into an app-private npm prefix, supervises the local service, and hosts the unmodified Harness Web UI.
+
+- **GitHub:** <https://github.com/Moresyl/dsh-studio>
+- **Releases:** <https://github.com/Moresyl/dsh-studio/releases>
+
+## 1. Install DSH Studio
+
+DSH Studio currently requires Node.js 20 or newer. Download the current release for your platform:
+
+| Platform | Package |
+| --- | --- |
+| Windows x64 | `.exe` (NSIS) or `.msi` |
+| macOS Apple Silicon / Intel | `.dmg` |
+| Linux x64 | `.AppImage`, `.deb`, or `.rpm` |
+
+The macOS builds are not yet signed or notarized. On first launch, approve the application in **System Settings → Privacy & Security**.
+
+You can also build from source:
+
+```sh
+git clone https://github.com/Moresyl/dsh-studio.git
+cd dsh-studio
+pnpm install
+pnpm tauri build
+```
+
+## 2. Start DeepSeek Harness
+
+Launch DSH Studio. It detects installed Node.js runtimes and checks for `@deepseek-ai/dsh`.
+
+If the harness is missing, select **Install DeepSeek Harness**. DSH Studio installs it into a private prefix in the app data directory rather than changing the global npm root. After installation, start the service and wait for the Harness Web UI to appear in the same window.
+
+The desktop shell chooses an unused loopback port, monitors the service with HTTP health checks, and restarts it with backoff if it becomes unresponsive. It does not fork or modify the upstream Harness UI.
+
+## 3. Configure the DeepSeek provider
+
+In the embedded Harness Web UI:
+
+1. Open **Settings → Models**.
+2. Find the **DeepSeek** card.
+3. Paste a key from the [DeepSeek Platform](https://platform.deepseek.com/api_keys).
+4. Save the provider.
+
+The key is write-only in the UI and is stored by Harness in its credential store. The model route becomes available immediately; no service restart is required.
+
+The official Harness adapter advertises these models by default:
+
+| Model ID | Suggested use |
+| --- | --- |
+| `deepseek-v4-pro` | Coding, long-running reasoning, and difficult agent tasks |
+| `deepseek-v4-flash` | Lower-latency everyday tasks |
+
+Both default entries use a **1,000,000-token context window**. The adapter enables thinking by default and supports `high` and `max` reasoning effort. Use `max` for difficult coding and multi-step tasks; do not disable thinking as a workaround for provider errors.
+
+## 4. Choose a workspace and run the first task
+
+1. Select a DeepSeek V4 model in the model picker. The selection becomes the default for new sessions.
+2. Select **Choose workspace**, add a local project directory, and choose it.
+3. Start a new session.
+4. Send a task such as:
+
+> Summarize this repository, identify its main packages, and suggest one small verified improvement.
+
+Harness can read and edit workspace files, run commands, delegate work, and maintain a plan. It requests approval for operations that require it under the active permission policy.
+
+## Troubleshooting
+
+- **Harness is not installed** — use the install action in DSH Studio and review the streamed npm output.
+- **Node.js is not detected** — install Node.js 20 or newer, then restart DSH Studio.
+- **`MISSING_CREDENTIAL`** — save the DeepSeek key again under **Settings → Models**.
+- **`UNKNOWN_MODEL`** — select `deepseek-v4-pro` or `deepseek-v4-flash` from the configured provider.
+- **The composer is disabled** — choose a workspace and a model before sending the first task.
+- **The local service stops responding** — DSH Studio probes it every 10 seconds and recycles it after three consecutive failed health checks.
+- **A restart opens a different port** — this is expected. DSH Studio asks the OS for an unused port and follows the new local origin automatically.
+
+## Security notes
+
+DSH Studio binds the service to loopback and does not expose a LAN-listening option. Quitting from the tray stops the supervised process tree; merely closing the window keeps the local service running in the tray.

--- a/docs/dsh-studio.zh-CN.md
+++ b/docs/dsh-studio.zh-CN.md
@@ -1,0 +1,82 @@
+[English](./dsh-studio.md) | [简体中文](./dsh-studio.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 在 DSH Studio 中使用 DeepSeek
+
+[DSH Studio](https://github.com/Moresyl/dsh-studio) 是一个采用 MIT 许可证的 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 跨平台桌面外壳。它会把上游 Harness 安装到应用专属的 npm 目录中，监控本地服务，并直接承载未经修改的 Harness Web UI。
+
+- **GitHub：** <https://github.com/Moresyl/dsh-studio>
+- **发行版：** <https://github.com/Moresyl/dsh-studio/releases>
+
+## 1. 安装 DSH Studio
+
+DSH Studio 目前要求系统已安装 Node.js 20 或更高版本。请下载适合当前平台的发行包：
+
+| 平台 | 安装包 |
+| --- | --- |
+| Windows x64 | `.exe`（NSIS）或 `.msi` |
+| macOS Apple Silicon / Intel | `.dmg` |
+| Linux x64 | `.AppImage`、`.deb` 或 `.rpm` |
+
+macOS 构建目前尚未签名和公证。首次启动时，需要在 **系统设置 → 隐私与安全性** 中允许该应用运行。
+
+也可以从源码构建：
+
+```sh
+git clone https://github.com/Moresyl/dsh-studio.git
+cd dsh-studio
+pnpm install
+pnpm tauri build
+```
+
+## 2. 启动 DeepSeek Harness
+
+启动 DSH Studio。它会检测已安装的 Node.js 运行时，并检查 `@deepseek-ai/dsh` 是否存在。
+
+如果尚未安装 Harness，请选择 **Install DeepSeek Harness**。DSH Studio 会把它安装到应用数据目录中的专属前缀，而不会修改全局 npm 根目录。安装完成后启动服务，等待 Harness Web UI 显示在同一个窗口中。
+
+桌面外壳会选择一个空闲的回环端口，通过 HTTP 健康检查监控服务，并在服务无响应时使用退避策略重启。它不会分叉或修改上游 Harness UI。
+
+## 3. 配置 DeepSeek 提供商
+
+在嵌入的 Harness Web UI 中：
+
+1. 打开 **Settings → Models**。
+2. 找到 **DeepSeek** 卡片。
+3. 粘贴从 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 获取的 API Key。
+4. 保存提供商。
+
+API Key 在 UI 中只写不可读，由 Harness 保存到凭据存储。模型路由会立即可用，无需重启服务。
+
+Harness 官方适配器默认提供以下模型：
+
+| 模型 ID | 建议用途 |
+| --- | --- |
+| `deepseek-v4-pro` | 编程、长程推理和困难的 Agent 任务 |
+| `deepseek-v4-flash` | 对延迟要求较高的日常任务 |
+
+两个默认模型均使用 **1,000,000 token 上下文窗口**。适配器默认启用思考模式，并支持 `high` 和 `max` 推理强度。对于困难的编程和多步骤任务请使用 `max`；不要把关闭思考模式作为规避提供商错误的方案。
+
+## 4. 选择工作区并运行第一个任务
+
+1. 在模型选择器中选择一个 DeepSeek V4 模型，该选择会成为新会话的默认模型。
+2. 选择 **Choose workspace**，添加一个本地项目目录并选中它。
+3. 新建会话。
+4. 发送类似下面的任务：
+
+> 总结这个代码库，指出主要包，并建议一个能够验证的小型改进。
+
+Harness 可以读取和编辑工作区文件、运行命令、委派工作并维护计划。对于当前权限策略要求审批的操作，Web UI 会先请求确认。
+
+## 故障排查
+
+- **Harness 未安装** — 使用 DSH Studio 中的安装操作，并查看实时输出的 npm 日志。
+- **未检测到 Node.js** — 安装 Node.js 20 或更高版本，然后重启 DSH Studio。
+- **`MISSING_CREDENTIAL`** — 在 **Settings → Models** 中重新保存 DeepSeek API Key。
+- **`UNKNOWN_MODEL`** — 从已配置的提供商中选择 `deepseek-v4-pro` 或 `deepseek-v4-flash`。
+- **输入框不可用** — 在发送第一个任务前先选择工作区和模型。
+- **本地服务停止响应** — DSH Studio 每 10 秒探测一次，连续三次健康检查失败后会回收并重启服务。
+- **重启后端口发生变化** — 这是正常行为。DSH Studio 会请求操作系统分配空闲端口，并自动跟随新的本地地址。
+
+## 安全说明
+
+DSH Studio 只把服务绑定到回环地址，不提供局域网监听选项。从托盘中退出会停止受监控的整个进程树；仅关闭窗口则会让本地服务继续在托盘中运行。


### PR DESCRIPTION
See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.

## Summary

Adds a bilingual installation-to-first-run guide for DSH Studio, the MIT-licensed desktop shell for DeepSeek Harness. The guide follows the current Harness Web UI and official DeepSeek provider defaults.

## Checklist

### Agent Configuration

- [x] Model names are current (v4-pro / v4-flash, not v3 names)
- [x] 1M context is configured or mentioned
- [x] Max thinking effort level is supported
- [x] Pricing is current (input, output, cache hit), verified against [DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing) — no pricing is included in this guide
- [x] Config fields are verified to work in the agent
- [x] No workarounds for already-fixed upstream bugs

### Documentation

- [x] Both English and Chinese versions included in a single PR
- [x] README table entry inserted in alphabetical order
- [x] One tool per PR; unrelated tools not combined
- [x] Images placed in `docs/assets/` with descriptive filenames and reasonable sizes — no images are added

## Verification sources

- Harness first-run workflow: https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/guide/index.md
- Provider configuration workflow: https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/guide/providers.md
- Official adapter defaults for V4 models, 1M context, and reasoning effort: https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/llm/llm-deepseek/README.md
- DSH Studio installation, supervision behavior, releases, and platform status: https://github.com/Moresyl/dsh-studio#readme
