### PR TITLE
docs: add SandBase Harness DeepSeek guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Each guide walks through installation, configuration, and first run — so you c
 | **Pi**          | Minimal, extensible terminal coding harness with tree-structured sessions and custom providers.               | [Guide](./docs/pi_mono.md)     |
 | **Qwen Code** | Coding agent CLI by the Alibaba Qwen team — now with built-in DeepSeek provider support. | [Guide](./docs/qwen_code.md) |
 | **Reasonix**    | DeepSeek-native coding agent that runs in the terminal — cache-first loop, MCP-native.                      | [Guide](./docs/reasonix.md)    |
+| **SandBase Harness** | Local-first, self-hosted runtime for durable agent sessions and governed MCP tools. | [Guide](./docs/sandbase_harness.md) |
 | **WorkBuddy/CodeBuddy** | AI agent and coding assistant with custom OpenAI-compatible model configuration. | [Guide](./docs/workbuddy.md) |
 
 ## Resources

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,6 +36,7 @@
 | **Pi** | 极简且高度可扩展的终端编码框架，支持树状会话和自定义供应商。 | [指南](./docs/pi_mono.zh-CN.md) |
 | **Qwen Code** | 阿里巴巴通义千问团队推出的 Coding Agent CLI，现已全面支持 DeepSeek 提供商。 | [指南](./docs/qwen_code.zh-CN.md) |
 | **Reasonix** | 运行在终端内的 DeepSeek 原生编程 Agent —— Cache-First 循环，原生支持 MCP。 | [指南](./docs/reasonix.zh-CN.md) |
+| **SandBase Harness** | 本地优先、可自托管的运行时，用于持久 Agent 会话和受治理的 MCP 工具。 | [指南](./docs/sandbase_harness.zh-CN.md) |
 | **WorkBuddy/CodeBuddy** | 支持自定义 OpenAI 兼容模型配置的 AI Agent 与编程助手。 | [指南](./docs/workbuddy.zh-CN.md) |
 
 ## 相关资源

