### PR TITLE
docs: add SandBase Harness integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Qwen Code** | Coding agent CLI by the Alibaba Qwen team — now with built-in DeepSeek provider support. | [Guide](./docs/qwen_code.md) |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
+| **SandBase Harness** | Local-first runtime for persistent and auditable AI agent sessions, with DeepSeek V4 support and a stdio MCP bridge. | [Guide](./docs/sandbase_harness.md) |
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
 
 ## Resources

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,6 +36,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Qwen Code** | 阿里巴巴通义千问团队推出的 Coding Agent CLI，现已全面支持 DeepSeek 提供商。 | [指南](./docs/qwen_code.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
+| **SandBase Harness** | 本地优先的持久化、可审计 AI Agent 运行时，支持 DeepSeek V4 和 stdio MCP Bridge。 | [指南](./docs/sandbase_harness.zh-CN.md) |
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
 
 ## 相关资源

--- a/docs/sandbase_harness.md
+++ b/docs/sandbase_harness.md
@@ -1,0 +1,72 @@
+[English](./sandbase_harness.md) | [简体中文](./sandbase_harness.zh-CN.md) · [← Back](../README.md)
+
+# Integrate SandBase Harness with DeepSeek V4
+
+SandBase Harness is a local-first runtime for persistent and auditable AI agent sessions. It supports DeepSeek V4 through DeepSeek's OpenAI-compatible API and can expose the runtime to DeepSeek Harness through a stdio MCP bridge.
+
+- **GitHub:** <https://github.com/sandbaseai/sandbase-harness>
+- **Runtime documentation:** <https://github.com/sandbaseai/sandbase-harness/blob/main/docs/deepseek-v4.md>
+
+#### 1. Install SandBase Harness
+
+Use the tagged source release so the runtime and its MCP integration are reproducible:
+
+```sh
+git clone --branch v0.3.8 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness
+npm ci
+npm run build:runtime
+mkdir ../my-agents
+cd ../my-agents
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
+```
+
+SandBase Harness requires Node.js 22 or newer. The runtime serves its local API on `http://127.0.0.1:3000` by default.
+
+#### 2. Configure DeepSeek V4
+
+Create an API key at the [DeepSeek Platform](https://platform.deepseek.com/api_keys), then export it for the runtime process:
+
+```sh
+export DEEPSEEK_API_KEY="<your DeepSeek API key>"
+```
+
+Open `http://127.0.0.1:3000/dashboard`, go to **Settings > Models**, switch to JSON, and save:
+
+```json
+{
+  "vendor": "openai_compatible",
+  "base_url": "https://api.deepseek.com/v1",
+  "api_key": "${DEEPSEEK_API_KEY}",
+  "options": {
+    "reasoning_effort": "max"
+  }
+}
+```
+
+Create an agent with model `deepseek-v4-pro` for the strongest coding and agent performance, or `deepseek-v4-flash` for lower latency. DeepSeek V4 supports up to 1 million tokens of context; SandBase Harness compacts long sessions automatically.
+
+#### 3. Run the first session
+
+In the Console, select the agent and start a session with a small verification task, such as:
+
+```text
+Inspect this project, summarize its test command, and do not modify any files.
+```
+
+The runtime keeps the session, tool activity, artifacts, and terminal metadata available for inspection and replay. Do not commit API keys to the workspace.
+
+#### Optional: connect DeepSeek Harness through MCP
+
+Build the runtime as above, then from a DeepSeek Harness workspace run:
+
+```sh
+export MANAGED_AGENTS_URL=http://127.0.0.1:3000
+curl --fail --silent --show-error "$MANAGED_AGENTS_URL/v1/x/health"
+dsh plugin --profile web add -w ../sandbase-harness
+dsh web
+```
+
+The installed bundle exposes managed agents, persistent sessions, streamed turns, artifacts, and cancellation through the `mcp__sandbase__*` namespace. If runtime authentication is enabled, also set `MANAGED_AGENTS_API_KEY` before starting DeepSeek Harness.
+

--- a/docs/sandbase_harness.zh-CN.md
+++ b/docs/sandbase_harness.zh-CN.md
@@ -1,0 +1,72 @@
+[English](./sandbase_harness.md) | [简体中文](./sandbase_harness.zh-CN.md) · [← 返回](../README.zh-CN.md)
+
+# 将 SandBase Harness 接入 DeepSeek V4
+
+SandBase Harness 是一个本地优先的 AI Agent 运行时，用于持久化、可审计的 Agent 会话。它通过 DeepSeek 的 OpenAI 兼容 API 支持 DeepSeek V4，也可以通过 stdio MCP Bridge 将运行时接入 DeepSeek Harness。
+
+- **GitHub：** <https://github.com/sandbaseai/sandbase-harness>
+- **运行时文档：** <https://github.com/sandbaseai/sandbase-harness/blob/main/docs/deepseek-v4.md>
+
+#### 1. 安装 SandBase Harness
+
+使用带标签的源码版本，保证运行时和 MCP 集成可复现：
+
+```sh
+git clone --branch v0.3.8 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness
+npm ci
+npm run build:runtime
+mkdir ../my-agents
+cd ../my-agents
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
+```
+
+SandBase Harness 需要 Node.js 22 或更高版本。运行时默认在 `http://127.0.0.1:3000` 提供本地 API。
+
+#### 2. 配置 DeepSeek V4
+
+在 [DeepSeek Platform](https://platform.deepseek.com/api_keys) 创建 API Key，然后为运行时进程设置环境变量：
+
+```sh
+export DEEPSEEK_API_KEY="<你的 DeepSeek API Key>"
+```
+
+打开 `http://127.0.0.1:3000/dashboard`，进入 **Settings > Models**，切换到 JSON 并保存：
+
+```json
+{
+  "vendor": "openai_compatible",
+  "base_url": "https://api.deepseek.com/v1",
+  "api_key": "${DEEPSEEK_API_KEY}",
+  "options": {
+    "reasoning_effort": "max"
+  }
+}
+```
+
+创建 Agent 时，使用 `deepseek-v4-pro` 获得更强的编码和 Agent 能力；如果更关注延迟，可使用 `deepseek-v4-flash`。DeepSeek V4 支持最高 100 万 Token 上下文；SandBase Harness 会自动压缩过长会话。
+
+#### 3. 运行第一个会话
+
+在 Console 中选择 Agent，使用一个小型验证任务启动会话，例如：
+
+```text
+检查这个项目，说明它的测试命令，不要修改任何文件。
+```
+
+运行时会保留会话、工具活动、产物和终止事件元数据，便于检查与回放。不要将 API Key 提交到工作区。
+
+#### 可选：通过 MCP 连接 DeepSeek Harness
+
+按上面的步骤构建运行时，然后在 DeepSeek Harness 工作区中运行：
+
+```sh
+export MANAGED_AGENTS_URL=http://127.0.0.1:3000
+curl --fail --silent --show-error "$MANAGED_AGENTS_URL/v1/x/health"
+dsh plugin --profile web add -w ../sandbase-harness
+dsh web
+```
+
+安装后的 Bundle 会通过 `mcp__sandbase__*` 命名空间暴露 Agent、持久化会话、流式轮次、产物和取消操作。如果运行时启用了认证，请在启动 DeepSeek Harness 前同时设置 `MANAGED_AGENTS_API_KEY`。
+


### PR DESCRIPTION
## Summary

Add a bilingual integration guide for SandBase Harness, a local-first runtime for persistent and auditable AI agent sessions.

The guide covers:
- installation from the tagged v0.3.8 source release;
- DeepSeek V4 configuration through the OpenAI-compatible API;
- the current model IDs, 1M context note, and max reasoning effort;
- first session verification; and
- the optional stdio MCP connection to DeepSeek Harness.

All commands and configuration are based on the upstream SandBase Harness documentation:
https://github.com/sandbaseai/sandbase-harness/blob/main/docs/deepseek-v4.md
https://github.com/sandbaseai/sandbase-harness/blob/main/examples/deepseek-harness/README.md
