### PR TITLE
fix(deepseek-tui): correct China endpoint hostname in BASE_URL guide

### DIFF
--- a/docs/deepseek-tui.md
+++ b/docs/deepseek-tui.md
@@ -68,7 +68,7 @@ By default DeepSeek-TUI uses **DeepSeek-V4-Pro**. Press `Shift+Tab` to cycle rea
 | Variable | Description |
 |---|---|
 | `DEEPSEEK_API_KEY` | API key (overrides config) |
-| `DEEPSEEK_BASE_URL` | API base URL — defaults to `https://api.deepseek.com`; use `https://api.deepseeki.com` for the China endpoint |
+| `DEEPSEEK_BASE_URL` | API base URL — defaults to `https://api.deepseek.com`, which is also the official host for the China endpoint (DeepSeek-TUI exposes `deepseek-cn` as a legacy alias for the same host) |
 | `DEEPSEEK_MODEL` | Override default model |
 | `DEEPSEEK_PROVIDER` | Switch provider — e.g. `nvidia-nim` (uses `NVIDIA_API_KEY`) |
 | `RUST_LOG` | Logging verbosity (e.g. `RUST_LOG=debug`) |

--- a/docs/deepseek-tui.zh-CN.md
+++ b/docs/deepseek-tui.zh-CN.md
@@ -68,7 +68,7 @@ DeepSeek-TUI 默认使用 **DeepSeek-V4-Pro**。按 `Shift+Tab` 切换推理强�
 | 变量 | 说明 |
 |---|---|
 | `DEEPSEEK_API_KEY` | API Key（覆盖配置文件中的值） |
-| `DEEPSEEK_BASE_URL` | API 基址，默认 `https://api.deepseek.com`；中国区使用 `https://api.deepseeki.com` |
+| `DEEPSEEK_BASE_URL` | API 基址，默认 `https://api.deepseek.com`，该主机同时为中国区官方端点（DeepSeek-TUI 的 `deepseek-cn` 仅为同一主机的旧别名） |
 | `DEEPSEEK_MODEL` | 覆盖默认模型 |
 | `DEEPSEEK_PROVIDER` | 切换提供商，例如 `nvidia-nim`（使用 `NVIDIA_API_KEY`） |
 | `RUST_LOG` | 日志级别，例如 `RUST_LOG=debug` |


### PR DESCRIPTION
## What

The DeepSeek-TUI guide listed `https://api.deepseeki.com` as the China endpoint for `DEEPSEEK_BASE_URL`. That hostname does not exist — HTTPS connections fail (status `000`), and it is not referenced anywhere in DeepSeek-TUI's own configuration.

## Why

Following the guide as written would direct users to a non-existent domain for the China endpoint. `CONTRIBUTING.md` states that only configuration options verified to work should be documented.

The upstream `config.example.toml` documents `deepseek-cn` as a legacy alias whose **official host is still `https://api.deepseek.com`** — there is no separate `deepseeki.com` host.

## Change

Update both the English (`docs/deepseek-tui.md`) and Chinese (`docs/deepseek-tui.zh-CN.md`) guides to state that the default host `https://api.deepseek.com` serves the China endpoint, and note `deepseek-cn` as a legacy alias for the same host. One PR, both languages — per the "one tool per PR, both languages in a single PR" rule.

## How verified

- `curl https://api.deepseeki.com` → HTTPS `000` (unreachable)
- `curl https://api.deepseek.com` → `401` (reachable, auth-gated as expected)
- `DeepSeek-TUI/config.example.toml:27`:
  `# provider = "deepseek-cn"  # legacy alias (official host is still https://api.deepseek.com)`
