### PR TITLE
docs: add dsh-session-recall integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Crush**       | Glamorous open-source AI coding agent for the terminal with multi-model support and LSP integration.        | [Guide](./docs/crush.md)       |
 | **Deep Code** | Open-source terminal AI coding assistant for the DeepSeek-V4 model with deep thinking, reasoning effort control, and Agent Skills. | [Guide](./docs/deepcode.md) |
 | **DeepSeek-TUI** | Open-source Rust terminal coding assistant for DeepSeek-V4 — Codex-style architecture, sandboxed tools, MCP client + server, 1M context. | [Guide](./docs/deepseek-tui.md) |
+| **dsh-session-recall** | Open-source DeepSeek Harness plugin giving the agent a `recall` tool that full-text searches its own past session transcripts via `ctx.sessionQuery` — cwd-scoped by default, with a persistent on-disk FTS index. | [Guide](./docs/dsh_session_recall.md) |
 | **GitHub Copilot** | AI peer programmer built into VS Code. | [Guide](./docs/github_copilot.md) |
 | **GitHub Copilot CLI** | Terminal-native AI coding assistant with agentic capabilities. | [Guide](./docs/copilot_cli.md) |
 | **Hermes**      | Open-source self-improving AI agent built by Nous Research.                                                 | [Guide](./docs/hermes.md)      |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@
 | **Crush** | 华丽的开源终端 AI 编程 Agent，支持多模型与 LSP 集成。 | [指南](./docs/crush.zh-CN.md) |
 | **Deep Code** | 开源的终端 AI 编程助手，专为 DeepSeek-V4 系列模型适配，支持深度思考、推理强度控制与 Agent Skills。 | [指南](./docs/deepcode.zh-CN.md) |
 | **DeepSeek-TUI** | 面向 DeepSeek-V4 的开源 Rust 终端编程助手 —— Codex 风格架构，沙箱化工具执行，内置 MCP 客户端与服务器，支持 100 万 token 上下文。 | [指南](./docs/deepseek-tui.zh-CN.md) |
+| **dsh-session-recall** | 开源 DeepSeek Harness 插件：给 agent 提供可全文检索自己全部历史会话原文的 `recall` 工具（走 `ctx.sessionQuery` 缝，默认限定当前项目目录，FTS 索引持久化落盘）。 | [指南](./docs/dsh_session_recall.zh-CN.md) |
 | **GitHub Copilot** | 内置于 VS Code 的 AI 编程助手。 | [指南](./docs/github_copilot.zh-CN.md) |
 | **GitHub Copilot CLI** | 终端原生的 AI 编程助手，支持 Agent 能力。 | [指南](./docs/copilot_cli.zh-CN.md) |
 | **Hermes**      | 开源自我进化 AI 助手。                                                | [指南](./docs/hermes.zh-CN.md)      |

--- a/docs/dsh_session_recall.md
+++ b/docs/dsh_session_recall.md
@@ -1,0 +1,29 @@
+[English](./dsh_session_recall.md) | [简体中文](./dsh_session_recall.zh-CN.md) · [← Back](../README.md)
+
+# Integrate with dsh-session-recall
+
+dsh-session-recall is an open-source plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH) — DeepSeek's official agent runtime. It gives the agent a `recall` tool that full-text searches its own past session transcripts: "that bug we fixed last week", "the font we chose for my resume". The official `@deepseek-ai/dsh-session-query` service deliberately ships no model-facing tool and no caller authorization; this plugin fills both gaps through the trusted `ctx.sessionQuery` seam — scoping every call to the calling agent's project directory by default — and turns the harness's opt-in FTS index into a persistent on-disk database.
+
+#### 1. Prerequisite: a DeepSeek Harness installation
+
+This is an out-of-tree DSH plugin, so it rides on an existing [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) setup. No extra API key — it searches sessions through DSH's own query engine and inherits whatever provider your harness already uses.
+
+#### 2. Install the plugin into a profile
+
+```
+dsh plugin --profile web add dsh-session-recall
+```
+
+The package declares `dsh.bundle`, so it joins the profile's plugin layer stack automatically. Its bundle patch additionally enables the FTS index (`openAt: first-search`) and points it at a persistent database under `<DSH_HOME>/session-recall/`, replacing the shipped in-memory default. Restart the `dsh web` process afterwards so the freshly installed layer is loaded.
+
+#### 3. Ask about the past
+
+Just talk to the agent:
+
+> "What did we do about the resume template font last week?"
+
+The model calls `recall` on its own whenever the user refers to earlier work or when prior context was compacted away. Each hit returns the best-matching event snippet per session — title, date, session id — and renders as a native search card in the Web UI. Variants the model uses as needed:
+
+- `all_projects: true` — search sessions from every project directory, not just the current one
+- `session_id` — search the events of one specific session
+- `limit` / `cursor` — page through results