--- a/docs/sandbase_harness.md
+++ b/docs/sandbase_harness.md
@@ -1,0 +1,72 @@
+# SandBase Harness with DeepSeek
+
+This guide connects DeepSeek Harness to a local SandBase Harness runtime over MCP. SandBase owns durable sessions, tool governance, approvals, credentials, audit, and replay; it is not a hosted model provider. The DeepSeek model remains configured in DeepSeek Harness.
+
+## Prerequisites
+
+- Node.js 22+ and npm 10+
+- DeepSeek Harness with stdio MCP support
+- A DeepSeek API key or another provider supported by DeepSeek Harness
+- Docker when using the published bridge image
+
+Use the current DeepSeek V4 model names `deepseek-v4-pro` or `deepseek-v4-flash`; do not use deprecated V3 model names. DeepSeek V4 supports up to 1 million tokens of context. When DeepSeek Harness exposes these controls, use its documented 1M context setting and maximum thinking/reasoning level. Provider-specific keys belong in DeepSeek Harness configuration and are not invented here.
+
+## 1. Install and start SandBase Harness
+
+```bash
+git clone --branch v0.3.8 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness
+npm ci
+npm run build:runtime
+mkdir ../sandbase-workspace && cd ../sandbase-workspace
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
+```
+
+The default local provider runs as the OS user. For stronger isolation, configure Docker or Kubernetes using the [deployment guide](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/deployment.md); isolation and resource boundaries depend on the selected backend and deployment.
+
+## 2. Configure MCP and the model
+
+From the sibling workspace, install the source checkout into the DeepSeek Harness Web profile:
+
+```bash
+export MANAGED_AGENTS_URL=http://127.0.0.1:3000
+# Set MANAGED_AGENTS_API_KEY only when runtime authentication is enabled.
+cd ../sandbase-workspace
+dsh plugin --profile web add -w ../sandbase-harness
+dsh web
+```
+
+In DeepSeek Harness' own provider settings, select `deepseek-v4-pro` for maximum reasoning or `deepseek-v4-flash` for lower latency. Follow its current documentation for endpoint, API key, context-window, and thinking controls. SandBase is the MCP/runtime layer and does not replace model configuration.
+
+The bridge connects only to `MANAGED_AGENTS_URL`; keep API keys out of committed files and screenshots. The source-checkout path also avoids confusion with the unrelated unscoped npm package named `managed-agents`.
+
+## 3. First run
+
+Ask the DeepSeek Harness Web session to list agents, create a session, run a short task, inspect the result, and list artifacts. The bridge exposes `list_agents`, `create_session`, `run_session`, `get_session`, `list_artifacts`, and `stop_session`.
+
+Verify the runtime before troubleshooting MCP:
+
+```bash
+curl --fail --silent --show-error "$MANAGED_AGENTS_URL/v1/x/health"
+curl --fail --silent --show-error "$MANAGED_AGENTS_URL/v1/agents"
+```
+
+If the second request requires authentication, repeat it with the runtime's accepted bearer key. A successful health check does not prove MCP data-API access.
+
+## Troubleshooting and scope
+
+- `MCP startup failed`: run `npm run build:runtime` and confirm `dist/mcp/index.js` exists.
+- `fetch failed`: start the runtime and check `MANAGED_AGENTS_URL`.
+- `401` or `403`: set `MANAGED_AGENTS_API_KEY` only when required.
+- No SandBase tools: verify that the Web profile installed the sibling checkout and inspect DSH startup logs.
+
+Session data and artifacts remain in the configured SandBase workspace. Local process, Docker, Kubernetes, and worker backends do not provide identical isolation; evaluate the selected backend and deployment configuration before running untrusted work. This is not a security certification.
+
+## Sources
+
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness)
+- [v0.3.8 release](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.8)
+- [Installation and MCP configuration](https://github.com/sandbaseai/sandbase-harness/blob/main/llms-install.md)
+- [DeepSeek Harness integration example](https://github.com/sandbaseai/sandbase-harness/tree/main/examples/deepseek-harness)
+- [DeepSeek API documentation](https://api-docs.deepseek.com/)

--- a/docs/sandbase_harness.zh-CN.md
+++ b/docs/sandbase_harness.zh-CN.md
@@ -1,0 +1,72 @@
+# 在 DeepSeek Harness 中使用 SandBase Harness
+
+本指南通过 MCP 将 DeepSeek Harness 连接到本地 SandBase Harness 运行时。SandBase 负责持久会话、工具治理、审批、凭据、审计和回放；它不是托管模型服务，DeepSeek 模型仍由 DeepSeek Harness 配置。
+
+## 前置条件
+
+- Node.js 22+ 和 npm 10+
+- 支持 stdio MCP 的 DeepSeek Harness
+- DeepSeek API key，或 DeepSeek Harness 支持的其他供应商
+- 使用已发布 bridge 镜像时需要 Docker
+
+请使用当前 DeepSeek V4 名称 `deepseek-v4-pro` 或 `deepseek-v4-flash`，不要使用已弃用的 V3 模型名称。DeepSeek V4 支持最高 100 万 token 上下文。当 DeepSeek Harness 暴露这些控制项时，按其文档启用 1M 上下文和最大思考/推理级别；本文不虚构供应商配置字段。
+
+## 1. 安装并启动 SandBase Harness
+
+```bash
+git clone --branch v0.3.8 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness
+npm ci
+npm run build:runtime
+mkdir ../sandbase-workspace && cd ../sandbase-workspace
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
+```
+
+默认 local provider 使用操作系统用户运行。需要更强隔离时，请按照[部署指南](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/deployment.md)配置 Docker 或 Kubernetes；隔离和资源边界取决于后端及部署配置。
+
+## 2. 配置 MCP 和模型
+
+从旁边的 workspace 将源码目录安装到 DeepSeek Harness Web profile：
+
+```bash
+export MANAGED_AGENTS_URL=http://127.0.0.1:3000
+# 只有运行时启用认证时才设置 MANAGED_AGENTS_API_KEY。
+cd ../sandbase-workspace
+dsh plugin --profile web add -w ../sandbase-harness
+dsh web
+```
+
+在 DeepSeek Harness 自身的供应商设置中选择 `deepseek-v4-pro`（最高推理）或 `deepseek-v4-flash`（较低延迟），并按其当前文档配置 endpoint、key、上下文窗口和思考控制。SandBase 是 MCP/运行时层，不替代模型配置。
+
+bridge 只连接 `MANAGED_AGENTS_URL`。不要把 API key 写入提交文件或截图；使用源码目录也可避免与另一个无 scope 的 npm `managed-agents` 包混淆。
+
+## 3. 首次运行
+
+在 DeepSeek Harness Web 会话中，让它列出 Agent、创建会话、运行一个简短任务、查看结果并列出 artifact。bridge 工具包括 `list_agents`、`create_session`、`run_session`、`get_session`、`list_artifacts` 和 `stop_session`。
+
+排查 MCP 前先验证运行时：
+
+```bash
+curl --fail --silent --show-error "$MANAGED_AGENTS_URL/v1/x/health"
+curl --fail --silent --show-error "$MANAGED_AGENTS_URL/v1/agents"
+```
+
+如果第二个请求需要认证，请使用运行时接受的 bearer key 重试。health 成功不代表 MCP 已获得 agents API 权限。
+
+## 故障排查与边界
+
+- `MCP startup failed`：执行 `npm run build:runtime`，确认 `dist/mcp/index.js` 存在。
+- `fetch failed`：启动运行时并检查 `MANAGED_AGENTS_URL`。
+- `401` 或 `403`：仅在运行时要求时设置 `MANAGED_AGENTS_API_KEY`。
+- 没有 SandBase 工具：确认 Web profile 安装了旁边的源码目录，并检查 DSH 启动日志。
+
+会话数据和 artifact 保存在配置的 SandBase workspace。local process、Docker、Kubernetes 和 worker 后端不提供相同隔离能力；运行不受信任任务前请评估所选后端和部署配置。本文不构成安全认证。
+
+## 来源
+
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness)
+- [v0.3.8 release](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.8)
+- [安装与 MCP 配置](https://github.com/sandbaseai/sandbase-harness/blob/main/llms-install.md)
+- [DeepSeek Harness 集成示例](https://github.com/sandbaseai/sandbase-harness/tree/main/examples/deepseek-harness)
+- [DeepSeek API 文档](https://api-docs.deepseek.com/)


### PR DESCRIPTION
## Summary
- add English and Simplified Chinese DeepSeek Harness integration guides for SandBase Harness
- document installation, MCP configuration, first run, troubleshooting, and backend-dependent isolation
- use current DeepSeek V4 naming and mention the 1M context / maximum reasoning guidance without inventing provider-specific keys
- add both alphabetically ordered README table entries

## Verification
- `git diff --check` passes
- the diff contains no deprecated V3 model names
- sources: https://github.com/sandbaseai/sandbase-harness/tree/main/examples/deepseek-harness and https://github.com/sandbaseai/sandbase-harness/blob/main/llms-install.md

I maintain/contribute to SandBase Harness and disclose that affiliation. The guide makes no hosted-service, benchmark, endorsement, or security-certification claim; effective isolation depends on backend/deployment configuration.