### PR TITLE
docs: update guides for DeepSeek V4.1 Flash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,25 +27,26 @@ Before submitting, verify these items. PRs missing any of them will be flagged d
 ### 1. Model Naming
 
 ```
-❌ deepseek-chat / deepseek-reasoner / deepseek-coder   (V3, deprecated)
-✅ deepseek-v4-pro / deepseek-v4-flash                   (current)
+❌ deepseek-chat / deepseek-reasoner / deepseek-coder   (V3, retired)
+❌ deepseek-v4-flash / deepseek-v4-flash-vision-exp     (compatibility aliases)
+✅ deepseek-flash                                       (current)
 ```
 
-DeepSeek renamed its models in April 2026. All code examples, config snippets, and prose must use the current names. Search your diff for `deepseek-chat` — if you find it, fix it.
+DeepSeek introduced the canonical `deepseek-flash` model ID in September 2026. All code examples, config snippets, and prose must use the current name. The retired Flash IDs remain temporary compatibility aliases, while `deepseek-v4-pro` routes to V4.1 Flash beginning September 14, 2026.
 
 ### 2. 1M Context Window
 
-DeepSeek V4 models support up to **1 million tokens** of context. Make sure your configuration reflects this:
+DeepSeek V4.1 Flash supports up to **1 million tokens** of context. Make sure your configuration reflects this:
 
-- **Claude Code / Anthropic-compatible**: append `[1m]` to model names, e.g. `deepseek-v4-pro[1m]`
+- **Claude Code / Anthropic-compatible**: append `[1m]` to model names, e.g. `deepseek-flash[1m]`
 - **OpenAI-compatible configs**: set `context_window: 1000000` / `max_tokens: 384000` where the tool supports it
-- **Other tools**: at minimum, note in prose that DeepSeek V4 supports 1M context
+- **Other tools**: at minimum, note in prose that DeepSeek V4.1 Flash supports 1M context
 
 If the tool doesn't expose a context window config, mention it in the description so users are aware.
 
 ### 3. Max Thinking / Reasoning Effort
 
