### PR TITLE
docs: add dsh-session-export integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **dsh-session-export** | Open-source DeepSeek Harness plugin adding a `/transcript` command that exports sessions as human-readable Markdown/JSON transcripts to a host path — tool calls, editor diffs, subagent lineage, token totals. | [Guide](./docs/dsh_session_export.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
-| **dsh-session-export** | Open-source DeepSeek Harness plugin adding a `/transcript` command that exports sessions as human-readable Markdown/JSON transcripts to a host path — tool calls, editor diffs, subagent lineage, token totals. | [Guide](./docs/dsh_session_export.md) |
+| **dsh-session-export** | Open-source DeepSeek Harness plugin: `/transcript` exports sessions as human-readable Markdown/JSON transcripts (tool calls, editor diffs, subagent lineage, token totals) and `/archive` writes raw per-session ZIP backups on any backend incl. SQLite — both to a host path. | [Guide](./docs/dsh_session_export.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
-| **dsh-session-export** | 开源 DeepSeek Harness 插件：新增 `/transcript` 命令，把会话导出为人类可读的 Markdown/JSON 转录并直接写入 Host 路径 —— 含工具调用、编辑器 diff、子代理谱系与 token 汇总。 | [指南](./docs/dsh_session_export.zh-CN.md) |
+| **dsh-session-export** | 开源 DeepSeek Harness 插件：`/transcript` 把会话导出为人类可读的 Markdown/JSON 转录（工具调用、编辑器 diff、子代理谱系、token 汇总），`/archive` 把原始会话日志写成兼容任意后端（含 SQLite）的逐会话 ZIP 备份 —— 均写入 Host 路径。 | [指南](./docs/dsh_session_export.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **dsh-session-export** | 开源 DeepSeek Harness 插件：新增 `/transcript` 命令，把会话导出为人类可读的 Markdown/JSON 转录并直接写入 Host 路径 —— 含工具调用、编辑器 diff、子代理谱系与 token 汇总。 | [指南](./docs/dsh_session_export.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |

--- a/docs/dsh_session_export.md
+++ b/docs/dsh_session_export.md
@@ -1,0 +1,32 @@
+[English](./dsh_session_export.md) | [简体中文](./dsh_session_export.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with dsh-session-export
+
+dsh-session-export is an open-source plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH) — DeepSeek's official agent runtime. It adds a `/transcript` command that exports a finished or running session as a human-readable transcript written directly to a host path. Where the shipped export tooling downloads a raw log ZIP through the browser, this plugin renders what you actually read: the full message flow, tool calls with editor diffs, subagent lineage, and token totals — as Markdown and/or JSON, through any `ctx.sessionQuery` persistence backend (JSONL, SQLite, …).
+
+#### 1. Prerequisite: a DeepSeek Harness installation
+
+This is an out-of-tree DSH plugin, so it rides on an existing [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) setup. No extra API key or model configuration — it reads sessions through DSH's own query engine and inherits whatever provider your harness already uses.
+
+#### 2. Install the plugin into a profile
+
+```
+dsh plugin --profile web add dsh-session-export
+```
+
+The package declares `dsh.bundle`, so it joins the profile's plugin layer stack automatically — no manual composition edits. Restart the `dsh web` process afterwards so the freshly installed layer is loaded.
+
+#### 3. Run `/transcript` in a session
+
+```
+/transcript
+```
+
+The command runs on DSH's human-command plane — zero tokens, the result never enters model history — and writes `transcript-<session>-<timestamp>.md` under `<session working directory>/dsh-transcripts/`.
+
+Useful variants:
+
+- `/transcript --json` — also write a machine-readable JSON document
+- `/transcript --full` — append the log-only events appendix (command lifecycles, compaction markers)
+- `/transcript --out <path>` — custom output path
+- `/transcript --id <sessionId>` — export a different session

--- a/docs/dsh_session_export.md
+++ b/docs/dsh_session_export.md
@@ -2,10 +2,10 @@
 
 # Integrate with dsh-session-export
 
-dsh-session-export is an open-source plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH) — DeepSeek's official agent runtime. It adds a `/transcript` command that exports a finished or running session as a human-readable transcript written directly to a host path. Where the shipped export tooling downloads a raw log ZIP through the browser, this plugin renders what you actually read: the full message flow, tool calls with editor diffs, subagent lineage, and token totals — as Markdown and/or JSON, through any `ctx.sessionQuery` persistence backend (JSONL, SQLite, …).
-
+dsh-session-export is an open-source plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH) — DeepSeek's official agent runtime. It adds a `/transcript` command that exports a finished or running session as a human-readable transcript written directly to a host path, and (since v0.2.0) an `/archive` command that writes raw session logs as per-session ZIP backups on any backend. Where the shipped export tooling downloads a raw log ZIP through the browser, this plugin renders what you actually read: the full message flow, tool calls with editor diffs, subagent lineage, and token totals — as Markdown and/or JSON, through any `ctx.sessionQuery` persistence backend (JSONL, SQLite, …).
 
 - **GitHub:** <https://github.com/kittimzhe/dsh-session-export>
+
 #### 1. Prerequisite: a DeepSeek Harness installation
 
 This is an out-of-tree DSH plugin, so it rides on an existing [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) setup. No extra API key or model configuration — it reads sessions through DSH's own query engine and inherits whatever provider your harness already uses.
@@ -13,7 +13,7 @@ This is an out-of-tree DSH plugin, so it rides on an existing [DeepSeek Harness]
 #### 2. Install the plugin into a profile
 
 ```
-dsh plugin --profile web add dsh-session-export
+dsh plugin --profile web add dsh-session-export@0.2.0
 ```
 
 The package declares `dsh.bundle`, so it joins the profile's plugin layer stack automatically — no manual composition edits. Restart the `dsh web` process afterwards so the freshly installed layer is loaded.
@@ -32,3 +32,18 @@ Useful variants:
 - `/transcript --full` — append the log-only events appendix (command lifecycles, compaction markers)
 - `/transcript --out <path>` — custom output path
 - `/transcript --id <sessionId>` — export a different session
+
+#### 4. Archive raw session logs with `/archive`
+
+```
+/archive
+```
+
+Writes a per-session ZIP (`session.jsonl` + `manifest.json`) to a host path — the complete, replay-validated raw log — useful as a backup or for migration. It reads through `sessionQuery.readSession`, so it works on any persistence backend, including SQLite (the official browser `/export` cannot read SQLite's raw artifacts).
+
+Useful variants:
+
+- `/archive --all` — archive every session in the current project directory
+- `/archive --since 7d` — restrict `--all` to the last 7 days (`7d`/`12h`/`30m`/`90s`)
+- `/archive --id <sessionId>` — a specific session, incl. subagent descendants
+- `/archive --out <dir>` — output directory (default `.dsh-archives/`)

--- a/docs/dsh_session_export.md
+++ b/docs/dsh_session_export.md
@@ -4,6 +4,8 @@
 
 dsh-session-export is an open-source plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH) — DeepSeek's official agent runtime. It adds a `/transcript` command that exports a finished or running session as a human-readable transcript written directly to a host path. Where the shipped export tooling downloads a raw log ZIP through the browser, this plugin renders what you actually read: the full message flow, tool calls with editor diffs, subagent lineage, and token totals — as Markdown and/or JSON, through any `ctx.sessionQuery` persistence backend (JSONL, SQLite, …).
 
+
+- **GitHub:** <https://github.com/kittimzhe/dsh-session-export>
 #### 1. Prerequisite: a DeepSeek Harness installation
 
 This is an out-of-tree DSH plugin, so it rides on an existing [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) setup. No extra API key or model configuration — it reads sessions through DSH's own query engine and inherits whatever provider your harness already uses.

--- a/docs/dsh_session_export.zh-CN.md
+++ b/docs/dsh_session_export.zh-CN.md
@@ -4,6 +4,8 @@
 
 dsh-session-export 是一款面向 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH，DeepSeek 官方 Agent 运行时）的开源插件。它新增 `/transcript` 命令，把已结束或正在运行的会话导出为人类可读的转录，直接写入 Host 文件系统路径。官方自带导出工具走浏览器下载原始日志 ZIP，而本插件渲染的是你真正读到的内容：完整消息流、带编辑器 diff 的工具调用、子代理谱系与 token 汇总 —— 以 Markdown 和/或 JSON 输出，兼容 `ctx.sessionQuery` 之后的任意持久化后端（JSONL、SQLite……）。
 
+
+- **GitHub:** <https://github.com/kittimzhe/dsh-session-export>
 #### 1. 前置条件：DeepSeek Harness 环境
 
 本插件是 DSH 的树外插件，需要已有的 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 环境。无需额外申请 API Key 或配置模型 —— 它通过 DSH 自带的会话查询引擎读取数据，沿用你的 Harness 已配置的模型提供方。

--- a/docs/dsh_session_export.zh-CN.md
+++ b/docs/dsh_session_export.zh-CN.md
@@ -1,0 +1,32 @@
+[English](./dsh_session_export.md) | [简体中文](./dsh_session_export.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 接入 dsh-session-export
+
+dsh-session-export 是一款面向 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH，DeepSeek 官方 Agent 运行时）的开源插件。它新增 `/transcript` 命令，把已结束或正在运行的会话导出为人类可读的转录，直接写入 Host 文件系统路径。官方自带导出工具走浏览器下载原始日志 ZIP，而本插件渲染的是你真正读到的内容：完整消息流、带编辑器 diff 的工具调用、子代理谱系与 token 汇总 —— 以 Markdown 和/或 JSON 输出，兼容 `ctx.sessionQuery` 之后的任意持久化后端（JSONL、SQLite……）。
+
+#### 1. 前置条件：DeepSeek Harness 环境
+
+本插件是 DSH 的树外插件，需要已有的 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 环境。无需额外申请 API Key 或配置模型 —— 它通过 DSH 自带的会话查询引擎读取数据，沿用你的 Harness 已配置的模型提供方。
+
+#### 2. 安装到 profile
+
+```
+dsh plugin --profile web add dsh-session-export
+```
+
+包内声明了 `dsh.bundle`，安装后会自动加入 profile 的插件层栈 —— 无需手动改组合配置。安装后重启 `dsh web` 进程，让新层生效。
+
+#### 3. 在会话中运行 `/transcript`
+
+```
+/transcript
+```
+
+该命令运行在 DSH 的人类命令平面上 —— 零 token 消耗，结果不会进入模型历史 —— 并在 `<会话工作目录>/dsh-transcripts/` 下生成 `transcript-<session>-<timestamp>.md`。
+
+常用变体：
+
+- `/transcript --json` —— 同时输出机器可读的 JSON 文档
+- `/transcript --full` —— 附上 log-only 事件附录（命令生命周期、压缩标记）
+- `/transcript --out <path>` —— 自定义输出路径
+- `/transcript --id <sessionId>` —— 导出其他会话

--- a/docs/dsh_session_export.zh-CN.md
+++ b/docs/dsh_session_export.zh-CN.md
@@ -2,10 +2,10 @@
 
 # 接入 dsh-session-export
 
-dsh-session-export 是一款面向 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH，DeepSeek 官方 Agent 运行时）的开源插件。它新增 `/transcript` 命令，把已结束或正在运行的会话导出为人类可读的转录，直接写入 Host 文件系统路径。官方自带导出工具走浏览器下载原始日志 ZIP，而本插件渲染的是你真正读到的内容：完整消息流、带编辑器 diff 的工具调用、子代理谱系与 token 汇总 —— 以 Markdown 和/或 JSON 输出，兼容 `ctx.sessionQuery` 之后的任意持久化后端（JSONL、SQLite……）。
-
+dsh-session-export 是一款面向 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH，DeepSeek 官方 Agent 运行时）的开源插件。它新增 `/transcript` 命令，把已结束或正在运行的会话导出为人类可读的转录，直接写入 Host 文件系统路径；自 v0.2.0 起还提供 `/archive` 命令，把原始会话日志写成兼容任意后端的逐会话 ZIP 备份。官方自带导出工具走浏览器下载原始日志 ZIP，而本插件渲染的是你真正读到的内容：完整消息流、带编辑器 diff 的工具调用、子代理谱系与 token 汇总 —— 以 Markdown 和/或 JSON 输出，兼容 `ctx.sessionQuery` 之后的任意持久化后端（JSONL、SQLite……）。
 
 - **GitHub:** <https://github.com/kittimzhe/dsh-session-export>
+
 #### 1. 前置条件：DeepSeek Harness 环境
 
 本插件是 DSH 的树外插件，需要已有的 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 环境。无需额外申请 API Key 或配置模型 —— 它通过 DSH 自带的会话查询引擎读取数据，沿用你的 Harness 已配置的模型提供方。
@@ -13,7 +13,7 @@ dsh-session-export 是一款面向 [DeepSeek Harness](https://github.com/deepsee
 #### 2. 安装到 profile
 
 ```
-dsh plugin --profile web add dsh-session-export
+dsh plugin --profile web add dsh-session-export@0.2.0
 ```
 
 包内声明了 `dsh.bundle`，安装后会自动加入 profile 的插件层栈 —— 无需手动改组合配置。安装后重启 `dsh web` 进程，让新层生效。
@@ -32,3 +32,18 @@ dsh plugin --profile web add dsh-session-export
 - `/transcript --full` —— 附上 log-only 事件附录（命令生命周期、压缩标记）
 - `/transcript --out <path>` —— 自定义输出路径
 - `/transcript --id <sessionId>` —— 导出其他会话
+
+#### 4. 用 `/archive` 归档原始会话日志
+
+```
+/archive
+```
+
+把每个会话写成一个 ZIP（`session.jsonl` + `manifest.json`）落到 Host 路径 —— 完整、replay 校验过的原始日志 —— 适合备份或迁移。它走 `sessionQuery.readSession`，因此兼容任意持久化后端，包括 SQLite（官方浏览器 `/export` 无法读取 SQLite 的 raw artifact）。
+
+常用变体：
+
+- `/archive --all` —— 归档当前项目目录下的全部会话
+- `/archive --since 7d` —— 限定 `--all` 只取最近 7 天（`7d`/`12h`/`30m`/`90s`）
+- `/archive --id <sessionId>` —— 指定会话，含子代理后代
+- `/archive --out <dir>` —— 输出目录（默认 `.dsh-archives/`）


### PR DESCRIPTION
## What

Adds an integration guide for **dsh-session-export** — an open-source out-of-tree plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). It ships two commands: `/transcript` exports a session as a human-readable Markdown/JSON transcript to a host path, and `/archive` (v0.2.0) writes raw session logs as per-session ZIP backups.

## Why

DeepSeek Harness's CONTRIBUTING encourages ecosystem growth via out-of-tree plugins. The shipped `@deepseek-ai/dsh-session-log-export` is browser-download-only and JSONL-only (its README lists these under "Known Limitations"); this plugin writes to a host path and works with any `ctx.sessionQuery` backend. `/archive` specifically covers the SQLite gap: SQLite persistence declares `supportsRawArtifacts: false`, so the official `/export` cannot read it, while `/archive` reads through `sessionQuery.readSession`.

## Verification

`/transcript` (v0.1.0): every command in the guide was executed and verified locally against real sessions — npm install → auto-activation via `dsh.bundle` → `/transcript` in the web UI with `--json`/`--full`/`--out`/`--id` variants.

`/archive` (v0.2.0): parser + execution path covered by 46 unit tests, and ZIP output validated with a real `unzip -t` (CRC32 + deflate + UTF-8 round-trip). The SQLite claim is pinned at the source — `session-persistence-sqlite/src/index.ts:55` (`supportsRawArtifacts = false`) vs the official exporter's `readRaw` at `session-log-export/src/archive.ts:243`.

Plugin source: https://github.com/kittimzhe/dsh-session-export (MIT).

## Checklist

- [x] Bilingual guide in a single PR
- [x] README table entries in both READMEs, alphabetical order
- [x] One tool per PR
- [x] Only verified configuration documented

*Disclosure: I'm the plugin's author; it's MIT-licensed. `/transcript` was verified live in the web UI; `/archive` is covered by unit tests + real ZIP validation (end-to-end UI run pending a fresh API key).*