--- a/docs/dsh_session_recall.zh-CN.md
+++ b/docs/dsh_session_recall.zh-CN.md
@@ -1,0 +1,29 @@
+[English](./dsh_session_recall.md) | [简体中文](./dsh_session_recall.zh-CN.md) · [← Back](../README.md)
+
+# 集成 dsh-session-recall
+
+dsh-session-recall 是 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH，DeepSeek 官方 Agent 运行时）的开源插件。它给 agent 提供一个 `recall` 工具，可以全文检索自己过往的会话原文："上周修的那个 bug"、"简历选的什么字体"。官方 `@deepseek-ai/dsh-session-query` 服务刻意不提供模型可调用的工具和调用方授权；本插件通过可信的 `ctx.sessionQuery` 缝补齐这两点——默认把每次调用限定在调用方 agent 的项目目录内——并把 Harness 默认关闭的 FTS 索引改为持久化落盘。
+
+#### 1. 前置条件：已安装 DeepSeek Harness
+
+这是一个 DSH out-of-tree 插件，需要先有 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 环境。不需要额外 API key——检索走 DSH 自己的查询引擎，沿用 Harness 已配置的任意 provider。
+
+#### 2. 把插件装进 profile
+
+```
+dsh plugin --profile web add dsh-session-recall
+```
+
+包声明了 `dsh.bundle`，会自动加入 profile 的插件层栈。它的 bundle patch 还会开启 FTS 索引（`openAt: first-search`）并指向 `<DSH_HOME>/session-recall/` 下的持久化数据库，替换官方默认的内存索引。之后重启 `dsh web` 进程，让新安装的层生效。
+
+#### 3. 直接问过去的事
+
+正常对话即可：
+
+> "上周简历模板的字体是怎么改的？"
+
+当用户提到之前做过的事、或早期上下文被压缩掉时，模型会自己调用 `recall`。每条命中返回该会话最强匹配事件的摘要——标题、日期、会话 id——并在 Web UI 里渲染成原生搜索卡片。模型按需使用的变体：
+
+- `all_projects: true` —— 搜索所有项目目录的会话，而不只是当前项目
+- `session_id` —— 只搜某一个会话内的事件
+- `limit` / `cursor` —— 翻页


### PR DESCRIPTION
## What

Adds an integration guide for **dsh-session-recall** — an open-source out-of-tree plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) that gives the agent a `recall` tool full-text searching its own past session transcripts through the trusted `ctx.sessionQuery` seam.

## Why

The official `@deepseek-ai/dsh-session-query` README explicitly lists "No registries or model-facing tool" and "No caller authorization" as deferred work, and the shipped web profile keeps its FTS index off (`openAt: never`) and in-memory. This plugin fills both gaps: a typed model-facing tool scoped to the calling agent's project cwd by default, plus a bundle patch that turns the index into a persistent on-disk database.

## Verification

End-to-end on a real headless profile against 31 live sessions: install via `dsh plugin add` (published as [dsh-session-recall@0.1.0](https://www.npmjs.com/package/dsh-session-recall)), `--dump-config` patch-composition check, bilingual queries hitting real history across project directories, persistent 16MB FTS index at `<DSH_HOME>/session-recall/index.db`. Plugin source: https://github.com/kittimzhe/dsh-session-recall (MIT).

## Checklist

- [x] Bilingual guide in a single PR
- [x] README table entries in both READMEs, alphabetical order
- [x] One tool per PR
- [x] Only verified configuration documented

*Disclosure: I'm the plugin's author; it's MIT-licensed and the guide documents only commands I executed myself. Companion to #399 (dsh-session-export) — happy to rebase if that lands first.*