-DeepSeek V4 Pro supports multiple reasoning effort levels (`max` and `high`). Your guide should be compatible with the `max` level so users get the best coding experience. See [Thinking Mode docs](https://api-docs.deepseek.com/guides/thinking_mode) for details.
+DeepSeek V4.1 Flash supports multiple reasoning effort levels (`max` and `high`). Your guide should be compatible with the `max` level so users get the best coding experience. See [Thinking Mode docs](https://api-docs.deepseek.com/guides/thinking_mode) for details.
 
 - **Claude Code**: `CLAUDE_CODE_EFFORT_LEVEL=max` (or equivalent `settings.json` config)
 - **Anthropic-compatible endpoint**: set `thinking: { type: "enabled" }` with max budget
@@ -59,8 +60,8 @@ If your guide includes pricing tables, always verify the numbers against the off
 
 | Model | Input / M tokens | Output / M tokens | Cache Hit / M tokens |
 |-------|-----------------|-------------------|----------------------|
-| deepseek-v4-pro | $0.435 | $0.87 | $0.003625 |
-| deepseek-v4-flash | $0.14 | $0.28 | $0.0028 |
+| deepseek-flash (off-peak) | $0.15 | $0.60 | $0.003 |
+| deepseek-flash (peak) | $0.30 | $1.20 | $0.006 |
 
 ## Common Pitfalls
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 A curated list of guides for integrating **DeepSeek** models into popular AI agent and coding-assistant tools.
 
-Each guide walks through installation, configuration, and first run — so you can start using DeepSeek-V4-Pro or DeepSeek-V4-Flash inside your favorite tool in a few minutes.
+Each guide walks through installation, configuration, and first run — so you can start using DeepSeek-V4.1-Flash inside your favorite tool in a few minutes.
+
+> **September 2026 update:** Use `deepseek-flash` for the latest V4.1 Flash model. It includes native visual understanding. The retired `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` IDs temporarily route to V4.1 Flash; `deepseek-v4-pro` will do the same starting September 14, 2026.
 
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,9 @@
 
 精选的 **DeepSeek** 模型接入指南合集，帮助你将 DeepSeek 接入主流 AI Agent 与编程助手工具。
 
-每份指南都包含安装、配置与首次运行的完整步骤，几分钟即可在你喜爱的工具中用上 DeepSeek-V4-Pro 或 DeepSeek-V4-Flash。
+每份指南都包含安装、配置与首次运行的完整步骤，几分钟即可在你喜爱的工具中用上 DeepSeek-V4.1-Flash。
+
+> **2026 年 9 月更新：** 请使用 `deepseek-flash` 调用最新的 V4.1 Flash 模型；该模型原生支持视觉理解。已退役的 `deepseek-v4-flash` 与 `deepseek-v4-flash-vision-exp` 暂时路由到 V4.1 Flash；`deepseek-v4-pro` 也将从 2026 年 9 月 14 日起路由到该模型。
 
 </div>
 

--- a/docs/cherry_studio.md
+++ b/docs/cherry_studio.md
@@ -23,7 +23,7 @@ Open Cherry Studio and click the gear icon in the lower-left corner to open **Se
 
 1. Open **Model Provider** in the left navigation and select **DeepSeek** from the built-in providers list.
 2. Paste your [DeepSeek API Key](https://platform.deepseek.com/api_keys) into the **API Key** field. Leave **API Host** as the default `https://api.deepseek.com`.
-3. Click **Fetch model list** to load the available DeepSeek models, then add **`deepseek-v4-pro`** and **`deepseek-v4-flash`** to the model list.
+3. Click **Fetch model list** to load the available DeepSeek models, then add **`deepseek-flash`** to the model list.
 4. Toggle the switch in the top-right of the DeepSeek provider page to enable it.
 
 <div align="center">
@@ -32,7 +32,7 @@ Open Cherry Studio and click the gear icon in the lower-left corner to open **Se
 
 #### 3. Start Chatting
 
-Open the **Agents** tab from the top navigation, click **+ Agents**, give your agent a name, set **Model** to **`deepseek-v4-pro`** (or **`deepseek-v4-flash`**), pick a permission mode, and click **Add**.
+Open the **Agents** tab from the top navigation, click **+ Agents**, give your agent a name, set **Model** to **`deepseek-flash`**, pick a permission mode, and click **Add**.
 
 <div align="center">
 <img src="./assets/cherry_studio_add_agent.png" width="720" border="1" />

--- a/docs/cherry_studio.zh-CN.md
+++ b/docs/cherry_studio.zh-CN.md
@@ -21,7 +21,7 @@ Cherry Studio 是一款面向 Windows / macOS / Linux 的开源桌面 AI 客户�
 
 1. 在左侧导航中打开 **模型服务**，在内置 Provider 列表里找到 **深度求索（DeepSeek）**。
 2. 将 [DeepSeek API Key](https://platform.deepseek.com/api_keys) 粘贴到 **API 密钥** 字段，**API 地址** 保持默认值 `https://api.deepseek.com`。
-3. 点击 **获取模型列表** 拉取可用模型，将 **`deepseek-v4-pro`** 与 **`deepseek-v4-flash`** 添加到模型列表。
+3. 点击 **获取模型列表** 拉取可用模型，将 **`deepseek-flash`** 添加到模型列表。
 4. 打开 DeepSeek 服务页面右上角的开关，启用该 Provider。
 
 <div align="center">
@@ -30,7 +30,7 @@ Cherry Studio 是一款面向 Windows / macOS / Linux 的开源桌面 AI 客户�
 
 #### 3. 开始对话
 
-进入顶部 **智能体** 页面，点击 **+ 智能体**，填写名称，**模型** 选择 **`deepseek-v4-pro`**（或 **`deepseek-v4-flash`**），按需选择权限模式，点击 **添加**。
+进入顶部 **智能体** 页面，点击 **+ 智能体**，填写名称，**模型** 选择 **`deepseek-flash`**，按需选择权限模式，点击 **添加**。
 
 <div align="center">
 <img src="./assets/cherry_studio_add_agent.zh-CN.png" width="720" border="1" />

--- a/docs/claude_code.md
+++ b/docs/claude_code.md
@@ -49,10 +49,10 @@ Configuration file content:
   "env": {
     "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
     "ANTHROPIC_AUTH_TOKEN": "<your DeepSeek API Key>",
-    "ANTHROPIC_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash[1m]",
+    "ANTHROPIC_MODEL": "deepseek-flash[1m]",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-flash[1m]",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-flash[1m]",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-flash[1m]",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "CLAUDE_CODE_EFFORT_LEVEL": "max"
   }
@@ -66,10 +66,10 @@ Linux / Mac users, run the following commands to configure environment variables
 ```
 export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
 export ANTHROPIC_AUTH_TOKEN=<your DeepSeek API Key>
-export ANTHROPIC_MODEL=deepseek-v4-pro[1m]
-export ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-pro[1m]
-export ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-pro[1m]
-export ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash[1m]
+export ANTHROPIC_MODEL=deepseek-flash[1m]
+export ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-flash[1m]
+export ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-flash[1m]
+export ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-flash[1m]
 export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 export CLAUDE_CODE_EFFORT_LEVEL=max
 ```
@@ -79,10 +79,10 @@ Windows users, run:
 ```
 $env:ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
 $env:ANTHROPIC_AUTH_TOKEN="<your DeepSeek API Key>"
-$env:ANTHROPIC_MODEL="deepseek-v4-pro[1m]"
-$env:ANTHROPIC_DEFAULT_OPUS_MODEL="deepseek-v4-pro[1m]"
-$env:ANTHROPIC_DEFAULT_SONNET_MODEL="deepseek-v4-pro[1m]"
-$env:ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-v4-flash[1m]"
+$env:ANTHROPIC_MODEL="deepseek-flash[1m]"
+$env:ANTHROPIC_DEFAULT_OPUS_MODEL="deepseek-flash[1m]"
+$env:ANTHROPIC_DEFAULT_SONNET_MODEL="deepseek-flash[1m]"
+$env:ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-flash[1m]"
 $env:CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
 $env:CLAUDE_CODE_EFFORT_LEVEL="max"
 ```

--- a/docs/claude_code.zh-CN.md
+++ b/docs/claude_code.zh-CN.md
@@ -49,10 +49,10 @@ Claude Code 可以通过配置文件或环境变量的方法进行配置。在�
   "env": {
     "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
     "ANTHROPIC_AUTH_TOKEN": "<你的 DeepSeek API Key>",
-    "ANTHROPIC_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash[1m]",
+    "ANTHROPIC_MODEL": "deepseek-flash[1m]",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-flash[1m]",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-flash[1m]",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-flash[1m]",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "CLAUDE_CODE_EFFORT_LEVEL": "max"
   }
@@ -66,10 +66,10 @@ Linux / Mac 用户执行以下命令配置 [DeepSeek Anthropic API](https://api.
 ```
 export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
 export ANTHROPIC_AUTH_TOKEN=<你的 DeepSeek API Key>
-export ANTHROPIC_MODEL=deepseek-v4-pro[1m]
-export ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-pro[1m]
-export ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-pro[1m]
-export ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash[1m]
+export ANTHROPIC_MODEL=deepseek-flash[1m]
+export ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-flash[1m]
+export ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-flash[1m]
+export ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-flash[1m]
 export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 export CLAUDE_CODE_EFFORT_LEVEL=max
 ```
@@ -79,10 +79,10 @@ Windows 用户执行：
 ```
 $env:ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
 $env:ANTHROPIC_AUTH_TOKEN="<你的 DeepSeek API Key>"
-$env:ANTHROPIC_MODEL="deepseek-v4-pro[1m]"
-$env:ANTHROPIC_DEFAULT_OPUS_MODEL="deepseek-v4-pro[1m]"
-$env:ANTHROPIC_DEFAULT_SONNET_MODEL="deepseek-v4-pro[1m]"
-$env:ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-v4-flash[1m]"
+$env:ANTHROPIC_MODEL="deepseek-flash[1m]"
+$env:ANTHROPIC_DEFAULT_OPUS_MODEL="deepseek-flash[1m]"
+$env:ANTHROPIC_DEFAULT_SONNET_MODEL="deepseek-flash[1m]"
+$env:ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-flash[1m]"
 $env:CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
 $env:CLAUDE_CODE_EFFORT_LEVEL="max"
 ```

--- a/docs/cline.md
+++ b/docs/cline.md
@@ -36,7 +36,7 @@ Cline is an AI coding assistant that runs as a VS Code extension, supporting mul
 - Enter your [DeepSeek API Key](https://platform.deepseek.com/api_keys).
 - Select the model you want to use.
 
-> **Note:** `deepseek-reasoner` and `deepseek-chat` models will be deprecated soon. Please wait for Cline to officially add `deepseek-v4-pro` and `deepseek-v4-flash` models.
+> **Note:** `deepseek-reasoner` and `deepseek-chat` are retired. If Cline's built-in DeepSeek provider does not list `deepseek-flash` yet, use the OpenAI-compatible setup below.
 
 <div align="center">
 <img src="./assets/cline_step_4_a.png" width="250" border="1" />
@@ -53,7 +53,7 @@ After configuration, you can start using Cline:
 - Select **API Provider** as **OpenAI Compatible**.
 - Set **Base URL** to `https://api.deepseek.com`.
 - Enter your [DeepSeek API Key](https://platform.deepseek.com/api_keys).
-- Enter **Model ID**, e.g. `deepseek-v4-pro`.
+- Enter **Model ID**, e.g. `deepseek-flash`.
 - (Optional) Click **Model Configuration** to adjust window size, temperature, pricing, and limits.
 
 <div align="center">

--- a/docs/cline.zh-CN.md
+++ b/docs/cline.zh-CN.md
@@ -36,7 +36,7 @@ Cline 是一款运行在 VS Code 中的 AI 编程助手扩展，支持多种 API
 - 填入你的 [DeepSeek API Key](https://platform.deepseek.com/api_keys)。
 - 选择要使用的模型。
 
-> **注意：** `deepseek-reasoner` 和 `deepseek-chat` 模型即将废弃，请等待 Cline 官方添加 `deepseek-v4-pro` 和 `deepseek-v4-flash` 模型。
+> **注意：** `deepseek-reasoner` 和 `deepseek-chat` 已退役。如果 Cline 内置的 DeepSeek Provider 尚未列出 `deepseek-flash`，请使用下方的 OpenAI Compatible 配置。
 
 <div align="center">
 <img src="./assets/cline_step_4_a.png" width="250" border="1" />
@@ -53,7 +53,7 @@ Cline 是一款运行在 VS Code 中的 AI 编程助手扩展，支持多种 API
 - 选择 **API Provider** 为 **OpenAI Compatible**。
 - **Base URL** 填入 `https://api.deepseek.com`。
 - 填入你的 [DeepSeek API Key](https://platform.deepseek.com/api_keys)。
-- 填入 **Model ID**，如 `deepseek-v4-pro`。
+- 填入 **Model ID**，如 `deepseek-flash`。
 - （选做）点击 **Model Configuration**，调整窗口大小、温度、价格和限量等参数。
 
 <div align="center">

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -43,7 +43,7 @@ server:
   addr: "127.0.0.1:38440"
 
 models:
-  deepseek-v4-pro:
+  deepseek-flash:
     context_window: 1000000
     max_output_tokens: 384000
     default_reasoning_level: "high"
@@ -57,32 +57,16 @@ models:
     extensions:
       deepseek_v4:
         enabled: true
-  deepseek-v4-flash:
-    context_window: 1000000
-    max_output_tokens: 384000
-    default_reasoning_level: "high"
-    supported_reasoning_levels:
-      - effort: "high"
-        description: "High reasoning effort"
-      - effort: "xhigh"
-        description: "Extra high reasoning effort"
-    supports_reasoning_summaries: true
-    default_reasoning_summary: "auto"
-    extensions:
-      deepseek_v4:
-        enabled: true
-
 providers:
   deepseek:
     base_url: "https://api.deepseek.com/anthropic"
     api_key: "sk-your-deepseek-api-key"
     offers:
-      - model: deepseek-v4-pro
-      - model: deepseek-v4-flash
+      - model: deepseek-flash
 
 routes:
   moonbridge:
-    model: deepseek-v4-pro
+    model: deepseek-flash
     provider: deepseek
 
 defaults:
@@ -90,7 +74,7 @@ defaults:
   max_tokens: 65536
 ```
 
-This minimal config uses the current Moon Bridge configuration structure and enables DeepSeek V4 Pro / Flash, Codex model metadata, and the DeepSeek V4 compatibility extension. **For image input, Web Search, or multi-provider routing**, extend it with the options from Moon Bridge's `config.example.yml`.
+This minimal config uses the current Moon Bridge configuration structure and enables DeepSeek V4.1 Flash, Codex model metadata, and the DeepSeek V4 compatibility extension. **For image input, Web Search, or multi-provider routing**, extend it with the options from Moon Bridge's `config.example.yml`.
 
 #### 4. Start Moon Bridge
 

--- a/docs/codex.zh-CN.md
+++ b/docs/codex.zh-CN.md
@@ -43,7 +43,7 @@ server:
   addr: "127.0.0.1:38440"
 
 models:
-  deepseek-v4-pro:
+  deepseek-flash:
     context_window: 1000000
     max_output_tokens: 384000
     default_reasoning_level: "high"
@@ -57,32 +57,16 @@ models:
     extensions:
       deepseek_v4:
         enabled: true
-  deepseek-v4-flash:
-    context_window: 1000000
-    max_output_tokens: 384000
-    default_reasoning_level: "high"
-    supported_reasoning_levels:
-      - effort: "high"
-        description: "High reasoning effort"
-      - effort: "xhigh"
-        description: "Extra high reasoning effort"
-    supports_reasoning_summaries: true
-    default_reasoning_summary: "auto"
-    extensions:
-      deepseek_v4:
-        enabled: true
-
 providers:
   deepseek:
     base_url: "https://api.deepseek.com/anthropic"
     api_key: "sk-your-deepseek-api-key"
     offers:
-      - model: deepseek-v4-pro
-      - model: deepseek-v4-flash
+      - model: deepseek-flash
 
 routes:
   moonbridge:
-    model: deepseek-v4-pro
+    model: deepseek-flash
     provider: deepseek
 
 defaults:
@@ -90,7 +74,7 @@ defaults:
   max_tokens: 65536
 ```
 
-这个最小配置使用当前 Moon Bridge 配置结构，启用 DeepSeek V4 Pro / Flash、Codex 模型元数据和 DeepSeek V4 兼容扩展。**如果需要图片输入、Web Search 或多 Provider 路由**，可以再参考 Moon Bridge 的 `config.example.yml` 扩展配置。
+这个最小配置使用当前 Moon Bridge 配置结构，启用 DeepSeek V4.1 Flash、Codex 模型元数据和 DeepSeek V4 兼容扩展。**如果需要图片输入、Web Search 或多 Provider 路由**，可以再参考 Moon Bridge 的 `config.example.yml` 扩展配置。
 
 #### 4. 启动 Moon Bridge
 

--- a/docs/copilot_cli.md
+++ b/docs/copilot_cli.md
@@ -27,7 +27,7 @@ Linux / Mac:
 export COPILOT_PROVIDER_TYPE=anthropic
 export COPILOT_PROVIDER_BASE_URL=https://api.deepseek.com/anthropic
 export COPILOT_PROVIDER_API_KEY=sk-your-deepseek-api-key
-export COPILOT_MODEL=deepseek-v4-pro
+export COPILOT_MODEL=deepseek-flash
 ```
 
 Windows (PowerShell):
@@ -36,10 +36,10 @@ Windows (PowerShell):
 $env:COPILOT_PROVIDER_TYPE="anthropic"
 $env:COPILOT_PROVIDER_BASE_URL="https://api.deepseek.com/anthropic"
 $env:COPILOT_PROVIDER_API_KEY="sk-your-deepseek-api-key"
-$env:COPILOT_MODEL="deepseek-v4-pro"
+$env:COPILOT_MODEL="deepseek-flash"
 ```
 
-Available models: `deepseek-v4-pro`, `deepseek-v4-flash`. Switch by changing `COPILOT_MODEL`.
+Available models: `deepseek-flash`. Switch by changing `COPILOT_MODEL`.
 
 #### 4. Start Copilot CLI
 
@@ -51,7 +51,7 @@ Full agent mode, tool calling, and MCP support — all powered by DeepSeek.
 
 #### Optional: Token Limits
 
-Since `deepseek-v4-pro` is not in Copilot CLI's built-in model catalog, configure the token limits explicitly:
+Since `deepseek-flash` is not in Copilot CLI's built-in model catalog, configure the token limits explicitly:
 
 Linux / Mac:
 

--- a/docs/copilot_cli.zh-CN.md
+++ b/docs/copilot_cli.zh-CN.md
@@ -27,7 +27,7 @@ Linux / Mac：
 export COPILOT_PROVIDER_TYPE=anthropic
 export COPILOT_PROVIDER_BASE_URL=https://api.deepseek.com/anthropic
 export COPILOT_PROVIDER_API_KEY=sk-your-deepseek-api-key
-export COPILOT_MODEL=deepseek-v4-pro
+export COPILOT_MODEL=deepseek-flash
 ```
 
 Windows（PowerShell）：
@@ -36,10 +36,10 @@ Windows（PowerShell）：
 $env:COPILOT_PROVIDER_TYPE="anthropic"
 $env:COPILOT_PROVIDER_BASE_URL="https://api.deepseek.com/anthropic"
 $env:COPILOT_PROVIDER_API_KEY="sk-your-deepseek-api-key"
-$env:COPILOT_MODEL="deepseek-v4-pro"
+$env:COPILOT_MODEL="deepseek-flash"
 ```
 
-可选模型：`deepseek-v4-pro`、`deepseek-v4-flash`，修改 `COPILOT_MODEL` 即可切换。
+可选模型：`deepseek-flash`，修改 `COPILOT_MODEL` 即可切换。
 
 #### 4. 启动 Copilot CLI
 
@@ -51,7 +51,7 @@ copilot
 
 #### 可选：配置 Token 限制
 
-由于 `deepseek-v4-pro` 不在 Copilot CLI 的内置模型目录中，建议显式配置 token 限制：
+由于 `deepseek-flash` 不在 Copilot CLI 的内置模型目录中，建议显式配置 token 限制：
 
 Linux / Mac：
 

--- a/docs/crush.md
+++ b/docs/crush.md
@@ -38,15 +38,8 @@ Crush supports custom providers via OpenAI-compatible APIs. Add DeepSeek to your
       "api_key": "$DEEPSEEK_API_KEY",
       "models": [
         {
-          "id": "deepseek-v4-pro",
-          "name": "DeepSeek-V4-Pro",
-          "context_window": 1048576,
-          "default_max_tokens": 32768,
-          "can_reason": true
-        },
-        {
-          "id": "deepseek-v4-flash",
-          "name": "DeepSeek-V4-Flash",
+          "id": "deepseek-flash",
+          "name": "DeepSeek-V4.1-Flash",
           "context_window": 1048576,
           "default_max_tokens": 32768,
           "can_reason": true
@@ -83,5 +76,5 @@ crush
 ```
 
 - Press `Ctrl+L` (or type `/model`) to open the model switcher.
-- Select the **DeepSeek** provider and choose `DeepSeek-V4-Pro` or `DeepSeek-V4-Flash`.
+- Select the **DeepSeek** provider and choose `DeepSeek-V4.1-Flash`.
 - Start coding with your new terminal bestie 💘

--- a/docs/crush.zh-CN.md
+++ b/docs/crush.zh-CN.md
@@ -38,15 +38,8 @@ Crush 支持通过 OpenAI 兼容 API 添加自定义供应商。在配置文件�
       "api_key": "$DEEPSEEK_API_KEY",
       "models": [
         {
-          "id": "deepseek-v4-pro",
-          "name": "DeepSeek-V4-Pro",
-          "context_window": 1048576,
-          "default_max_tokens": 32768,
-          "can_reason": true
-        },
-        {
-          "id": "deepseek-v4-flash",
-          "name": "DeepSeek-V4-Flash",
+          "id": "deepseek-flash",
+          "name": "DeepSeek-V4.1-Flash",
           "context_window": 1048576,
           "default_max_tokens": 32768,
           "can_reason": true
@@ -83,5 +76,5 @@ crush
 ```
 
 - 按 `Ctrl+L`（或输入 `/model`）打开模型切换器。
-- 选择 **DeepSeek** 供应商，然后选择 `DeepSeek-V4-Pro` 或 `DeepSeek-V4-Flash`。
+- 选择 **DeepSeek** 供应商，然后选择 `DeepSeek-V4.1-Flash`。
 - 开始与你的终端编程新搭档一起编码 💘

--- a/docs/deepcode.md
+++ b/docs/deepcode.md
@@ -28,7 +28,7 @@ Create `~/.deepcode/settings.json` with your DeepSeek API key and model settings
 ```json
 {
   "env": {
-    "MODEL": "deepseek-v4-pro",
+    "MODEL": "deepseek-flash",
     "BASE_URL": "https://api.deepseek.com",
     "API_KEY": "sk-..."
   },
@@ -45,7 +45,7 @@ Get your API Key from the [DeepSeek Platform](https://platform.deepseek.com/api_
 
 | Option | Description |
 |--------|-------------|
-| `MODEL` | Model name, e.g. `deepseek-v4-pro` or `deepseek-v4-flash` |
+| `MODEL` | Model name, e.g. `deepseek-flash` |
 | `BASE_URL` | API base URL, defaults to `https://api.deepseek.com` |
 | `thinkingEnabled` | Enable deep thinking mode (defaults to `true` for deepseek-v4 models) |
 | `reasoningEffort` | `"max"` or `"high"` — controls how much reasoning the model performs |

--- a/docs/deepcode.zh-CN.md
+++ b/docs/deepcode.zh-CN.md
@@ -28,7 +28,7 @@ deepcode --version
 ```json
 {
   "env": {
-    "MODEL": "deepseek-v4-pro",
+    "MODEL": "deepseek-flash",
     "BASE_URL": "https://api.deepseek.com",
     "API_KEY": "sk-..."
   },
@@ -45,7 +45,7 @@ deepcode --version
 
 | 选项 | 说明 |
 |------|------|
-| `MODEL` | 模型名称，例如 `deepseek-v4-pro` 或 `deepseek-v4-flash` |
+| `MODEL` | 模型名称，例如 `deepseek-flash` |
 | `BASE_URL` | API 地址，默认为 `https://api.deepseek.com` |
 | `thinkingEnabled` | 启用深度思考模式（deepseek-v4 模型默认开启） |
 | `reasoningEffort` | `"max"` 或 `"high"` — 控制模型的推理强度 |

--- a/docs/deepseek-droid-guide-zh.md
+++ b/docs/deepseek-droid-guide-zh.md
@@ -7,10 +7,10 @@
 
 | 模型                         | 提供商       | Base URL                             |
 | -------------------------- | --------- | ------------------------------------ |
-| DeepSeek V4 Pro            | Anthropic | `https://api.deepseek.com/anthropic` |
-| DeepSeek V4 Flash          | Anthropic | `https://api.deepseek.com/anthropic` |
-| DeepSeek V4 Pro (OpenAI)   | OpenAI    | `https://api.deepseek.com`           |
-| DeepSeek V4 Flash (OpenAI) | OpenAI    | `https://api.deepseek.com`           |
+| DeepSeek V4.1 Flash            | Anthropic | `https://api.deepseek.com/anthropic` |
+| DeepSeek V4.1 Flash          | Anthropic | `https://api.deepseek.com/anthropic` |
+| DeepSeek V4.1 Flash (OpenAI)   | OpenAI    | `https://api.deepseek.com`           |
+| DeepSeek V4.1 Flash (OpenAI) | OpenAI    | `https://api.deepseek.com`           |
 
 
 ## 配置
@@ -21,23 +21,12 @@
 
 ```json
 {
-  "model": "deepseek-v4-pro",
-  "id": "custom:deepseek-v4-pro---Anthropic",
+  "model": "deepseek-flash",
+  "id": "custom:deepseek-flash---Anthropic",
   "index": 1,
   "baseUrl": "https://api.deepseek.com/anthropic",
   "apiKey": "<your DeepSeek API Key>",
-  "displayName": "DeepSeek V4 Pro",
-  "maxOutputTokens": 384000,
-  "noImageSupport": false,
-  "provider": "anthropic"
-},
-{
-  "model": "deepseek-v4-flash",
-  "id": "custom:deepseek-v4-flash---Anthropic",
-  "index": 2,
-  "baseUrl": "https://api.deepseek.com/anthropic",
-  "apiKey": "<your DeepSeek API Key>",
-  "displayName": "DeepSeek V4 Flash",
+  "displayName": "DeepSeek V4.1 Flash",
   "maxOutputTokens": 384000,
   "noImageSupport": false,
   "provider": "anthropic"
@@ -48,23 +37,12 @@
 
 ```json
 {
-  "model": "deepseek-v4-pro",
-  "id": "custom:deepseek-v4-pro---OpenAI",
+  "model": "deepseek-flash",
+  "id": "custom:deepseek-flash---OpenAI",
   "index": 1,
   "baseUrl": "https://api.deepseek.com",
   "apiKey": "<your DeepSeek API Key>",
-  "displayName": "DeepSeek V4 Pro (OpenAI)",
-  "maxOutputTokens": 384000,
-  "noImageSupport": false,
-  "provider": "openai"
-},
-{
-  "model": "deepseek-v4-flash",
-  "id": "custom:deepseek-v4-flash---OpenAI",
-  "index": 2,
-  "baseUrl": "https://api.deepseek.com",
-  "apiKey": "<your DeepSeek API Key>",
-  "displayName": "DeepSeek V4 Flash (OpenAI)",
+  "displayName": "DeepSeek V4.1 Flash (OpenAI)",
   "maxOutputTokens": 384000,
   "noImageSupport": false,
   "provider": "openai"
@@ -77,9 +55,9 @@
 
 ```json
 "missionModelSettings": {
-  "workerModel": "custom:deepseek-v4-pro---Anthropic",
+  "workerModel": "custom:deepseek-flash---Anthropic",
   "workerReasoningEffort": "none",
-  "validationWorkerModel": "custom:deepseek-v4-flash---Anthropic",
+  "validationWorkerModel": "custom:deepseek-flash---Anthropic",
   "validationWorkerReasoningEffort": "none",
   "skipUserTesting": true,
   "skipScrutiny": true
@@ -98,7 +76,7 @@ Factory 支持三种 Provider 类型，决定 API 兼容性：
 | `generic-chat-completion-api` | OpenAI Chat Completions API          | OpenRouter、Fireworks、Together AI、Ollama、vLLM 及大多数开源 providers     | [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) |
 
 
-DeepSeek V4 Pro 和 V4 Flash 支持 `anthropic` 和 `openai` 两种 Provider 类型。
+DeepSeek V4.1 Flash 支持 `anthropic` 和 `openai` 两种 Provider 类型。
 
 ## 注意事项
 

--- a/docs/deepseek-droid-guide.md
+++ b/docs/deepseek-droid-guide.md
@@ -7,10 +7,10 @@ This guide explains how to add DeepSeek models to Factory AI Droid's `settings.j
 
 | Model                      | Provider  | Base URL                             |
 | -------------------------- | --------- | ------------------------------------ |
-| DeepSeek V4 Pro            | Anthropic | `https://api.deepseek.com/anthropic` |
-| DeepSeek V4 Flash          | Anthropic | `https://api.deepseek.com/anthropic` |
-| DeepSeek V4 Pro (OpenAI)   | OpenAI    | `https://api.deepseek.com`           |
-| DeepSeek V4 Flash (OpenAI) | OpenAI    | `https://api.deepseek.com`           |
+| DeepSeek V4.1 Flash            | Anthropic | `https://api.deepseek.com/anthropic` |
+| DeepSeek V4.1 Flash          | Anthropic | `https://api.deepseek.com/anthropic` |
+| DeepSeek V4.1 Flash (OpenAI)   | OpenAI    | `https://api.deepseek.com`           |
+| DeepSeek V4.1 Flash (OpenAI) | OpenAI    | `https://api.deepseek.com`           |
 
 
 ## Configuration
@@ -21,23 +21,12 @@ Add these entries to the `customModels` array in `~/.factory/settings.json`:
 
 ```json
 {
-  "model": "deepseek-v4-pro",
-  "id": "custom:deepseek-v4-pro---Anthropic",
+  "model": "deepseek-flash",
+  "id": "custom:deepseek-flash---Anthropic",
   "index": 1,
   "baseUrl": "https://api.deepseek.com/anthropic",
   "apiKey": "<your DeepSeek API Key>",
-  "displayName": "DeepSeek V4 Pro",
-  "maxOutputTokens": 384000,
-  "noImageSupport": false,
-  "provider": "anthropic"
-},
-{
-  "model": "deepseek-v4-flash",
-  "id": "custom:deepseek-v4-flash---Anthropic",
-  "index": 2,
-  "baseUrl": "https://api.deepseek.com/anthropic",
-  "apiKey": "<your DeepSeek API Key>",
-  "displayName": "DeepSeek V4 Flash",
+  "displayName": "DeepSeek V4.1 Flash",
   "maxOutputTokens": 384000,
   "noImageSupport": false,
   "provider": "anthropic"
@@ -48,23 +37,12 @@ Add these entries to the `customModels` array in `~/.factory/settings.json`:
 
 ```json
 {
-  "model": "deepseek-v4-pro",
-  "id": "custom:deepseek-v4-pro---OpenAI",
+  "model": "deepseek-flash",
+  "id": "custom:deepseek-flash---OpenAI",
   "index": 1,
   "baseUrl": "https://api.deepseek.com",
   "apiKey": "<your DeepSeek API Key>",
-  "displayName": "DeepSeek V4 Pro (OpenAI)",
-  "maxOutputTokens": 384000,
-  "noImageSupport": false,
-  "provider": "openai"
-},
-{
-  "model": "deepseek-v4-flash",
-  "id": "custom:deepseek-v4-flash---OpenAI",
-  "index": 2,
-  "baseUrl": "https://api.deepseek.com",
-  "apiKey": "<your DeepSeek API Key>",
-  "displayName": "DeepSeek V4 Flash (OpenAI)",
+  "displayName": "DeepSeek V4.1 Flash (OpenAI)",
   "maxOutputTokens": 384000,
   "noImageSupport": false,
   "provider": "openai"
@@ -77,9 +55,9 @@ To use DeepSeek as the default worker/validation model, update `missionModelSett
 
 ```json
 "missionModelSettings": {
-  "workerModel": "custom:deepseek-v4-pro---Anthropic",
+  "workerModel": "custom:deepseek-flash---Anthropic",
   "workerReasoningEffort": "none",
-  "validationWorkerModel": "custom:deepseek-v4-flash---Anthropic",
+  "validationWorkerModel": "custom:deepseek-flash---Anthropic",
   "validationWorkerReasoningEffort": "none",
   "skipUserTesting": true,
   "skipScrutiny": true
@@ -98,7 +76,7 @@ Factory supports three provider types that determine API compatibility:
 | `generic-chat-completion-api` | OpenAI Chat Completions API          | OpenRouter, Fireworks, Together AI, Ollama, vLLM, and most open-source providers                                      | [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) |
 
 
-DeepSeek V4 Pro and V4 Flash support both `anthropic` and `openai` provider types.
+DeepSeek V4.1 Flash supports both `anthropic` and `openai` provider types.
 
 ## Notes
 
@@ -130,4 +108,3 @@ DeepSeek V4 Pro and V4 Flash support both `anthropic` and `openai` provider type
 
 - Check your provider's rate limits and usage quotas
 - Monitor your usage through your provider's dashboard
-

--- a/docs/deepseek-tui.md
+++ b/docs/deepseek-tui.md
@@ -2,7 +2,7 @@
 
 # Integrate with DeepSeek-TUI
 
-DeepSeek-TUI is an open-source terminal AI coding assistant built in Rust as a Codex-style 13-crate workspace. It talks to `api.deepseek.com` directly, supports DeepSeek-V4-Pro and DeepSeek-V4-Flash with the full 1M-token context window, and ships sandboxed tool execution on macOS (Seatbelt), Linux (Landlock), and Windows.
+DeepSeek-TUI is an open-source terminal AI coding assistant built in Rust as a Codex-style 13-crate workspace. It talks to `api.deepseek.com` directly, supports DeepSeek-V4.1-Flash with the full 1M-token context window, and ships sandboxed tool execution on macOS (Seatbelt), Linux (Landlock), and Windows.
 
 - **GitHub:** <https://github.com/Hmbown/DeepSeek-TUI>
 
@@ -40,7 +40,7 @@ deepseek
 
 `deepseek` is the canonical entry point. It dispatches to the interactive TUI by default, or to subcommands like `deepseek doctor`, `deepseek mcp list`, `deepseek serve --http`, `deepseek -p "one-shot prompt"`, and `deepseek --yolo`.
 
-By default DeepSeek-TUI uses **DeepSeek-V4-Pro**. Press `Shift+Tab` to cycle reasoning effort (`off → high → max`). Press `Tab` to cycle modes:
+By default DeepSeek-TUI uses **DeepSeek-V4.1-Flash**. Press `Shift+Tab` to cycle reasoning effort (`off → high → max`). Press `Tab` to cycle modes:
 
 | Mode | What it does |
 |---|---|

--- a/docs/deepseek-tui.zh-CN.md
+++ b/docs/deepseek-tui.zh-CN.md
@@ -2,7 +2,7 @@
 
 # 接入 DeepSeek-TUI
 
-DeepSeek-TUI 是一款采用 Rust 编写的开源终端 AI 编程助手，使用 Codex 风格的 13-crate 工作区架构。原生对接 `api.deepseek.com`，支持 DeepSeek-V4-Pro 与 DeepSeek-V4-Flash 全 100 万 token 上下文，并在 macOS（Seatbelt）、Linux（Landlock）和 Windows 上提供沙箱化的工具执行能力。
+DeepSeek-TUI 是一款采用 Rust 编写的开源终端 AI 编程助手，使用 Codex 风格的 13-crate 工作区架构。原生对接 `api.deepseek.com`，支持 DeepSeek-V4.1-Flash 全 100 万 token 上下文，并在 macOS（Seatbelt）、Linux（Landlock）和 Windows 上提供沙箱化的工具执行能力。
 
 - **GitHub：** <https://github.com/Hmbown/DeepSeek-TUI>
 
@@ -40,7 +40,7 @@ deepseek
 
 `deepseek` 是规范的入口命令。默认进入交互式 TUI，也可调用子命令，如 `deepseek doctor`、`deepseek mcp list`、`deepseek serve --http`、`deepseek -p "一次性 prompt"`、`deepseek --yolo` 等。
 
-DeepSeek-TUI 默认使用 **DeepSeek-V4-Pro**。按 `Shift+Tab` 切换推理强度（`off → high → max`）。按 `Tab` 切换模式：
+DeepSeek-TUI 默认使用 **DeepSeek-V4.1-Flash**。按 `Shift+Tab` 切换推理强度（`off → high → max`）。按 `Tab` 切换模式：
 
 | 模式 | 说明 |
 |---|---|

--- a/docs/github_copilot.md
+++ b/docs/github_copilot.md
@@ -2,7 +2,7 @@
 
 # Integrate with GitHub Copilot
 
-**DeepSeek V4 for Copilot Chat** is a VS Code extension that adds DeepSeek V4 Pro & Flash directly into the GitHub Copilot Chat model picker. You keep Copilot's agent mode, tool calling, skills, and MCP — all powered by DeepSeek.
+**DeepSeek V4 for Copilot Chat** is a VS Code extension that adds DeepSeek V4.1 Flash directly to the GitHub Copilot Chat model picker. You keep Copilot's agent mode, tool calling, skills, and MCP — all powered by DeepSeek.
 
 #### 1. Install the Extension
 
@@ -25,7 +25,7 @@
 
 - Open Copilot Chat (`Cmd+Shift+I` / `Ctrl+Shift+I`).
 - Click the model picker at the top-right of the chat panel.
-- Choose **DeepSeek V4 Pro** or **DeepSeek V4 Flash**.
+- Choose **DeepSeek V4.1 Flash**.
 - Start chatting — agent mode, tool calling, and all Copilot features work out of the box.
 
 #### Optional: Configure Thinking Effort
@@ -37,7 +37,7 @@ In the model picker, click the gear icon next to a DeepSeek model to choose the 
 
 #### Optional: Vision Support
 
-DeepSeek V4 is text-only, but the extension handles images automatically. Drop a screenshot into chat and it proxies through another installed Copilot model (Claude, GPT-4o) to describe the image before sending to DeepSeek. Run **DeepSeek: Set Vision Proxy Model** to pick which model handles image descriptions.
+DeepSeek V4.1 Flash natively understands images; the extension can pass screenshots directly when its current release supports the new model capability. Drop a screenshot into chat and it proxies through another installed Copilot model (Claude, GPT-4o) to describe the image before sending to DeepSeek. Run **DeepSeek: Set Vision Proxy Model** to pick which model handles image descriptions.
 
 <div align="center">
 <img src="https://raw.githubusercontent.com/Vizards/deepseek-v4-for-copilot/main/resources/screenshots/01-picker.png" width='1024' border='1'  />

--- a/docs/github_copilot.zh-CN.md
+++ b/docs/github_copilot.zh-CN.md
@@ -2,7 +2,7 @@
 
 # 接入 GitHub Copilot
 
-**DeepSeek V4 for Copilot Chat** 是一个 VS Code 插件，将 DeepSeek V4 Pro 和 Flash 直接添加到 GitHub Copilot 的模型选择器中。你仍可使用 Copilot 的 Agent 模式、工具调用、Skills 和 MCP — 全部由 DeepSeek 驱动。
+**DeepSeek V4 for Copilot Chat** 是一个 VS Code 插件，可将 DeepSeek V4.1 Flash 直接添加到 GitHub Copilot 的模型选择器中。你仍可使用 Copilot 的 Agent 模式、工具调用、Skills 和 MCP — 全部由 DeepSeek 驱动。
 
 #### 1. 安装插件
 
@@ -25,7 +25,7 @@
 
 - 打开 Copilot Chat（`Cmd+Shift+I` / `Ctrl+Shift+I`）。
 - 点击聊天面板右上角的模型选择器。
-- 选择 **DeepSeek V4 Pro** 或 **DeepSeek V4 Flash**。
+- 选择 **DeepSeek V4.1 Flash**。
 - 即可开始对话 — Agent 模式、工具调用及所有 Copilot 功能均可直接使用。
 
 #### 可选：配置思考深度
@@ -37,7 +37,7 @@
 
 #### 可选：视觉支持
 
-DeepSeek V4 为纯文本模型，但插件会自动处理图片。将截图拖入对话后，插件会通过其他已安装的 Copilot 模型（如 Claude、GPT-4o）描述图片内容，再发送给 DeepSeek。执行 **DeepSeek: Set Vision Proxy Model** 可选择用于图片描述的模型。
+DeepSeek V4.1 Flash 原生支持视觉理解；插件的新版本支持该能力时可直接传入截图。将截图拖入对话后，插件会通过其他已安装的 Copilot 模型（如 Claude、GPT-4o）描述图片内容，再发送给 DeepSeek。执行 **DeepSeek: Set Vision Proxy Model** 可选择用于图片描述的模型。
 
 <div align="center">
 <img src="https://raw.githubusercontent.com/Vizards/deepseek-v4-for-copilot/main/resources/screenshots/01-picker.png" width='1024' border='1'  />

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -29,5 +29,5 @@ Reload your shell and start Hermes configuration:
 - When prompted for the model provider, select **DeepSeek**
 - Enter your [DeepSeek API Key](https://platform.deepseek.com/api_keys)
 - Enter the Base URL as `https://api.deepseek.com`
-- Select the `deepseek-v4-pro` model
+- Select the `deepseek-flash` model
 - Continue with the remaining options

--- a/docs/hermes.zh-CN.md
+++ b/docs/hermes.zh-CN.md
@@ -29,5 +29,5 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 - 当提示选择模型提供商时，选择 **DeepSeek**
 - 输入你的 [DeepSeek API Key](https://platform.deepseek.com/api_keys)
 - Base URL 填写 `https://api.deepseek.com`
-- 选择 `deepseek-v4-pro` 模型
+- 选择 `deepseek-flash` 模型
 - 继续完成其余配置选项

--- a/docs/kilo_code.md
+++ b/docs/kilo_code.md
@@ -52,8 +52,8 @@ kilo
 - Select one of the available DeepSeek models:
   - DeepSeek Chat
   - DeepSeek Reasoner
-  - DeepSeek V4 Flash
-  - DeepSeek V4 Pro
+  - DeepSeek V4.1 Flash
+  - DeepSeek V4.1 Flash
 
 <div align="center">
 <img src="./assets/kilo_code_step_4.png" width="1024" border="1" />

--- a/docs/kilo_code.zh-CN.md
+++ b/docs/kilo_code.zh-CN.md
@@ -52,8 +52,8 @@ kilo
 - 选择一个可用的 DeepSeek 模型：
   - DeepSeek Chat
   - DeepSeek Reasoner
-  - DeepSeek V4 Flash
-  - DeepSeek V4 Pro
+  - DeepSeek V4.1 Flash
+  - DeepSeek V4.1 Flash
 
 <div align="center">
 <img src="./assets/kilo_code_step_4.png" width="1024" border="1" />

--- a/docs/lobehub.md
+++ b/docs/lobehub.md
@@ -31,8 +31,8 @@ https://app.lobehub.com/settings/provider/deepseek
 2. Make sure the provider switch in the upper-right corner is enabled.
 3. Paste your DeepSeek API Key into **API Key**.
 4. Leave **API Proxy URL** empty unless you use a custom proxy. The default endpoint is `https://api.deepseek.com`.
-5. Optional: click **Check** under **Connectivity Check**. LobeHub uses `deepseek-v4-flash` as the default check model.
-6. In **Model List**, confirm that **DeepSeek V4 Pro** and **DeepSeek V4 Flash** are enabled. If needed, click **Fetch models** to refresh the provider model list.
+5. Optional: click **Check** under **Connectivity Check**. LobeHub uses `deepseek-flash` as the default check model.
+6. In **Model List**, confirm that **DeepSeek V4.1 Flash** are enabled. If needed, click **Fetch models** to refresh the provider model list.
 
 <div align="center">
 <img src="./assets/lobehub_chrome_provider_settings.en-US.jpg" width="1024" border="1" />
@@ -46,7 +46,7 @@ Return to **Home** or open any agent chat.
 
 1. Click the current model chip in the chat input toolbar.
 2. Search for `DeepSeek V4`.
-3. Choose **DeepSeek V4 Pro** for coding, long-horizon planning, and agent workflows, or **DeepSeek V4 Flash** for lower-latency everyday chat.
+3. Choose **DeepSeek V4.1 Flash** for coding, planning, agent workflows, and everyday chat.
 4. Send a message to start the conversation.
 
 <div align="center">
@@ -79,7 +79,7 @@ DEEPSEEK_PROXY_URL=https://api.deepseek.com
 To restrict the visible DeepSeek model list to V4 models only, add:
 
 ```bash
-DEEPSEEK_MODEL_LIST=-all,+deepseek-v4-pro,+deepseek-v4-flash
+DEEPSEEK_MODEL_LIST=-all,+deepseek-flash
 ```
 
 For most hosted web and desktop users, the UI configuration in **Settings → Service Model → DeepSeek** is enough.
@@ -87,6 +87,6 @@ For most hosted web and desktop users, the UI configuration in **Settings → Se
 #### Troubleshooting
 
 - `401` or authentication errors: recheck the API Key and make sure it is pasted into **API Key**, not **API Proxy URL**.
-- Model not found: refresh the model list and confirm that the enabled model ids are `deepseek-v4-pro` and `deepseek-v4-flash`.
+- Model not found: refresh the model list and confirm that the enabled model ids are `deepseek-flash`.
 - Connection check fails with a proxy: the proxy URL must include `http://` or `https://` and should route to the DeepSeek-compatible API endpoint.
-- Reasoning controls are missing: make sure you selected **DeepSeek V4 Pro** or **DeepSeek V4 Flash**, not another provider's routed model.
+- Reasoning controls are missing: make sure you selected **DeepSeek V4.1 Flash**, not another provider's routed model.

--- a/docs/lobehub.zh-CN.md
+++ b/docs/lobehub.zh-CN.md
@@ -31,8 +31,8 @@ https://app.lobehub.com/settings/provider/deepseek
 2. 确认右上角的 Provider 开关已开启。
 3. 将 DeepSeek API Key 粘贴到 **API Key**。
 4. 除非你使用自定义代理，**API 代理地址** 可以保持为空；默认端点是 `https://api.deepseek.com`。
-5. 可选：点击 **连通性检查** 中的 **检查**。LobeHub 默认使用 `deepseek-v4-flash` 作为检查模型。
-6. 在 **模型列表** 中确认 **DeepSeek V4 Pro** 与 **DeepSeek V4 Flash** 已启用。如需刷新模型列表，点击 **获取模型列表**。
+5. 可选：点击 **连通性检查** 中的 **检查**。LobeHub 默认使用 `deepseek-flash` 作为检查模型。
+6. 在 **模型列表** 中确认 **DeepSeek V4.1 Flash** 已启用。如需刷新模型列表，点击 **获取模型列表**。
 
 <div align="center">
 <img src="./assets/lobehub_chrome_provider_settings.zh-CN.jpg" width="1024" border="1" />
@@ -46,7 +46,7 @@ https://app.lobehub.com/settings/provider/deepseek
 
 1. 点击输入框工具栏中的当前模型标签。
 2. 搜索 `DeepSeek V4`。
-3. 编码、长程规划和 Agent 工作流建议选择 **DeepSeek V4 Pro**；日常对话和低延迟场景可以选择 **DeepSeek V4 Flash**。
+3. 编码、长程规划、Agent 工作流和日常对话均选择 **DeepSeek V4.1 Flash**。
 4. 发送消息即可开始对话。
 
 <div align="center">
@@ -79,7 +79,7 @@ DEEPSEEK_PROXY_URL=https://api.deepseek.com
 如果只想显示 DeepSeek V4 模型，可以继续添加：
 
 ```bash
-DEEPSEEK_MODEL_LIST=-all,+deepseek-v4-pro,+deepseek-v4-flash
+DEEPSEEK_MODEL_LIST=-all,+deepseek-flash
 ```
 
 对于大多数网页端和桌面端用户，在 **设置 → 服务模型 → DeepSeek** 中完成 UI 配置即可。
@@ -87,6 +87,6 @@ DEEPSEEK_MODEL_LIST=-all,+deepseek-v4-pro,+deepseek-v4-flash
 #### 常见问题
 
 - `401` 或鉴权失败：检查 API Key 是否正确，并确认它填在 **API Key**，不是 **API 代理地址**。
-- 找不到模型：刷新模型列表，并确认已启用的模型 id 是 `deepseek-v4-pro` 和 `deepseek-v4-flash`。
+- 找不到模型：刷新模型列表，并确认已启用的模型 id 是 `deepseek-flash`。
 - 使用代理时连通性检查失败：代理地址必须包含 `http://` 或 `https://`，并且应转发到 DeepSeek 兼容 API 端点。
-- 看不到推理强度控制：确认当前选择的是 **DeepSeek V4 Pro** 或 **DeepSeek V4 Flash**，而不是其他服务商的转发模型。
+- 看不到推理强度控制：确认当前选择的是 **DeepSeek V4.1 Flash**，而不是其他服务商的转发模型。

--- a/docs/nanobot.md
+++ b/docs/nanobot.md
@@ -50,7 +50,7 @@ Edit the `config.json` file and modify the following configuration items:
 {
     "agents": {
         "defaults": {
-            "model": "deepseek-v4-pro",
+            "model": "deepseek-flash",
             "provider": "deepseek",
         }
     },

--- a/docs/nanobot.zh-CN.md
+++ b/docs/nanobot.zh-CN.md
@@ -50,7 +50,7 @@ nanobot onboard
 {
     "agents": {
         "defaults": {
-            "model": "deepseek-v4-pro",
+            "model": "deepseek-flash",
             "provider": "deepseek",
         }
     },

--- a/docs/oh-my-pi.md
+++ b/docs/oh-my-pi.md
@@ -26,37 +26,14 @@ providers:
     apiKey: DEEPSEEK_API_KEY
     authHeader: true
     models:
-      - id: deepseek-v4-pro
-        name: DeepSeek V4 Pro
+      - id: deepseek-flash
+        name: DeepSeek V4.1 Flash
         reasoning: true
         thinking:
           minLevel: high
           maxLevel: xhigh
           mode: effort
-        input: [text]
-        contextWindow: 1000000
-        maxTokens: 384000
-        compat:
-          supportsDeveloperRole: false
-          supportsReasoningEffort: true
-          maxTokensField: max_tokens
-          reasoningEffortMap:
-            high: high
-            xhigh: max
-          supportsToolChoice: false
-          requiresReasoningContentForToolCalls: true
-          requiresAssistantContentForToolCalls: true
-          extraBody:
-            thinking:
-              type: enabled
-      - id: deepseek-v4-flash
-        name: DeepSeek V4 Flash
-        reasoning: true
-        thinking:
-          minLevel: high
-          maxLevel: xhigh
-          mode: effort
-        input: [text]
+        input: [text, image]
         contextWindow: 1000000
         maxTokens: 384000
         compat:
@@ -109,20 +86,14 @@ These three fields are essential. Without them, DeepSeek V4 will return 400 erro
 
 ```sh
 cd /path/to/your-project
-omp --model deepseek/deepseek-v4-pro
-```
-
-For faster responses:
-
-```sh
-omp --model deepseek/deepseek-v4-flash
+omp --model deepseek/deepseek-flash
 ```
 
 Switch models inside Oh My Pi with `/model` or `Ctrl+L`.
 
 ## Known issues
 
-**Do not rely on the built-in model entries.** Recent builds list `deepseek-v4-pro` and `deepseek-v4-flash` via `omp --list-models deepseek`, but they lack the three critical compat fields above. Long thinking-mode conversations with tool calls will 400. Always use the `models.yml` configuration shown above.
+**Do not rely on the built-in model entries.** Recent builds list `deepseek-flash` via `omp --list-models deepseek`, but they lack the three critical compat fields above. Long thinking-mode conversations with tool calls will 400. Always use the `models.yml` configuration shown above.
 
 Oh My Pi does not currently have a DeepSeek OAuth `/login` entry. API keys must be provided via the `DEEPSEEK_API_KEY` environment variable or the `apiKey` field in `models.yml`.
 

--- a/docs/oh-my-pi.zh-CN.md
+++ b/docs/oh-my-pi.zh-CN.md
@@ -26,37 +26,14 @@ providers:
     apiKey: DEEPSEEK_API_KEY
     authHeader: true
     models:
-      - id: deepseek-v4-pro
-        name: DeepSeek V4 Pro
+      - id: deepseek-flash
+        name: DeepSeek V4.1 Flash
         reasoning: true
         thinking:
           minLevel: high
           maxLevel: xhigh
           mode: effort
-        input: [text]
-        contextWindow: 1000000
-        maxTokens: 384000
-        compat:
-          supportsDeveloperRole: false
-          supportsReasoningEffort: true
-          maxTokensField: max_tokens
-          reasoningEffortMap:
-            high: high
-            xhigh: max
-          supportsToolChoice: false
-          requiresReasoningContentForToolCalls: true
-          requiresAssistantContentForToolCalls: true
-          extraBody:
-            thinking:
-              type: enabled
-      - id: deepseek-v4-flash
-        name: DeepSeek V4 Flash
-        reasoning: true
-        thinking:
-          minLevel: high
-          maxLevel: xhigh
-          mode: effort
-        input: [text]
+        input: [text, image]
         contextWindow: 1000000
         maxTokens: 384000
         compat:
@@ -109,20 +86,14 @@ providers:
 
 ```sh
 cd /path/to/your-project
-omp --model deepseek/deepseek-v4-pro
-```
-
-需要更快响应时：
-
-```sh
-omp --model deepseek/deepseek-v4-flash
+omp --model deepseek/deepseek-flash
 ```
 
 在 Oh My Pi 内输入 `/model` 或按 `Ctrl+L` 切换模型。
 
 ## 已知问题
 
-**不推荐依赖内置模型条目。** 较新版本 `omp --list-models deepseek` 能列出 `deepseek-v4-pro` 和 `deepseek-v4-flash`，但内置条目缺少上述三项关键 compat。直接用内置条目在 thinking mode 下带 tool call 的长对话大概率 400。始终使用上方的 `models.yml` 配置。
+**不推荐依赖内置模型条目。** 较新版本 `omp --list-models deepseek` 能列出 `deepseek-flash`，但内置条目缺少上述三项关键 compat。直接用内置条目在 thinking mode 下带 tool call 的长对话大概率 400。始终使用上方的 `models.yml` 配置。
 
 Oh My Pi 目前没有 DeepSeek 的 OAuth `/login` 入口。只能通过 `DEEPSEEK_API_KEY` 环境变量或 `models.yml` 中的 `apiKey` 字段配置 API Key。
 

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -26,7 +26,7 @@ After the initial installation, you will automatically enter the setup phase. Us
 - When prompted: `Setup mode` It is recommended to select **QuickStart**.
 - When prompted: `Model/auth provider` Select **DeepSeek**.
 - When prompted: `Enter DeepSeek API key` Enter your [DeepSeek API Key](https://platform.deepseek.com/api_keys).
-- When prompted: `Default model` Navigate to **Enter model** and enter the model name (`deepseek-v4-pro` or `deepseek-v4-flash`).
+- When prompted: `Default model` Navigate to **Enter model** and enter the model name (`deepseek-flash`).
 - For the remaining configuration (message channels, Skills, etc.), configure as needed. Beginners can select **Skip for now**.
 
 To avoid compatibility issues, it is strongly recommended to upgrade OpenClaw to the latest version, ensuring the version number is >= [v2026.4.24](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24), which adds proper support for DeepSeek V4 thinking mode. If you encounter a 400 error about `reasoning_content`, updating to the latest version should resolve it.

--- a/docs/openclaw.zh-CN.md
+++ b/docs/openclaw.zh-CN.md
@@ -26,7 +26,7 @@ iwr -useb https://openclaw.ai/install.ps1 | iex
 - 遇到提示：`Setup mode` 推荐选择 **QuickStart**。
 - 遇到提示：`Model/auth provider` 请选择 **DeepSeek**。
 - 遇到提示：`Enter DeepSeek API key` 请填入你的 [DeepSeek API Key](https://platform.deepseek.com/api_keys)。
-- 遇到提示：`Default model` 请将光标指向 **Enter model**，填写模型名称（`deepseek-v4-pro` 或 `deepseek-v4-flash`）。
+- 遇到提示：`Default model` 请将光标指向 **Enter model**，填写模型名称（`deepseek-flash`）。
 - 后续的其余配置（消息频道、Skill 等）请根据需求配置，新手可以先选择 **Skip for now**。
 
 为避免兼容性问题，强烈建议将 OpenClaw 升级到最新版本，确保版本号 >= [v2026.4.24](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24)，该版本新增了对 DeepSeek V4 Thinking Mode 的正确支持。如果遇到关于 `reasoning_content` 的 400 报错，更新到最新版本即可解决。

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -15,4 +15,4 @@ To avoid compatibility issues, it is strongly recommended to upgrade OpenCode to
 - Execute the `opencode` command<br/>
 - Type `/connect` in the input box, then enter `deepseek` and select the provider<br/>
 - Enter your [DeepSeek API Key](https://platform.deepseek.com/api_keys)<br/>
-- Select the DeepSeek-V4-Pro model
+- Select the DeepSeek-V4.1-Flash model

--- a/docs/opencode.zh-CN.md
+++ b/docs/opencode.zh-CN.md
@@ -15,4 +15,4 @@ OpenCode 是一个开源 AI 编程助手，提供终端、网页等运行形式�
 - 执行 `opencode` 命令<br/>
 - 输入框中输入 `/connect`，然后输入 `deepseek` 并选择供应商<br/>
 - 填入 [DeepSeek API Key](https://platform.deepseek.com/api_keys)<br/>
-- 选择 DeepSeek-V4-Pro 模型
+- 选择 DeepSeek-V4.1-Flash 模型

--- a/docs/pi_mono.md
+++ b/docs/pi_mono.md
@@ -40,43 +40,17 @@ Pi supports custom providers via `models.json`. Add DeepSeek as an OpenAI-compat
       "apiKey": "$DEEPSEEK_API_KEY",
       "models": [
         {
-          "id": "deepseek-v4-pro",
-          "name": "DeepSeek V4 Pro",
+          "id": "deepseek-flash",
+          "name": "DeepSeek V4.1 Flash",
           "contextWindow": 1000000,
           "maxTokens": 384000,
-          "input": ["text"],
+          "input": ["text", "image"],
           "reasoning": true,
           "thinkingLevelMap": { "minimal": null, "low": null, "medium": null, "high": "high", "xhigh": "max" },
           "cost": {
-            "input": 1.74,
-            "output": 3.48,
-            "cacheRead": 0.145,
-            "cacheWrite": 0
-          },
-          "compat": {
-            "requiresReasoningContentOnAssistantMessages": true,
-            "thinkingFormat": "deepseek",
-            "reasoningEffortMap": {
-              "minimal": "high",
-              "low": "high",
-              "medium": "high",
-              "high": "high",
-              "xhigh": "max"
-            }
-          }
-        },
-        {
-          "id": "deepseek-v4-flash",
-          "name": "DeepSeek V4 Flash",
-          "contextWindow": 1000000,
-          "maxTokens": 384000,
-          "input": ["text"],
-          "reasoning": true,
-          "thinkingLevelMap": { "minimal": null, "low": null, "medium": null, "high": "high", "xhigh": "max" },
-          "cost": {
-            "input": 0.14,
-            "output": 0.28,
-            "cacheRead": 0.028,
+            "input": 0.30,
+            "output": 1.20,
+            "cacheRead": 0.006,
             "cacheWrite": 0
           },
           "compat": {
@@ -123,7 +97,7 @@ pi
 ```
 
 - Type `/model` to open the model switcher.
-- Select **deepseek** and choose `DeepSeek-V4-Pro` or `DeepSeek-V4-Flash`.
+- Select **deepseek** and choose `DeepSeek-V4.1-Flash`.
 - Start coding with your minimal terminal harness.
 
 For more configuration options, see the [Pi models documentation](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent/docs/models.md).

--- a/docs/pi_mono.zh-CN.md
+++ b/docs/pi_mono.zh-CN.md
@@ -40,43 +40,17 @@ Pi 通过 `models.json` 支持自定义供应商。将 DeepSeek 添加为 OpenAI
       "apiKey": "$DEEPSEEK_API_KEY",
       "models": [
         {
-          "id": "deepseek-v4-pro",
-          "name": "DeepSeek V4 Pro",
+          "id": "deepseek-flash",
+          "name": "DeepSeek V4.1 Flash",
           "contextWindow": 1000000,
           "maxTokens": 384000,
-          "input": ["text"],
+          "input": ["text", "image"],
           "reasoning": true,
           "thinkingLevelMap": { "minimal": null, "low": null, "medium": null, "high": "high", "xhigh": "max" },
           "cost": {
-            "input": 1.74,
-            "output": 3.48,
-            "cacheRead": 0.145,
-            "cacheWrite": 0
-          },
-          "compat": {
-            "requiresReasoningContentOnAssistantMessages": true,
-            "thinkingFormat": "deepseek",
-            "reasoningEffortMap": {
-              "minimal": "high",
-              "low": "high",
-              "medium": "high",
-              "high": "high",
-              "xhigh": "max"
-            }
-          }
-        },
-        {
-          "id": "deepseek-v4-flash",
-          "name": "DeepSeek V4 Flash",
-          "contextWindow": 1000000,
-          "maxTokens": 384000,
-          "input": ["text"],
-          "reasoning": true,
-          "thinkingLevelMap": { "minimal": null, "low": null, "medium": null, "high": "high", "xhigh": "max" },
-          "cost": {
-            "input": 0.14,
-            "output": 0.28,
-            "cacheRead": 0.028,
+            "input": 0.30,
+            "output": 1.20,
+            "cacheRead": 0.006,
             "cacheWrite": 0
           },
           "compat": {
@@ -123,7 +97,7 @@ pi
 ```
 
 - 输入 `/model` 打开模型切换器。
-- 选择 **deepseek**，然后选择 `DeepSeek-V4-Pro` 或 `DeepSeek-V4-Flash`。
+- 选择 **deepseek**，然后选择 `DeepSeek-V4.1-Flash`。
 - 开始使用你的极简终端编码框架。
 
 更多配置选项请参阅 [Pi 模型文档](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent/docs/models.md)。

--- a/docs/qwen_code.md
+++ b/docs/qwen_code.md
@@ -57,13 +57,13 @@ The `/auth` menu will appear. Follow these steps:
 1. Select **Third-party Providers**
 2. Select **DeepSeek API Key**
 3. **Step 1/2** — paste your DeepSeek API key and press Enter
-4. **Step 2/2** — confirm the model IDs: `deepseek-v4-pro, deepseek-v4-flash` (or edit if needed), press Enter
+4. **Step 2/2** — confirm the model IDs: `deepseek-flash` (or edit if needed), press Enter
 
 After confirmation, you'll see: `Successfully configured DeepSeek API Key`.
 
 #### 4. Switch to a DeepSeek Model
 
-Run the `/model` command and select `deepseek-v4-pro` or `deepseek-v4-flash`:
+Run the `/model` command and select `deepseek-flash`:
 
 ```
 /model

--- a/docs/qwen_code.zh-CN.md
+++ b/docs/qwen_code.zh-CN.md
@@ -57,13 +57,13 @@ qwen
 1. 选择 **Third-party Providers**
 2. 选择 **DeepSeek API Key**
 3. **步骤 1/2** — 粘贴你的 DeepSeek API Key，回车
-4. **步骤 2/2** — 确认模型 ID：`deepseek-v4-pro, deepseek-v4-flash`（可自行修改），回车
+4. **步骤 2/2** — 确认模型 ID：`deepseek-flash`（可自行修改），回车
 
 确认后将显示：`Successfully configured DeepSeek API Key`。
 
 #### 4. 切换到 DeepSeek 模型
 
-运行 `/model` 命令，选择 `deepseek-v4-pro` 或 `deepseek-v4-flash`：
+运行 `/model` 命令，选择 `deepseek-flash`：
 
 ```
 /model

--- a/docs/reasonix.md
+++ b/docs/reasonix.md
@@ -20,7 +20,7 @@ cd /path/to/my-project
 npx reasonix code
 ```
 
-No global install required. By default Reasonix uses **DeepSeek-V4-Flash** for cost-efficient iteration. Type `/pro` inside the TUI to arm **DeepSeek-V4-Pro** for the next turn, or `/preset max` to use Pro for the whole session. Run `/help` for the full slash-command reference.
+No global install required. Reasonix uses **DeepSeek-V4.1-Flash** by default. Legacy Pro selections will route to V4.1 Flash after September 14, 2026. Run `/help` for the full slash-command reference.
 
 <div align="center">
 <img src="https://raw.githubusercontent.com/esengine/reasonix/main/docs/logo.svg" width='640' />

--- a/docs/reasonix.zh-CN.md
+++ b/docs/reasonix.zh-CN.md
@@ -20,7 +20,7 @@ cd /path/to/my-project
 npx reasonix code
 ```
 
-无需全局安装。Reasonix 默认使用 **DeepSeek-V4-Flash** 跑日常迭代以控制成本。在 TUI 中输入 `/pro` 可在下一轮切换到 **DeepSeek-V4-Pro**，`/preset max` 则整个 session 都走 Pro。输入 `/help` 查看完整 slash 命令参考。
+无需全局安装。Reasonix 默认使用 **DeepSeek-V4.1-Flash**。旧有的 Pro 选项将在 2026 年 9 月 14 日后路由到 V4.1 Flash。输入 `/help` 查看完整 slash 命令参考。
 
 <div align="center">
 <img src="https://raw.githubusercontent.com/esengine/reasonix/main/docs/logo.svg" width='640' />

--- a/docs/workbuddy.md
+++ b/docs/workbuddy.md
@@ -36,35 +36,23 @@ Then add the following configuration:
 {
   "models": [
     {
-      "id": "deepseek-v4-pro",
-      "name": "DeepSeek V4 Pro",
+      "id": "deepseek-flash",
+      "name": "DeepSeek V4.1 Flash",
       "vendor": "DeepSeek",
       "url": "https://api.deepseek.com/v1/chat/completions",
       "apiKey": "${DEEPSEEK_API_KEY}",
-      "maxInputTokens": 128000,
-      "maxOutputTokens": 8192,
+      "maxInputTokens": 1000000,
+      "maxOutputTokens": 384000,
       "supportsToolCall": true,
-      "supportsImages": false,
+      "supportsImages": true,
       "relatedModels": {
-        "lite": "deepseek-v4-flash",
-        "reasoning": "deepseek-v4-pro"
+        "lite": "deepseek-flash",
+        "reasoning": "deepseek-flash"
       }
-    },
-    {
-      "id": "deepseek-v4-flash",
-      "name": "DeepSeek V4 Flash",
-      "vendor": "DeepSeek",
-      "url": "https://api.deepseek.com/v1/chat/completions",
-      "apiKey": "${DEEPSEEK_API_KEY}",
-      "maxInputTokens": 128000,
-      "maxOutputTokens": 8192,
-      "supportsToolCall": true,
-      "supportsImages": false
     }
   ],
   "availableModels": [
-    "deepseek-v4-pro",
-    "deepseek-v4-flash"
+    "deepseek-flash"
   ]
 }
 ```
@@ -78,8 +66,7 @@ Fully quit WorkBuddy/CodeBuddy, then open it again.
 In the model selector, choose:
 
 ```
-DeepSeek V4 Pro
-DeepSeek V4 Flash
+DeepSeek V4.1 Flash
 ```
 
 #### 4. Optional: Verify the API Key
@@ -92,7 +79,7 @@ $env:DEEPSEEK_API_KEY="<your DeepSeek API Key>"
 curl https://api.deepseek.com/v1/chat/completions `
   -H "Content-Type: application/json" `
   -H "Authorization: Bearer $env:DEEPSEEK_API_KEY" `
-  -d '{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":false}'
+  -d '{"model":"deepseek-flash","messages":[{"role":"user","content":"hi"}],"stream":false}'
 ```
 
 If the request succeeds, the API Key and model name are valid.
@@ -100,7 +87,7 @@ If the request succeeds, the API Key and model name are valid.
 #### Troubleshooting
 
 - `Authentication Fails` or `401`: Check whether `apiKey` is your real DeepSeek API Key. Do not put the API URL in the API Key field.
-- `Model Not Found` or `404`: Check whether the model id is exactly `deepseek-v4-pro` or `deepseek-v4-flash`.
+- `Model Not Found` or `404`: Check whether the model id is exactly `deepseek-flash`.
 - `Failed to read local model configuration`: Check whether `models.json` is valid JSON and saved as UTF-8 without BOM.
 - The model does not appear in the selector: Fully restart WorkBuddy/CodeBuddy and confirm the file is placed under `.codebuddy\models.json`.
 - `${DEEPSEEK_API_KEY}` is shown literally in the UI: Restart WorkBuddy/CodeBuddy from a terminal where `DEEPSEEK_API_KEY` is available. If the desktop UI still does not expand environment variables, paste the actual API Key in the UI or in your local `models.json`.

--- a/docs/workbuddy.zh-CN.md
+++ b/docs/workbuddy.zh-CN.md
@@ -36,35 +36,23 @@ setx DEEPSEEK_API_KEY "<your DeepSeek API Key>"
 {
   "models": [
     {
-      "id": "deepseek-v4-pro",
-      "name": "DeepSeek V4 Pro",
+      "id": "deepseek-flash",
+      "name": "DeepSeek V4.1 Flash",
       "vendor": "DeepSeek",
       "url": "https://api.deepseek.com/v1/chat/completions",
       "apiKey": "${DEEPSEEK_API_KEY}",
-      "maxInputTokens": 128000,
-      "maxOutputTokens": 8192,
+      "maxInputTokens": 1000000,
+      "maxOutputTokens": 384000,
       "supportsToolCall": true,
-      "supportsImages": false,
+      "supportsImages": true,
       "relatedModels": {
-        "lite": "deepseek-v4-flash",
-        "reasoning": "deepseek-v4-pro"
+        "lite": "deepseek-flash",
+        "reasoning": "deepseek-flash"
       }
-    },
-    {
-      "id": "deepseek-v4-flash",
-      "name": "DeepSeek V4 Flash",
-      "vendor": "DeepSeek",
-      "url": "https://api.deepseek.com/v1/chat/completions",
-      "apiKey": "${DEEPSEEK_API_KEY}",
-      "maxInputTokens": 128000,
-      "maxOutputTokens": 8192,
-      "supportsToolCall": true,
-      "supportsImages": false
     }
   ],
   "availableModels": [
-    "deepseek-v4-pro",
-    "deepseek-v4-flash"
+    "deepseek-flash"
   ]
 }
 ```
@@ -78,8 +66,7 @@ setx DEEPSEEK_API_KEY "<your DeepSeek API Key>"
 在模型选择器中选择：
 
 ```
-DeepSeek V4 Pro
-DeepSeek V4 Flash
+DeepSeek V4.1 Flash
 ```
 
 #### 4. 可选：验证 API Key
@@ -92,7 +79,7 @@ $env:DEEPSEEK_API_KEY="<your DeepSeek API Key>"
 curl https://api.deepseek.com/v1/chat/completions `
   -H "Content-Type: application/json" `
   -H "Authorization: Bearer $env:DEEPSEEK_API_KEY" `
-  -d '{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":false}'
+  -d '{"model":"deepseek-flash","messages":[{"role":"user","content":"hi"}],"stream":false}'
 ```
 
 如果请求成功，说明 API Key 和模型名都可用。
@@ -100,7 +87,7 @@ curl https://api.deepseek.com/v1/chat/completions `
 #### 常见问题
 
 - `Authentication Fails` 或 `401`：检查 `apiKey` 是否为真实 DeepSeek API Key。不要把接口 URL 填到 API Key 字段。
-- `未找到模型` 或 `404`：检查模型 id 是否严格写成 `deepseek-v4-pro` 或 `deepseek-v4-flash`。
+- `未找到模型` 或 `404`：检查模型 id 是否严格写成 `deepseek-flash`。
 - `读取本地模型配置失败`：检查 `models.json` 是否是合法 JSON，并保存为 UTF-8 无 BOM。
 - 模型选择器中不显示：完全重启 WorkBuddy/CodeBuddy，并确认文件放在 `.codebuddy\models.json`。
 - UI 中直接显示 `${DEEPSEEK_API_KEY}`：请从已设置 `DEEPSEEK_API_KEY` 的终端中重启 WorkBuddy/CodeBuddy。如果桌面端仍不展开环境变量，可以在 UI 或本地 `models.json` 中填入真实 API Key。


### PR DESCRIPTION
## Summary

Update the English and Chinese integration guides for the September 2026 DeepSeek-V4.1-Flash release. The examples now use the canonical `deepseek-flash` model ID, describe the temporary legacy-ID routing and V4 Pro transition, and reflect native vision support where an integration exposes image capability metadata.

This also consolidates former Pro/Flash pairs into a single model entry and refreshes the contributor pricing snapshot from the official [Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing/) page. The repository-wide scope is intentional because the model-ID migration affects every documented integration.

## Validation

- `git diff --check`
- Searched all Markdown for stale model IDs; remaining occurrences only document compatibility aliases and transition behavior
- Checked modified Markdown for balanced code fences
- Reviewed changed JSON configuration snippets after consolidating duplicate model entries

## Checklist

- [x] Model names use `deepseek-flash`
- [x] 1M context is configured or mentioned
- [x] Max thinking effort remains supported
- [x] Pricing was verified against the DeepSeek API docs
- [x] English and Chinese guides are updated together
- [ ] Agent configurations were not exercised in every third-party client